### PR TITLE
feat: persist issue branches for reuse on subsequent invocations

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -361,6 +361,7 @@ export function getEventTypeAndContext(envVars: PreparedContext): {
 export function generatePrompt(
   context: PreparedContext,
   githubData: FetchDataResult,
+  isReusedBranch?: boolean,
 ): string {
   const {
     contextData,
@@ -534,7 +535,7 @@ ${context.directPrompt ? `   - DIRECT INSTRUCTION: A direct instruction was prov
       - Use mcp__github_file_ops__commit_files to commit files atomically in a single commit (supports single or multiple files).
       - When pushing changes with this tool and TRIGGER_USERNAME is not "Unknown", include a "Co-authored-by: ${context.triggerUsername} <${context.triggerUsername}@users.noreply.github.com>" line in the commit message.`
           : `
-      - You are already on the correct branch (${eventData.claudeBranch || "the PR branch"}). Do not create a new branch.
+      - You are already on the correct branch (${eventData.claudeBranch || "the PR branch"}). Do not create a new branch.${isReusedBranch ? `\n      - NOTE: This branch (${eventData.claudeBranch}) was reused from a previous Claude invocation on this issue. It may already contain some work.` : ''}
       - Push changes directly to the current branch using mcp__github_file_ops__commit_files (works for both new and existing files)
       - Use mcp__github_file_ops__commit_files to commit files atomically in a single commit (supports single or multiple files).
       - When pushing changes and TRIGGER_USERNAME is not "Unknown", include a "Co-authored-by: ${context.triggerUsername} <${context.triggerUsername}@users.noreply.github.com>" line in the commit message.
@@ -641,6 +642,7 @@ export async function createPrompt(
   claudeBranch: string | undefined,
   githubData: FetchDataResult,
   context: ParsedGitHubContext,
+  isReusedBranch?: boolean,
 ) {
   try {
     const preparedContext = prepareContext(
@@ -653,7 +655,7 @@ export async function createPrompt(
     await mkdir("/tmp/claude-prompts", { recursive: true });
 
     // Generate the prompt
-    const promptContent = generatePrompt(preparedContext, githubData);
+    const promptContent = generatePrompt(preparedContext, githubData, isReusedBranch);
 
     // Log the final prompt to console
     console.log("===== FINAL PROMPT =====");

--- a/src/entrypoints/prepare.ts
+++ b/src/entrypoints/prepare.ts
@@ -81,6 +81,7 @@ async function run() {
       branchInfo.claudeBranch,
       githubData,
       context,
+      branchInfo.isReusedBranch,
     );
 
     // Step 11: Get MCP configuration


### PR DESCRIPTION
This PR addresses issue #103

- Claude now checks for existing branches before creating new ones for issues
- Issue branches are preserved even with 0 commits to allow reuse
- Claude is aware when it's reusing an existing branch

This allows users to iteratively ask Claude to make changes on the same branch before creating a PR.

Generated with [Claude Code](https://claude.ai/code)