### PR TITLE
Add issue labeled event

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -260,6 +260,10 @@ export function prepareContext(
           claudeBranch,
         };
       } else if (eventAction === "labeled") {
+        const payload = context.payload;
+        const labelName =
+          "label" in payload && payload.label ? payload.label.name : "";
+
         eventData = {
           eventName: "issues",
           eventAction: "labeled",
@@ -267,7 +271,7 @@ export function prepareContext(
           issueNumber,
           defaultBranch,
           claudeBranch,
-          label: context.payload.issue.labels[0].name,
+          label: labelName,
         };
       } else {
         throw new Error(`Unsupported issue action: ${eventAction}`);
@@ -332,8 +336,7 @@ export function getEventTypeAndContext(envVars: PreparedContext): {
           eventType: "ISSUE_CREATED",
           triggerContext: `new issue with '${envVars.triggerPhrase}' in body`,
         };
-      }
-      else if (eventData.eventAction === "labeled") {
+      } else if (eventData.eventAction === "labeled") {
         return {
           eventType: "ISSUE_LABELED",
           triggerContext: `issue labeled with '${eventData.label}'`,

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -259,6 +259,16 @@ export function prepareContext(
           defaultBranch,
           claudeBranch,
         };
+      } else if (eventAction === "labeled") {
+        eventData = {
+          eventName: "issues",
+          eventAction: "labeled",
+          isPR: false,
+          issueNumber,
+          defaultBranch,
+          claudeBranch,
+          label: context.payload.issue.labels[0].name,
+        };
       } else {
         throw new Error(`Unsupported issue action: ${eventAction}`);
       }
@@ -321,6 +331,12 @@ export function getEventTypeAndContext(envVars: PreparedContext): {
         return {
           eventType: "ISSUE_CREATED",
           triggerContext: `new issue with '${envVars.triggerPhrase}' in body`,
+        };
+      }
+      else if (eventData.eventAction === "labeled") {
+        return {
+          eventType: "ISSUE_LABELED",
+          triggerContext: `issue labeled with '${eventData.label}'`,
         };
       }
       return {

--- a/src/create-prompt/types.ts
+++ b/src/create-prompt/types.ts
@@ -68,6 +68,16 @@ type IssueAssignedEvent = {
   assigneeTrigger: string;
 };
 
+type IssueLabeledEvent = {
+  eventName: "issues";
+  eventAction: "labeled";
+  isPR: false;
+  issueNumber: string;
+  defaultBranch: string;
+  claudeBranch: string;
+  label: string;
+};
+
 type PullRequestEvent = {
   eventName: "pull_request";
   eventAction?: string; // opened, synchronize, etc.
@@ -85,6 +95,7 @@ export type EventData =
   | IssueCommentEvent
   | IssueOpenedEvent
   | IssueAssignedEvent
+  | IssueLabeledEvent
   | PullRequestEvent;
 
 // Combined type with separate eventData field


### PR DESCRIPTION
This PR adds support for the `ISSUE_LABELED` event. Now Claude Code can detect when a Github issue has a label added and handles it properly. This is useful for creating label-based workflows. For example, adding a "auto-fix" label to trigger a Claude Code session.

### Changes

-  Updated code to recognize and process labeled issue events.
-  Added a new type for labeled issues to keep things organized.

## Testing 
- Tested on our own repository and correctly saw labeled issues trigger Claude Code and not throw the error. Correctly extracts the label name and logs `Event type: ISSUE_LABELED with '<name>'` 