### PR TITLE
Rename anthropic_model input to model with backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Use a specific Claude model:
 ```yaml
 - uses: anthropics/claude-code-action@beta
   with:
-    anthropic_model: "claude-3-7-sonnet-20250219"
+    # model: "claude-3-5-sonnet-20241022"  # Optional: specify a different model
     # ... other inputs
 ```
 
@@ -284,21 +284,20 @@ Use provider-specific model names based on your chosen provider:
 # For direct Anthropic API (default)
 - uses: anthropics/claude-code-action@beta
   with:
-    anthropic_model: "claude-3-7-sonnet-20250219"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     # ... other inputs
 
 # For Amazon Bedrock with OIDC
 - uses: anthropics/claude-code-action@beta
   with:
-    anthropic_model: "anthropic.claude-3-7-sonnet-20250219-beta:0" # Cross-region inference
+    model: "anthropic.claude-3-7-sonnet-20250219-beta:0" # Cross-region inference
     use_bedrock: "true"
     # ... other inputs
 
 # For Google Vertex AI with OIDC
 - uses: anthropics/claude-code-action@beta
   with:
-    anthropic_model: "claude-3-7-sonnet@20250219"
+    model: "claude-3-7-sonnet@20250219"
     use_vertex: "true"
     # ... other inputs
 ```
@@ -324,7 +323,7 @@ Both AWS Bedrock and GCP Vertex AI require OIDC authentication.
 
 - uses: anthropics/claude-code-action@beta
   with:
-    anthropic_model: "anthropic.claude-3-7-sonnet-20250219-beta:0"
+    model: "anthropic.claude-3-7-sonnet-20250219-beta:0"
     use_bedrock: "true"
     # ... other inputs
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ jobs:
 | `direct_prompt`       | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)                | No       | -                            |
 | `timeout_minutes`     | Timeout in minutes for execution                                                                                     | No       | `30`                         |
 | `github_token`        | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!** | No       | -                            |
-| `anthropic_model`     | Model to use (provider-specific format required for Bedrock/Vertex)                                                  | No       | `claude-3-7-sonnet-20250219` |
+| `model`               | Model to use (provider-specific format required for Bedrock/Vertex)                                                  | No       | -                            |
+| `anthropic_model`     | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                | No       | `claude-3-7-sonnet-20250219` |
 | `use_bedrock`         | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                          | No       | `false`                      |
 | `use_vertex`          | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                        | No       | `false`                      |
 | `allowed_tools`       | Additional tools for Claude to use (the base GitHub tools will always be included)                                   | No       | ""                           |

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,11 @@ inputs:
     required: false
 
   # Claude Code configuration
-  anthropic_model:
+  model:
     description: "Model to use (provider-specific format required for Bedrock/Vertex)"
+    required: false
+  anthropic_model:
+    description: "DEPRECATED: Use 'model' instead. Model to use (provider-specific format required for Bedrock/Vertex)"
     required: false
     default: "claude-3-7-sonnet-20250219"
   allowed_tools:
@@ -98,14 +101,14 @@ runs:
         allowed_tools: ${{ env.ALLOWED_TOOLS }}
         disallowed_tools: ${{ env.DISALLOWED_TOOLS }}
         timeout_minutes: ${{ inputs.timeout_minutes }}
-        anthropic_model: ${{ inputs.anthropic_model }}
+        anthropic_model: ${{ inputs.model || inputs.anthropic_model }}
         mcp_config: ${{ steps.prepare.outputs.mcp_config }}
         use_bedrock: ${{ inputs.use_bedrock }}
         use_vertex: ${{ inputs.use_vertex }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
       env:
         # Model configuration
-        ANTHROPIC_MODEL: ${{ inputs.anthropic_model }}
+        ANTHROPIC_MODEL: ${{ inputs.model || inputs.anthropic_model }}
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
 
         # AWS configuration


### PR DESCRIPTION
## Summary
- Renamed the `anthropic_model` input parameter to `model` for cleaner naming
- Maintained backward compatibility by keeping `anthropic_model` with deprecation notice
- Used GitHub Actions expression syntax to prioritize `model` over `anthropic_model`

## Test plan
- [ ] Existing workflows using `anthropic_model` continue to work unchanged
- [ ] New workflows can use the cleaner `model` parameter
- [ ] If both parameters are provided, `model` takes precedence
- [ ] Default value remains on `anthropic_model` to ensure backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)