### PR TITLE
Update temp directory paths to use `runner` temp directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ runs:
       if: steps.prepare.outputs.contains_trigger == 'true'
       uses: anthropics/claude-code-base-action@1370ac97fbba9bddec20ea2924b5726bf10d8b94 # v0.0.9
       with:
-        prompt_file: /tmp/claude-prompts/claude-prompt.txt
+        prompt_file: ${{ runner.temp }}/claude-prompts/claude-prompt.txt
         allowed_tools: ${{ env.ALLOWED_TOOLS }}
         disallowed_tools: ${{ env.DISALLOWED_TOOLS }}
         timeout_minutes: ${{ inputs.timeout_minutes }}

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -620,7 +620,9 @@ export async function createPrompt(
       claudeBranch,
     );
 
-    await mkdir(`${process.env.RUNNER_TEMP}/claude-prompts`, { recursive: true });
+    await mkdir(`${process.env.RUNNER_TEMP}/claude-prompts`, {
+      recursive: true,
+    });
 
     // Generate the prompt
     const promptContent = generatePrompt(preparedContext, githubData);
@@ -631,7 +633,10 @@ export async function createPrompt(
     console.log("=======================");
 
     // Write the prompt file
-    await writeFile(`${process.env.RUNNER_TEMP}/claude-prompts/claude-prompt.txt`, promptContent);
+    await writeFile(
+      `${process.env.RUNNER_TEMP}/claude-prompts/claude-prompt.txt`,
+      promptContent,
+    );
 
     // Set allowed tools
     const allAllowedTools = buildAllowedToolsString(

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -620,7 +620,7 @@ export async function createPrompt(
       claudeBranch,
     );
 
-    await mkdir("/tmp/claude-prompts", { recursive: true });
+    await mkdir(`${process.env.RUNNER_TEMP}/claude-prompts`, { recursive: true });
 
     // Generate the prompt
     const promptContent = generatePrompt(preparedContext, githubData);
@@ -631,7 +631,7 @@ export async function createPrompt(
     console.log("=======================");
 
     // Write the prompt file
-    await writeFile("/tmp/claude-prompts/claude-prompt.txt", promptContent);
+    await writeFile(`${process.env.RUNNER_TEMP}/claude-prompts/claude-prompt.txt`, promptContent);
 
     // Set allowed tools
     const allAllowedTools = buildAllowedToolsString(


### PR DESCRIPTION
Currently, this action create prompt file into /tmp/claude-prompts. This directory isn't cleaned up after each run on self-hosted runners.

Instead, we should:
- Default to using the designated [runner temp directory](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#runner-context) that is guaranteed to be empty at the start of each job.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables

> RUNNER_TEMP / runner.temp
> The path to a temporary directory on the runner. This directory is emptied at the beginning and end of each job. Note that files will not be removed if the runner's user account does not have permission to delete them.