### PR TITLE
feat: optional Claude co-author trailer (ADD_CLAUDE_COAUTHOR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ jobs:
 | `mcp_config`          | Additional MCP configuration (JSON string) that merges with the built-in GitHub MCP servers                          | No       | ""        |
 | `assignee_trigger`    | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                        | No       | -         |
 | `trigger_phrase`      | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                        | No       | `@claude` |
+| `add_claude_coauthor` | Add Claude as a co-author to commits                                                                                 | No       | `false`   |
 | `claude_env`          | Custom environment variables to pass to Claude Code execution (YAML format)                                          | No       | ""        |
 
 \*Required when using direct Anthropic API (default and when not using Bedrock or Vertex)

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,10 @@ inputs:
     description: "Timeout in minutes for execution"
     required: false
     default: "30"
+  add_claude_coauthor:
+    description: "Add Claude as a co-author to commits"
+    required: false
+    default: "false"
 
 outputs:
   execution_file:
@@ -99,6 +103,7 @@ runs:
         TRIGGER_PHRASE: ${{ inputs.trigger_phrase }}
         ASSIGNEE_TRIGGER: ${{ inputs.assignee_trigger }}
         BASE_BRANCH: ${{ inputs.base_branch }}
+        ADD_CLAUDE_COAUTHOR: ${{ inputs.add_claude_coauthor }}
         ALLOWED_TOOLS: ${{ inputs.allowed_tools }}
         DISALLOWED_TOOLS: ${{ inputs.disallowed_tools }}
         CUSTOM_INSTRUCTIONS: ${{ inputs.custom_instructions }}
@@ -148,6 +153,9 @@ runs:
         VERTEX_REGION_CLAUDE_3_5_HAIKU: ${{ env.VERTEX_REGION_CLAUDE_3_5_HAIKU }}
         VERTEX_REGION_CLAUDE_3_5_SONNET: ${{ env.VERTEX_REGION_CLAUDE_3_5_SONNET }}
         VERTEX_REGION_CLAUDE_3_7_SONNET: ${{ env.VERTEX_REGION_CLAUDE_3_7_SONNET }}
+
+        # Co-author settings
+        ADD_CLAUDE_COAUTHOR: ${{ inputs.add_claude_coauthor }}
 
     - name: Update comment with job link
       if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.claude_comment_id && always()

--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -69,6 +69,13 @@ server.tool(
     const owner = REPO_OWNER;
     const repo = REPO_NAME;
     const branch = BRANCH_NAME;
+
+    // Check if we should add Claude as a co-author
+    const addClaudeCoauthor = process.env.ADD_CLAUDE_COAUTHOR === "true";
+    const commitMessage = addClaudeCoauthor
+      ? `${message}\n\nCo-Authored-By: Claude <noreply@anthropic.com>`
+      : message;
+
     try {
       const githubToken = process.env.GITHUB_TOKEN;
       if (!githubToken) {
@@ -171,7 +178,7 @@ server.tool(
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          message: message,
+          message: commitMessage,
           tree: treeData.sha,
           parents: [baseSha],
         }),
@@ -263,6 +270,13 @@ server.tool(
     const owner = REPO_OWNER;
     const repo = REPO_NAME;
     const branch = BRANCH_NAME;
+
+    // Check if we should add Claude as a co-author
+    const addClaudeCoauthor = process.env.ADD_CLAUDE_COAUTHOR === "true";
+    const commitMessage = addClaudeCoauthor
+      ? `${message}\n\nCo-Authored-By: Claude <noreply@anthropic.com>`
+      : message;
+
     try {
       const githubToken = process.env.GITHUB_TOKEN;
       if (!githubToken) {
@@ -365,7 +379,7 @@ server.tool(
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          message: message,
+          message: commitMessage,
           tree: treeData.sha,
           parents: [baseSha],
         }),


### PR DESCRIPTION
Closes #173

## Context & Motivation

* Commits generated by the action are currently authored by **GitHub Actions**.  
  When browsing the history, it is impossible to know which changes were produced by Claude without opening the diff.  
* GitHub supports a standard commit-trailer (`Co-Authored-By`) for attributing commits to additional authors :contentReference[oaicite:0]{index=0}.  
* Exposing a simple boolean input keeps existing users’ workflows intact while giving teams who rely heavily on Claude clearer attribution and auditability.

## Implementation Details

| File / Area | Key Updates |
|-------------|-------------|
| `action.yml` | Added new input `add_claude_coauthor` (default: `"false"`). Wired through to env var `ADD_CLAUDE_COAUTHOR`. |
| `src/mcp/github-file-ops-server.ts` | In both the **create** and **update** commit flows:<br>  1. Read `process.env.ADD_CLAUDE_COAUTHOR`.<br>  2. Build `commitMessage` that conditionally appends the trailer (with required blank line).<br>  3. Use `commitMessage` when creating the commit via GitHub REST API. |
| `README.md` | Documented the new input. |

## Usage

```yaml
steps:
  - uses: anthropics/claude-code-action@main
    with:
      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
      github_token:      ${{ secrets.GITHUB_TOKEN }}
      add_claude_coauthor: "true"   # new
```

Resulting commit message example:
```
commit message

Co-Authored-By: Claude <noreply@anthropic.com>
```
