### PR TITLE
fix: replace github.action_path with GITHUB_ACTION_PATH for containerized workflows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,14 +83,14 @@ runs:
     - name: Install Dependencies
       shell: bash
       run: |
-        cd ${{ github.action_path }}
+        cd ${GITHUB_ACTION_PATH}
         bun install
 
     - name: Prepare action
       id: prepare
       shell: bash
       run: |
-        bun run ${{ github.action_path }}/src/entrypoints/prepare.ts
+        bun run ${GITHUB_ACTION_PATH}/src/entrypoints/prepare.ts
       env:
         TRIGGER_PHRASE: ${{ inputs.trigger_phrase }}
         ASSIGNEE_TRIGGER: ${{ inputs.assignee_trigger }}
@@ -147,7 +147,7 @@ runs:
       if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.claude_comment_id && always()
       shell: bash
       run: |
-        bun run ${{ github.action_path }}/src/entrypoints/update-comment-link.ts
+        bun run ${GITHUB_ACTION_PATH}/src/entrypoints/update-comment-link.ts
       env:
         REPOSITORY: ${{ github.repository }}
         PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}


### PR DESCRIPTION
This change fixes an issue where the action fails in containerized workflow jobs. By using `${GITHUB_ACTION_PATH}` instead of `${{ github.action_path }}`, the action can properly locate its resources in container environments.

Fixes #132

Generated with [Claude Code](https://claude.ai/code)