### PR TITLE
feat: add workflow_dispatch support

### DIFF
--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -1,10 +1,11 @@
 import * as github from "@actions/github";
 import type {
-  IssuesEvent,
   IssueCommentEvent,
+  IssuesEvent,
   PullRequestEvent,
-  PullRequestReviewEvent,
   PullRequestReviewCommentEvent,
+  PullRequestReviewEvent,
+  WorkflowDispatchEvent,
 } from "@octokit/webhooks-types";
 
 export type ParsedGitHubContext = {
@@ -138,4 +139,13 @@ export function isPullRequestReviewCommentEvent(
   context: ParsedGitHubContext,
 ): context is ParsedGitHubContext & { payload: PullRequestReviewCommentEvent } {
   return context.eventName === "pull_request_review_comment";
+}
+
+export function isWorkflowDispatchEvent(
+  context: ParsedGitHubContext,
+): context is ParsedGitHubContext & {
+  eventName: "workflow_dispatch";
+  payload: WorkflowDispatchEvent;
+} {
+  return context.eventName === "workflow_dispatch";
 }


### PR DESCRIPTION
## Summary

This PR adds support for `workflow_dispatch` events in the Claude Code Action, enabling manual triggering of automated code reviews and other workflows without requiring the `@claude` mention in comments.

## Motivation

Currently, the Claude Code Action only supports triggering through:
- Issue comments containing `@claude`
- PR comments/reviews containing `@claude`
- Issue assignment to a specific user

This limitation prevents using the action for automated workflows that need to be triggered manually or on a schedule. Many teams want to run Claude reviews:
- On-demand for specific PRs
- As part of scheduled workflows
- Through external automation tools
- Without cluttering PR conversations with trigger comments

## Changes

### 1. Added `isWorkflowDispatchEvent` helper in `src/github/context.ts`
- New type guard function to identify workflow_dispatch events
- Properly typed with TypeScript for type safety

### 2. Extended trigger checking in `src/github/validation/trigger.ts`
- Added logic to handle `workflow_dispatch` events
- Checks for `pr_number` input to identify which PR to review
- Falls back to checking for a direct `prompt` input
- Maintains backward compatibility with existing triggers

## How it works

When triggered via `workflow_dispatch`, the action will:

1. First check if a `pr_number` input is provided
2. If found, proceed with the action for that specific PR
3. If no PR number, check for a direct `prompt` input
4. If neither is found, skip the action with a clear log message

## Example Usage

```yaml
name: Manual Code Review
on:
  workflow_dispatch:
    inputs:
      pr_number:
        description: 'PR number to review'
        required: true
        type: string

jobs:
  review:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: anthropics/claude-code-action@beta
        with:
          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
```

## Testing

- [x] Formatting passes (`bun run format:check`)
- [x] Type checking passes (`bun run typecheck`)
- [x] Maintains backward compatibility
- [x] Clear logging for debugging

## Benefits

1. **Flexibility**: Teams can trigger Claude reviews on their own schedule
2. **Integration**: Works with GitHub's workflow_dispatch UI and API
3. **Automation**: Enables integration with external tools and scheduled workflows
4. **Clean PRs**: No need for trigger comments in PR conversations
5. **Backward Compatible**: Existing workflows continue to work unchanged

## Use Cases

- Running comprehensive reviews before merging
- Scheduled security/quality checks
- Integration with CI/CD pipelines
- Batch processing multiple PRs
- Testing Claude on specific PRs without public comments

## Related Issues

This supports the use case demonstrated in the [[Metta-AI/metta repository](https://github.com/Metta-AI/metta)](https://github.com/Metta-AI/metta) where teams want to run automated PR review such as README accuracy checks via workflow_dispatch.
