### PR TITLE
feat: add configurable branch prefix to avoid naming conflicts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
   base_branch:
     description: "The branch to use as the base/source when creating new branches (defaults to repository default branch)"
     required: false
+  branch_prefix:
+    description: "Prefix for branches created by Claude (e.g. 'claude-agent' creates 'claude-agent/issue-123')"
+    required: false
+    default: "claude"
 
   # Claude Code configuration
   model:
@@ -95,6 +99,7 @@ runs:
         TRIGGER_PHRASE: ${{ inputs.trigger_phrase }}
         ASSIGNEE_TRIGGER: ${{ inputs.assignee_trigger }}
         BASE_BRANCH: ${{ inputs.base_branch }}
+        BRANCH_PREFIX: ${{ inputs.branch_prefix }}
         ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
         CUSTOM_INSTRUCTIONS: ${{ inputs.custom_instructions }}
         DIRECT_PROMPT: ${{ inputs.direct_prompt }}

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -33,6 +33,7 @@ export type ParsedGitHubContext = {
     customInstructions: string;
     directPrompt: string;
     baseBranch?: string;
+    branchPrefix: string;
   };
 };
 
@@ -57,6 +58,7 @@ export function parseGitHubContext(): ParsedGitHubContext {
       customInstructions: process.env.CUSTOM_INSTRUCTIONS ?? "",
       directPrompt: process.env.DIRECT_PROMPT ?? "",
       baseBranch: process.env.BASE_BRANCH,
+      branchPrefix: process.env.BRANCH_PREFIX ?? "claude",
     },
   };
 


### PR DESCRIPTION
  ## Problem
  When a repository has an existing branch named `claude`, the action fails with a 422 error when trying to create branches like
  `claude/issue-123`. This is due to Git's limitation where you cannot have both a branch named `X` and branches named `X/...`.

  This can easily happen if:
  - You have a team member named Claude who creates their own branch
  - You previously created a `claude` branch for testing _(what happend to us, took a long time to figure out)_
  - You have a feature/module/component named "claude" in your project

  ## Solution
  This PR adds a configurable `branch_prefix` input parameter that allows users to customize the prefix used for branch creation.

  ## Changes
  - Add `branch_prefix` input parameter to action.yml (defaults to 'claude' for backward compatibility)
  - Pass branch prefix through context and use it for branch creation
  - Improve error serialization to show full error details instead of `[Object ...]`
  - Add detailed error messages for 422 errors explaining the Git naming conflict
  - Provide clear solutions when branch creation fails

  ## Example Usage
  ```yaml
  - uses: anthropics/claude-code-action@v1
    with:
      branch_prefix: 'claude-agent'  # Avoids conflicts with existing 'claude' branch

  Testing

  Successfully tested on a private repository which had an existing claude branch causing 422 errors. With this fix
   and branch_prefix: 'claude-agent', the action now works correctly.