### PR TITLE
Accept multiline input for allowed_tools and disallowed_tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,15 @@ Claude does **not** have access to execute arbitrary Bash commands by default. I
 ```yaml
 - uses: anthropics/claude-code-action@beta
   with:
-    allowed_tools: "Bash(npm install),Bash(npm run test),Edit,Replace,NotebookEditCell"
-    disallowed_tools: "TaskOutput,KillTask"
+    allowed_tools: |
+      Bash(npm install)
+      Bash(npm run test)
+      Edit
+      Replace
+      NotebookEditCell
+    disallowed_tools: |
+      TaskOutput
+      KillTask
     # ... other inputs
 ```
 

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -52,14 +52,8 @@ export function parseGitHubContext(): ParsedGitHubContext {
     inputs: {
       triggerPhrase: process.env.TRIGGER_PHRASE ?? "@claude",
       assigneeTrigger: process.env.ASSIGNEE_TRIGGER ?? "",
-      allowedTools: (process.env.ALLOWED_TOOLS ?? "")
-        .split(",")
-        .map((tool) => tool.trim())
-        .filter((tool) => tool.length > 0),
-      disallowedTools: (process.env.DISALLOWED_TOOLS ?? "")
-        .split(",")
-        .map((tool) => tool.trim())
-        .filter((tool) => tool.length > 0),
+      allowedTools: parseMultilineInput(process.env.ALLOWED_TOOLS ?? ""),
+      disallowedTools: parseMultilineInput(process.env.DISALLOWED_TOOLS ?? ""),
       customInstructions: process.env.CUSTOM_INSTRUCTIONS ?? "",
       directPrompt: process.env.DIRECT_PROMPT ?? "",
       baseBranch: process.env.BASE_BRANCH,
@@ -114,6 +108,14 @@ export function parseGitHubContext(): ParsedGitHubContext {
     default:
       throw new Error(`Unsupported event type: ${context.eventName}`);
   }
+}
+
+export function parseMultilineInput(s: string): string[] {
+  return s
+    .split(/,|[\n\r]+/)
+    .map((tool) => tool.replace(/#.+$/, ""))
+    .map((tool) => tool.trim())
+    .filter((tool) => tool.length > 0);
 }
 
 export function isIssuesEvent(

--- a/test/github/context.test.ts
+++ b/test/github/context.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "bun:test";
+import { parseMultilineInput } from "../../src/github/context";
+
+describe("parseMultilineInput", () => {
+  it("should parse a comma-separated string", () => {
+    const input = `Bash(bun install),Bash(bun test:*),Bash(bun typecheck)`;
+    const result = parseMultilineInput(input);
+    expect(result).toEqual([
+      "Bash(bun install)",
+      "Bash(bun test:*)",
+      "Bash(bun typecheck)",
+    ]);
+  });
+
+  it("should parse multiline string", () => {
+    const input = `Bash(bun install)
+Bash(bun test:*)
+Bash(bun typecheck)`;
+    const result = parseMultilineInput(input);
+    expect(result).toEqual([
+      "Bash(bun install)",
+      "Bash(bun test:*)",
+      "Bash(bun typecheck)",
+    ]);
+  });
+
+  it("should parse comma-separated multiline line", () => {
+    const input = `Bash(bun install),Bash(bun test:*)
+Bash(bun typecheck)`;
+    const result = parseMultilineInput(input);
+    expect(result).toEqual([
+      "Bash(bun install)",
+      "Bash(bun test:*)",
+      "Bash(bun typecheck)",
+    ]);
+  });
+
+  it("should ignore comments", () => {
+    const input = `Bash(bun install),
+Bash(bun test:*) # For testing
+# For type checking
+Bash(bun typecheck)
+`;
+    const result = parseMultilineInput(input);
+    expect(result).toEqual([
+      "Bash(bun install)",
+      "Bash(bun test:*)",
+      "Bash(bun typecheck)",
+    ]);
+  });
+
+  it("should parse an empty string", () => {
+    const input = "";
+    const result = parseMultilineInput(input);
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
This improves `allowed_tools` and `disallowed_tools` inputs to accept a multiline string.

It supports:

- Comma separated string (currently supported)
- Line separated string
- Comment leading with `#`

Resolves https://github.com/anthropics/claude-code-action/issues/167.
