### PR TITLE
Pin GitHub Action dependencies to commit SHAs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # https://github.com/oven-sh/setup-bun/releases/tag/v2.0.2
       with:
         bun-version: 1.2.11
 
@@ -94,7 +94,7 @@ runs:
     - name: Run Claude Code
       id: claude-code
       if: steps.prepare.outputs.contains_trigger == 'true'
-      uses: anthropics/claude-code-base-action@beta
+      uses: anthropics/claude-code-base-action@5097b6cdfe5fc5a3ac0166cc344c34ed23c93982 # https://github.com/anthropics/claude-code-base-action/releases/tag/v0.0.5
       with:
         prompt_file: /tmp/claude-prompts/claude-prompt.txt
         allowed_tools: ${{ env.ALLOWED_TOOLS }}


### PR DESCRIPTION
Pin oven-sh/setup-bun and anthropics/claude-code-base-action to specific commit SHAs instead of version tags to ensure reproducible builds and improve supply chain security.

Similar to https://github.com/anthropics/claude-code-base-action/pull/11, for https://github.com/anthropics/claude-code-action/issues/15

🤖 Generated with [Claude Code](https://claude.ai/code)