### PR TITLE
Support ANTHROPIC_BASE_URL override from env

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -109,7 +109,7 @@ runs:
         # Model configuration
         ANTHROPIC_MODEL: ${{ inputs.model || inputs.anthropic_model }}
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
-        
+
         # Provider configuration
         ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
 

--- a/action.yml
+++ b/action.yml
@@ -109,6 +109,9 @@ runs:
         # Model configuration
         ANTHROPIC_MODEL: ${{ inputs.model || inputs.anthropic_model }}
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
+        
+        # Provider configuration
+        ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
 
         # AWS configuration
         AWS_REGION: ${{ env.AWS_REGION }}


### PR DESCRIPTION
We would like to override the ANTHROPIC_BASE_URL when using the claude-code github action.
Related [PR](https://github.com/anthropics/claude-code-base-action/pull/20).