### PR TITLE
fix: Remove deprecated tools from allowed_tools to align with what is available in github-mcp-server

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,4 +29,4 @@ jobs:
 
             Be constructive and specific in your feedback. Give inline comments where applicable.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_tools: "mcp__github__add_pull_request_review_comment"
+          allowed_tools: "mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"

--- a/examples/claude-auto-review.yml
+++ b/examples/claude-auto-review.yml
@@ -35,4 +35,4 @@ jobs:
 
             Provide constructive feedback with specific suggestions for improvement.
             Use inline comments to highlight specific areas of concern.
-          # allowed_tools: "mcp__github__add_pull_request_review_comment"
+          # allowed_tools: "mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"


### PR DESCRIPTION
The current examples for allowed_tools include mcp__github__add_pull_request_review_comment, which is no longer provided by [github/github-mcp-server](https://github.com/github/github-mcp-server). This causes confusion for the GitHub Action, as the tool has been deprecated.

This tool was replaced by several new tools, as outlined in [this PR](https://github.com/github/github-mcp-server/pull/410). I’ve updated the examples and the "Auto Review PRs" action to use the new tools accordingly.

I discovered this issue after multiple failed attempts to get Claude to add inline comments—it kept throwing errors due to the missing tool. Updating the allowed_tools list resolved the problem.