### PR TITLE
chore: switch to upstream github-mcp-server v0.4.0

### DIFF
--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -31,7 +31,9 @@ export async function prepareMcpConfig(
             "--rm",
             "-e",
             "GITHUB_PERSONAL_ACCESS_TOKEN",
-            "ghcr.io/anthropics/github-mcp-server:sha-7382253",
+            // Using github-mcp-server v0.4.0
+            // https://github.com/github/github-mcp-server/releases/tag/v0.4.0
+            "ghcr.io/github/github-mcp-server:sha-e9f748f",
           ],
           env: {
             GITHUB_PERSONAL_ACCESS_TOKEN: githubToken,

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -31,9 +31,7 @@ export async function prepareMcpConfig(
             "--rm",
             "-e",
             "GITHUB_PERSONAL_ACCESS_TOKEN",
-            // Using github-mcp-server v0.4.0
-            // https://github.com/github/github-mcp-server/releases/tag/v0.4.0
-            "ghcr.io/github/github-mcp-server:sha-e9f748f",
+            "ghcr.io/github/github-mcp-server:sha-e9f748f", // https://github.com/github/github-mcp-server/releases/tag/v0.4.0
           ],
           env: {
             GITHUB_PERSONAL_ACCESS_TOKEN: githubToken,


### PR DESCRIPTION
Switch from anthropics fork to github/github-mcp-server at commit e9f748f (version 0.4.0).

Closes #125

Release link: https://github.com/github/github-mcp-server/releases/tag/v0.4.0

Generated with [Claude Code](https://claude.ai/code)