### PR TITLE
feat: allow user override of hardcoded disallowed tools

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -58,10 +58,23 @@ export function buildAllowedToolsString(
 
 export function buildDisallowedToolsString(
   customDisallowedTools?: string,
+  allowedTools?: string,
 ): string {
-  let allDisallowedTools = DISALLOWED_TOOLS.join(",");
+  let disallowedTools = [...DISALLOWED_TOOLS];
+  
+  // If user has explicitly allowed some hardcoded disallowed tools, remove them from disallowed list
+  if (allowedTools) {
+    const allowedToolsArray = allowedTools.split(",").map(tool => tool.trim());
+    disallowedTools = disallowedTools.filter(tool => !allowedToolsArray.includes(tool));
+  }
+  
+  let allDisallowedTools = disallowedTools.join(",");
   if (customDisallowedTools) {
-    allDisallowedTools = `${allDisallowedTools},${customDisallowedTools}`;
+    if (allDisallowedTools) {
+      allDisallowedTools = `${allDisallowedTools},${customDisallowedTools}`;
+    } else {
+      allDisallowedTools = customDisallowedTools;
+    }
   }
   return allDisallowedTools;
 }
@@ -648,6 +661,7 @@ export async function createPrompt(
     );
     const allDisallowedTools = buildDisallowedToolsString(
       preparedContext.disallowedTools,
+      preparedContext.allowedTools,
     );
 
     core.exportVariable("ALLOWED_TOOLS", allAllowedTools);

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -61,13 +61,17 @@ export function buildDisallowedToolsString(
   allowedTools?: string,
 ): string {
   let disallowedTools = [...DISALLOWED_TOOLS];
-  
+
   // If user has explicitly allowed some hardcoded disallowed tools, remove them from disallowed list
   if (allowedTools) {
-    const allowedToolsArray = allowedTools.split(",").map(tool => tool.trim());
-    disallowedTools = disallowedTools.filter(tool => !allowedToolsArray.includes(tool));
+    const allowedToolsArray = allowedTools
+      .split(",")
+      .map((tool) => tool.trim());
+    disallowedTools = disallowedTools.filter(
+      (tool) => !allowedToolsArray.includes(tool),
+    );
   }
-  
+
   let allDisallowedTools = disallowedTools.join(",");
   if (customDisallowedTools) {
     if (allDisallowedTools) {

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -722,4 +722,45 @@ describe("buildDisallowedToolsString", () => {
     expect(parts).toContain("BadTool1");
     expect(parts).toContain("BadTool2");
   });
+
+  test("should remove hardcoded disallowed tools if they are in allowed tools", () => {
+    const customDisallowedTools = "BadTool1,BadTool2";
+    const allowedTools = "WebSearch,SomeOtherTool";
+    const result = buildDisallowedToolsString(customDisallowedTools, allowedTools);
+
+    // WebSearch should be removed from disallowed since it's in allowed
+    expect(result).not.toContain("WebSearch");
+    
+    // WebFetch should still be disallowed since it's not in allowed
+    expect(result).toContain("WebFetch");
+
+    // Custom disallowed tools should still be present
+    expect(result).toContain("BadTool1");
+    expect(result).toContain("BadTool2");
+  });
+
+  test("should remove all hardcoded disallowed tools if they are all in allowed tools", () => {
+    const allowedTools = "WebSearch,WebFetch,SomeOtherTool";
+    const result = buildDisallowedToolsString(undefined, allowedTools);
+
+    // Both hardcoded disallowed tools should be removed
+    expect(result).not.toContain("WebSearch");
+    expect(result).not.toContain("WebFetch");
+    
+    // Result should be empty since no custom disallowed tools provided
+    expect(result).toBe("");
+  });
+
+  test("should handle custom disallowed tools when all hardcoded tools are overridden", () => {
+    const customDisallowedTools = "BadTool1,BadTool2";
+    const allowedTools = "WebSearch,WebFetch";
+    const result = buildDisallowedToolsString(customDisallowedTools, allowedTools);
+
+    // Hardcoded tools should be removed
+    expect(result).not.toContain("WebSearch");
+    expect(result).not.toContain("WebFetch");
+    
+    // Only custom disallowed tools should remain
+    expect(result).toBe("BadTool1,BadTool2");
+  });
 });

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -726,11 +726,14 @@ describe("buildDisallowedToolsString", () => {
   test("should remove hardcoded disallowed tools if they are in allowed tools", () => {
     const customDisallowedTools = "BadTool1,BadTool2";
     const allowedTools = "WebSearch,SomeOtherTool";
-    const result = buildDisallowedToolsString(customDisallowedTools, allowedTools);
+    const result = buildDisallowedToolsString(
+      customDisallowedTools,
+      allowedTools,
+    );
 
     // WebSearch should be removed from disallowed since it's in allowed
     expect(result).not.toContain("WebSearch");
-    
+
     // WebFetch should still be disallowed since it's not in allowed
     expect(result).toContain("WebFetch");
 
@@ -746,7 +749,7 @@ describe("buildDisallowedToolsString", () => {
     // Both hardcoded disallowed tools should be removed
     expect(result).not.toContain("WebSearch");
     expect(result).not.toContain("WebFetch");
-    
+
     // Result should be empty since no custom disallowed tools provided
     expect(result).toBe("");
   });
@@ -754,12 +757,15 @@ describe("buildDisallowedToolsString", () => {
   test("should handle custom disallowed tools when all hardcoded tools are overridden", () => {
     const customDisallowedTools = "BadTool1,BadTool2";
     const allowedTools = "WebSearch,WebFetch";
-    const result = buildDisallowedToolsString(customDisallowedTools, allowedTools);
+    const result = buildDisallowedToolsString(
+      customDisallowedTools,
+      allowedTools,
+    );
 
     // Hardcoded tools should be removed
     expect(result).not.toContain("WebSearch");
     expect(result).not.toContain("WebFetch");
-    
+
     // Only custom disallowed tools should remain
     expect(result).toBe("BadTool1,BadTool2");
   });


### PR DESCRIPTION
Allow users to override hardcoded disallowed tools (WebSearch, WebFetch) by including them in their allowed_tools configuration.

Resolves #49

Generated with [Claude Code](https://claude.ai/code)