### PR TITLE
fix: replace incorrect mcp_config_file with mcp_config in workflow example

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -99,6 +99,6 @@ jobs:
         with:
           prompt_file: /tmp/claude-prompts/triage-prompt.txt
           allowed_tools: "Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues"
-          mcp_config_file: /tmp/mcp-config/mcp-servers.json
+          mcp_config: /tmp/mcp-config/mcp-servers.json
           timeout_minutes: "5"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Description

This PR fixes a parameter name typo in the issue-triage workflow example. The workflow incorrectly uses `mcp_config_file` when the actual parameter name defined in `anthropics/claude-code-base-action` is `mcp_config`.

## Problem

The issue-triage workflow example contains an incorrect parameter name on line 102:

```yaml
mcp_config_file: /tmp/mcp-config/mcp-servers.json
```

This causes the MCP configuration to be ignored when running the workflow, as the claude-code-base-action doesn't recognize `mcp_config_file` as a valid input.

## Solution

Changed the parameter name from `mcp_config_file` to `mcp_config` to match the actual parameter defined in the claude-code-base-action's `action.yml`:

```yaml
mcp_config:
  description: "MCP configuration as JSON string or path to MCP configuration JSON file"
  required: false
  default: ""
```

## Changes

- `.github/workflows/issue-triage.yml`: Line 102 - Changed `mcp_config_file` to `mcp_config`

## Impact

This fix ensures that:

1. The MCP server configuration is properly passed to the claude-code-base-action
2. The GitHub MCP server can be correctly initialized with the provided token
3. The example workflow works as intended for users who copy it

## Testing

The correct parameter name is verified by:

1. Checking the [claude-code-base-action's action.yml](https://github.com/anthropics/claude-code-base-action/blob/beta/action.yml#L58-L61)
2. Confirming that `mcp_config` accepts both JSON strings and file paths
3. Cross-referencing with working examples in other workflows

## Related Issues

This typo may affect users who are trying to set up issue triage automation using the provided example, causing their MCP configurations to be silently ignored.


🤖 Generated with [Claude Code](https://claude.ai/code)