### PR TITLE
fix: set disallowed_tools as env when runing prepare.ts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,6 +100,7 @@ runs:
         ASSIGNEE_TRIGGER: ${{ inputs.assignee_trigger }}
         BASE_BRANCH: ${{ inputs.base_branch }}
         ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
+        DISALLOWED_TOOLS: ${{ inputs.disallowed_tools }}
         CUSTOM_INSTRUCTIONS: ${{ inputs.custom_instructions }}
         DIRECT_PROMPT: ${{ inputs.direct_prompt }}
         MCP_CONFIG: ${{ inputs.mcp_config }}


### PR DESCRIPTION
# overview

This pull request introduces a minor update to the `action.yml` file by adding support for specifying disallowed tools in the workflow configuration.

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R103): Added a new input, `DISALLOWED_TOOLS`, to the `runs:` section to allow users to define tools that should not be used.

### background

The input.disallowed_tools value passed to the Prepare action is intended to be expanded into an environment variable and accessed via env.DISALLOWED_TOOLS in the claude-code-base-action. However, currently, input.disallowed_tools is not being passed during the execution of prepare.ts.