### PR TITLE
fix: add baseUrl to Octokit initialization in update_claude_comment

### DIFF
--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { readFile } from "fs/promises";
 import { join } from "path";
 import fetch from "node-fetch";
+import { GITHUB_API_URL } from "../github/api/config";
 import { Octokit } from "@octokit/rest";
 import { updateClaudeComment } from "../github/operations/comments/update-claude-comment";
 
@@ -39,7 +40,6 @@ const REPO_OWNER = process.env.REPO_OWNER;
 const REPO_NAME = process.env.REPO_NAME;
 const BRANCH_NAME = process.env.BRANCH_NAME;
 const REPO_DIR = process.env.REPO_DIR || process.cwd();
-const GITHUB_API_URL = process.env.GITHUB_API_URL || "https://api.github.com";
 
 if (!REPO_OWNER || !REPO_NAME || !BRANCH_NAME) {
   console.error(

--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -6,7 +6,6 @@ import { z } from "zod";
 import { readFile } from "fs/promises";
 import { join } from "path";
 import fetch from "node-fetch";
-import { GITHUB_API_URL } from "../github/api/config";
 import { Octokit } from "@octokit/rest";
 import { updateClaudeComment } from "../github/operations/comments/update-claude-comment";
 
@@ -40,6 +39,7 @@ const REPO_OWNER = process.env.REPO_OWNER;
 const REPO_NAME = process.env.REPO_NAME;
 const BRANCH_NAME = process.env.BRANCH_NAME;
 const REPO_DIR = process.env.REPO_DIR || process.cwd();
+const GITHUB_API_URL = process.env.GITHUB_API_URL || "https://api.github.com";
 
 if (!REPO_OWNER || !REPO_NAME || !BRANCH_NAME) {
   console.error(

--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -466,6 +466,7 @@ server.tool(
 
       const octokit = new Octokit({
         auth: githubToken,
+        baseUrl: GITHUB_API_URL,
       });
 
       const isPullRequestReviewComment =

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -46,6 +46,7 @@ export async function prepareMcpConfig(
             ...(claudeCommentId && { CLAUDE_COMMENT_ID: claudeCommentId }),
             GITHUB_EVENT_NAME: process.env.GITHUB_EVENT_NAME || "",
             IS_PR: process.env.IS_PR || "false",
+            GITHUB_API_URL: process.env.GITHUB_API_URL || "https://api.github.com",
           },
         },
       },

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -1,4 +1,5 @@
 import * as core from "@actions/core";
+import { GITHUB_API_URL } from "../github/api/config";
 
 type PrepareConfigParams = {
   githubToken: string;
@@ -46,7 +47,7 @@ export async function prepareMcpConfig(
             ...(claudeCommentId && { CLAUDE_COMMENT_ID: claudeCommentId }),
             GITHUB_EVENT_NAME: process.env.GITHUB_EVENT_NAME || "",
             IS_PR: process.env.IS_PR || "false",
-            GITHUB_API_URL: process.env.GITHUB_API_URL || "https://api.github.com",
+            GITHUB_API_URL: GITHUB_API_URL,
           },
         },
       },


### PR DESCRIPTION
Fixes Bad credentials error on GitHub Enterprise Server by passing
GITHUB_API_URL as baseUrl when initializing Octokit, consistent with
other Octokit instances in the codebase.

Fixes #156
Related to #107

Generated with [Claude Code](https://claude.ai/code)