### PR TITLE
feat: Add comment_id as output to the Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ jobs:
 
 ## Outputs
 
-| Output           | Description                                   |
-| ---------------- | --------------------------------------------- |
-| `comment_id`     | ID of the comment created by Claude           |
-| `execution_file` | Path to the Claude Code execution output file |
+| Output           | Description                                             |
+| ---------------- | ------------------------------------------------------- |
+| `comment_ids`    | Newline-separated list of comment IDs created by Claude |
+| `execution_file` | Path to the Claude Code execution output file           |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ jobs:
 
 > **Note**: This action is currently in beta. Features and APIs may change as we continue to improve the integration.
 
+## Outputs
+
+| Output           | Description                                   |
+| ---------------- | --------------------------------------------- |
+| `comment_id`     | ID of the comment created by Claude           |
+| `execution_file` | Path to the Claude Code execution output file |
+
 ## Examples
 
 ### Ways to Tag @claude

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,9 @@ inputs:
     default: "30"
 
 outputs:
+  comment_id:
+    description: "ID of the comment created by Claude"
+    value: ${{ steps.prepare.outputs.claude_comment_id }}
   execution_file:
     description: "Path to the Claude Code execution output file"
     value: ${{ steps.claude-code.outputs.execution_file }}

--- a/action.yml
+++ b/action.yml
@@ -57,8 +57,8 @@ inputs:
     default: "30"
 
 outputs:
-  comment_id:
-    description: "ID of the comment created by Claude"
+  comment_ids:
+    description: "Newline-separated list of comment IDs created by Claude"
     value: ${{ steps.prepare.outputs.claude_comment_id }}
   execution_file:
     description: "Path to the Claude Code execution output file"


### PR DESCRIPTION
# Description

Expose the comment ID that the action creates, as an Action output.

This will allow users to identify the comment and interact with it in later steps in the workflow(s) where the action is used. This could allow hiding old comments, reacting to comments, filtering out Claude-created comments from other processing, notifying external services about Claude activities, etc.

Some of the above (or other) behaviors may make sense to include in the claude-code-action eventually, but simply exposing the created comment's ID is a backwards-compatible, nondisruptive, code-minimal way to enable users to build those use-cases *now*, without requiring any significant design decisions in the claude-code-action itself.

It's also probably a nice thing to do in general!