### PR TITLE
docs(auth + vertex): configure GitHub App token and required env vars for Claude on Vertex AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,14 @@ Use provider-specific model names based on your chosen provider:
 
 Both AWS Bedrock and GCP Vertex AI require OIDC authentication.
 
+**Important:** Add the following at the top level of your workflow YAML to enable OIDC:
 ```yaml
-# For AWS Bedrock with OIDC
+permissions:
+  id-token: write # Required for OIDC
+```
+
+#### For AWS Bedrock with OIDC
+```yaml
 - name: Configure AWS Credentials (OIDC)
   uses: aws-actions/configure-aws-credentials@v4
   with:
@@ -326,13 +332,10 @@ Both AWS Bedrock and GCP Vertex AI require OIDC authentication.
     anthropic_model: "anthropic.claude-3-7-sonnet-20250219-beta:0"
     use_bedrock: "true"
     # ... other inputs
-
-  permissions:
-    id-token: write # Required for OIDC
 ```
 
+#### For GCP Vertex AI with OIDC
 ```yaml
-# For GCP Vertex AI with OIDC
 - name: Authenticate to Google Cloud
   uses: google-github-actions/auth@v2
   with:
@@ -351,9 +354,6 @@ Both AWS Bedrock and GCP Vertex AI require OIDC authentication.
     anthropic_model: "claude-3-7-sonnet@20250219"
     use_vertex: "true"
     # ... other inputs
-
-  permissions:
-    id-token: write # Required for OIDC
 ```
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -339,7 +339,9 @@ permissions:
 
 **secrets:**
 - VERTEX_PROJECT_ID: Your Google Cloud project ID where Vertex AI and Claude access are configured.
-- VERTEX_REGION:
+- `VERTEX_REGION`: The default region for Vertex AI model execution (e.g. `us-east5`).
+- `VERTEX_REGION_CLAUDE_3_7_SONNET`: Model-specific override for the `claude-3-7-sonnet` model. Must match the region where the model is available in Vertex AI.
+
 ```yaml
 - name: Authenticate to Google Cloud
   uses: google-github-actions/auth@v2
@@ -358,6 +360,7 @@ permissions:
   env:
     ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
     CLOUD_ML_REGION: ${{ secrets.VERTEX_REGION }}
+    VERTEX_REGION_CLAUDE_3_7_SONNET: ${{ secrets.VERTEX_REGION_CLAUDE_3_7_SONNET }}
   with:
     anthropic_model: "claude-3-7-sonnet"
     use_vertex: "true"

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ permissions:
 #### For GCP Vertex AI with OIDC
 
 **secrets:**
-- VERTEX_PROJECT_ID: Your Google Cloud project ID where Vertex AI and Claude access are configured.
+- `ANTHROPIC_VERTEX_PROJECT_ID`: Your Google Cloud project ID where Vertex AI and Claude access are configured.
 - `CLOUD_ML_REGION`: The default region for Vertex AI model execution (e.g. `us-east5`).
 
 ```yaml
@@ -508,7 +508,7 @@ permissions:
 
 - uses: anthropics/claude-code-action@beta
   env:
-    ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
+    ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.ANTHROPIC_VERTEX_PROJECT_ID }}
     CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}
 
   with:

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ permissions:
     CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}
 
   with:
-    anthropic_model: "claude-3-7-sonnet"
+    anthropic_model: "claude-3-7-sonnet@20250219"
     use_vertex: "true"
     github_token: ${{ steps.app-token.outputs.token }}
     # ... other inputs

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ permissions:
   with:
     anthropic_model: "anthropic.claude-3-7-sonnet-20250219-beta:0"
     use_bedrock: "true"
+    github_token: ${{ steps.app-token.outputs.token }}
     # ... other inputs
 ```
 
@@ -353,6 +354,7 @@ permissions:
   with:
     anthropic_model: "claude-3-7-sonnet@20250219"
     use_vertex: "true"
+    github_token: ${{ steps.app-token.outputs.token }}
     # ... other inputs
 ```
 

--- a/README.md
+++ b/README.md
@@ -336,6 +336,10 @@ permissions:
 ```
 
 #### For GCP Vertex AI with OIDC
+
+**secrets:**
+- VERTEX_PROJECT_ID: Your Google Cloud project ID where Vertex AI and Claude access are configured.
+- VERTEX_REGION:
 ```yaml
 - name: Authenticate to Google Cloud
   uses: google-github-actions/auth@v2
@@ -351,8 +355,11 @@ permissions:
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
 - uses: anthropics/claude-code-action@beta
+  env:
+    ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
+    CLOUD_ML_REGION: ${{ secrets.VERTEX_REGION }}
   with:
-    anthropic_model: "claude-3-7-sonnet@20250219"
+    anthropic_model: "claude-3-7-sonnet"
     use_vertex: "true"
     github_token: ${{ steps.app-token.outputs.token }}
     # ... other inputs

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ permissions:
 
 **secrets:**
 - VERTEX_PROJECT_ID: Your Google Cloud project ID where Vertex AI and Claude access are configured.
-- `VERTEX_REGION`: The default region for Vertex AI model execution (e.g. `us-east5`).
+- `CLOUD_ML_REGION`: The default region for Vertex AI model execution (e.g. `us-east5`).
 
 ```yaml
 - name: Authenticate to Google Cloud
@@ -509,7 +509,8 @@ permissions:
 - uses: anthropics/claude-code-action@beta
   env:
     ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
-    CLOUD_ML_REGION: ${{ secrets.VERTEX_REGION }}
+    CLOUD_ML_REGION: ${{ secrets.CLOUD_ML_REGION }}
+
   with:
     anthropic_model: "claude-3-7-sonnet"
     use_vertex: "true"

--- a/README.md
+++ b/README.md
@@ -491,7 +491,6 @@ permissions:
 **secrets:**
 - VERTEX_PROJECT_ID: Your Google Cloud project ID where Vertex AI and Claude access are configured.
 - `VERTEX_REGION`: The default region for Vertex AI model execution (e.g. `us-east5`).
-- `VERTEX_REGION_CLAUDE_3_7_SONNET`: Model-specific override for the `claude-3-7-sonnet` model. Must match the region where the model is available in Vertex AI.
 
 ```yaml
 - name: Authenticate to Google Cloud
@@ -511,7 +510,6 @@ permissions:
   env:
     ANTHROPIC_VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
     CLOUD_ML_REGION: ${{ secrets.VERTEX_REGION }}
-    VERTEX_REGION_CLAUDE_3_7_SONNET: ${{ secrets.VERTEX_REGION_CLAUDE_3_7_SONNET }}
   with:
     anthropic_model: "claude-3-7-sonnet"
     use_vertex: "true"


### PR DESCRIPTION
- Moved the permissions block to the top-level context as required by GitHub Actions
- Removed unsupported permissions declarations from individual steps
- Explicitly passed the GitHub App token (${{ steps.app-token.outputs.token }}) to anthropics/claude-code-action@beta to avoid fallback to GITHUB_TOKEN or OIDC
- Resolved 401 Unauthorized errors during token exchange by ensuring proper authentication
- Added required environment variables and corresponding secrets:
   - CLOUD_ML_REGION
   - ANTHROPIC_VERTEX_PROJECT_ID

- See #12  for details on model-specific region requirements (no longer required)