### PR TITLE
fix: Update condition for final message in output

### DIFF
--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -166,7 +166,7 @@ async function run() {
           if (Array.isArray(outputData) && outputData.length > 0) {
             const lastElement = outputData[outputData.length - 1];
             if (
-              lastElement.role === "system" &&
+              lastElement.type === "result" &&
               "cost_usd" in lastElement &&
               "duration_ms" in lastElement
             ) {


### PR DESCRIPTION
The last message in the Claude Code output does not have a role set to system, but instead has a field "type" set to "result". With the current condition, the duration is never appended to the header of the comments.

This change updates the condition to match the current output file format.

## Before Change

![CleanShot 2025-06-01 at 17 14 43@2x](https://github.com/user-attachments/assets/79b32d15-7b8b-426a-9d92-b6229e9d41e0)

## After Change

![CleanShot 2025-06-01 at 17 15 07@2x](https://github.com/user-attachments/assets/22ab05c8-b4af-4ede-a95a-016f83c4ed51)

## Sample Output

An example of the last item in the array from the Claude Code output.

```
{
    "type": "result",
    "subtype": "success",
    "cost_usd": 3.403821050000001,
    "is_error": false,
    "duration_ms": 329579,
    "duration_api_ms": 292419,
    "num_turns": 56,
    "result": "(no content)",
    "total_cost": 3.403821050000001,
    "session_id": "xxxxx"
  }
```