### PR TITLE
Add shallow fetch to improve performance for large repositories

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -52,7 +52,8 @@ export async function setupBranch(
       const branchName = prData.headRefName;
 
       // Execute git commands to checkout PR branch (shallow fetch for performance)
-      await $`git fetch origin --depth=1 ${branchName}`;
+      // Fetch the branch with a depth of 20 to avoid fetching too much history, while still allowing for some context
+      await $`git fetch origin --depth=20 ${branchName}`;
       await $`git checkout ${branchName}`;
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -51,8 +51,8 @@ export async function setupBranch(
 
       const branchName = prData.headRefName;
 
-      // Execute git commands to checkout PR branch
-      await $`git fetch origin ${branchName}`;
+      // Execute git commands to checkout PR branch (shallow fetch for performance)
+      await $`git fetch origin --depth=1 ${branchName}`;
       await $`git checkout ${branchName}`;
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);
@@ -98,8 +98,8 @@ export async function setupBranch(
       sha: currentSHA,
     });
 
-    // Checkout the new branch
-    await $`git fetch origin ${newBranch}`;
+    // Checkout the new branch (shallow fetch for performance)
+    await $`git fetch origin --depth=1 ${newBranch}`;
     await $`git checkout ${newBranch}`;
 
     console.log(


### PR DESCRIPTION
This change adds `--depth=1` to git fetch operations to perform shallow fetches instead of full history downloads. This significantly reduces checkout time for large repositories.

Fixes #52

Generated with [Claude Code](https://claude.ai/code)