### PR TITLE
feat: add claude_env input for custom environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ jobs:
           # trigger_phrase: "/claude"
           # Optional: add assignee trigger for issues
           # assignee_trigger: "claude"
+          # Optional: add custom environment variables (YAML format)
+          # claude_env: |
+          #   NODE_ENV: test
+          #   DEBUG: true
+          #   API_URL: https://api.example.com
 ```
 
 ## Inputs
@@ -85,6 +90,7 @@ jobs:
 | `mcp_config`          | Additional MCP configuration (JSON string) that merges with the built-in GitHub MCP servers                          | No       | ""        |
 | `assignee_trigger`    | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                        | No       | -         |
 | `trigger_phrase`      | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                        | No       | `@claude` |
+| `claude_env`          | Custom environment variables to pass to Claude Code execution (YAML format)                                          | No       | ""        |
 
 \*Required when using direct Anthropic API (default and when not using Bedrock or Vertex)
 
@@ -288,6 +294,22 @@ This action is built on top of [`anthropics/claude-code-base-action`](https://gi
 - **Perform Branch Operations**: Cannot merge branches, rebase, or perform other git operations beyond pushing commits
 
 ## Advanced Configuration
+
+### Custom Environment Variables
+
+You can pass custom environment variables to Claude Code execution using the `claude_env` input. This is useful for CI/test setups that require specific environment variables:
+
+```yaml
+- uses: anthropics/claude-code-action@beta
+  with:
+    claude_env: |
+      NODE_ENV: test
+      CI: true
+      DATABASE_URL: postgres://test:test@localhost:5432/test_db
+    # ... other inputs
+```
+
+The `claude_env` input accepts YAML format where each line defines a key-value pair. These environment variables will be available to Claude Code during execution, allowing it to run tests, build processes, or other commands that depend on specific environment configurations.
 
 ### Custom Tools
 

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,8 @@ inputs:
     default: ""
   mcp_config:
     description: "Additional MCP configuration (JSON string) that merges with the built-in GitHub MCP servers"
+  claude_env:
+    description: "Custom environment variables to pass to Claude Code execution (YAML format)"
     required: false
     default: ""
 
@@ -114,6 +116,7 @@ runs:
         use_bedrock: ${{ inputs.use_bedrock }}
         use_vertex: ${{ inputs.use_vertex }}
         anthropic_api_key: ${{ inputs.anthropic_api_key }}
+        claude_env: ${{ inputs.claude_env }}
       env:
         # Model configuration
         ANTHROPIC_MODEL: ${{ inputs.model || inputs.anthropic_model }}


### PR DESCRIPTION
Adds support for passing custom environment variables to Claude Code execution through a new `claude_env` input.

This allows users to pass environment variables required for their CI test setup or other commands.

Closes #101

Generated with [Claude Code](https://claude.ai/code)