### PR TITLE
feat: use dynamic fetch depth based on PR commit count

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -45,9 +45,16 @@ export async function setupBranch(
 
       const branchName = prData.headRefName;
 
-      // Execute git commands to checkout PR branch (shallow fetch for performance)
-      // Fetch the branch with a depth of 20 to avoid fetching too much history, while still allowing for some context
-      await $`git fetch origin --depth=20 ${branchName}`;
+      // Determine optimal fetch depth based on PR commit count, with a minimum of 20
+      const commitCount = prData.commits.totalCount;
+      const fetchDepth = Math.max(commitCount, 20);
+
+      console.log(
+        `PR #${entityNumber}: ${commitCount} commits, using fetch depth ${fetchDepth}`,
+      );
+
+      // Execute git commands to checkout PR branch (dynamic depth based on PR size)
+      await $`git fetch origin --depth=${fetchDepth} ${branchName}`;
       await $`git checkout ${branchName}`;
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);


### PR DESCRIPTION
## Summary

Improves git context for large PRs by using dynamic fetch depth based on actual PR commit count instead of a fixed depth of 20 commits.

## Changes

- **Dynamic Fetch Depth**: Replace fixed `--depth=20` with calculated depth 
- **Context-Aware Minimum**: Use `Math.max(commitCount, 20)` to ensure sufficient git context

## Benefits

- **Better Context**: Large PRs (>20 commits) fetch complete PR history instead of being truncated at 20
- **Unchanged Small PRs**: PRs with ≤20 commits maintain the same depth-20 behavior
- **Contextual Appropriateness**: Fetch depth matches the actual scope of changes in the PR

## Example Behavior

- **5-commit PR**: Fetches depth 20 (unchanged - minimum for git context)
- **50-commit PR**: Fetches depth 50 (improved - gets full PR context vs. truncated 20)

This change ensures large PRs have complete context for Claude's analysis while maintaining proven behavior for smaller PRs.