### PR TITLE
feat: add MultiEdit to base_allowed_tools

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -24,6 +24,7 @@ export type { CommonFields, PreparedContext } from "./types";
 
 const BASE_ALLOWED_TOOLS = [
   "Edit",
+  "MultiEdit",
   "Glob",
   "Grep",
   "LS",


### PR DESCRIPTION
Add MultiEdit tool to the BASE_ALLOWED_TOOLS array to enable Claude Code to use the MultiEdit tool for making multiple edits to a single file in one operation.

Closes #154

Generated with [Claude Code](https://claude.ai/code)