### PR TITLE
Fix 401 error on GitHub Enterprise Server by passing GITHUB_API_URL to Octokit

### DIFF
--- a/src/github/api/client.ts
+++ b/src/github/api/client.ts
@@ -9,7 +9,10 @@ export type Octokits = {
 
 export function createOctokit(token: string): Octokits {
   return {
-    rest: new Octokit({ auth: token }),
+    rest: new Octokit({
+      auth: token,
+      baseUrl: GITHUB_API_URL,
+    }),
     graphql: graphql.defaults({
       baseUrl: GITHUB_API_URL,
       headers: {


### PR DESCRIPTION
## Summary
This PR fixes a 401 Unauthorized error that occurs in GitHub Enterprise Server by specifying the baseUrl when creating the Octokit instance. #107 

## Changes
- Adds `baseUrl: GITHUB_API_URL` to Octokit initialization

## Purpose
To ensure authenticated API requests work properly in GitHub Enterprise Server environments.

