### PR TITLE
update MCP server image to version 0.5.0

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -32,7 +32,7 @@ jobs:
                   "--rm",
                   "-e",
                   "GITHUB_PERSONAL_ACCESS_TOKEN",
-                  "ghcr.io/github/github-mcp-server:sha-7aced2b"
+                  "ghcr.io/github/github-mcp-server:sha-6d69797"
                 ],
                 "env": {
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_TOKEN }}"

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -62,7 +62,7 @@ export async function prepareMcpConfig(
           "--rm",
           "-e",
           "GITHUB_PERSONAL_ACCESS_TOKEN",
-          "ghcr.io/github/github-mcp-server:sha-e9f748f", // https://github.com/github/github-mcp-server/releases/tag/v0.4.0
+          "ghcr.io/github/github-mcp-server:sha-6d69797", // https://github.com/github/github-mcp-server/releases/tag/v0.5.0
         ],
         env: {
           GITHUB_PERSONAL_ACCESS_TOKEN: githubToken,


### PR DESCRIPTION
This pull request updates the GitHub MCP server image version to ensure compatibility with the latest release (v0.5.0). The changes involve updating the image reference in both the GitHub Actions workflow and the MCP server installation script.

### Updates to MCP server image version:

* [`.github/workflows/issue-triage.yml`](diffhunk://#diff-4eea6c17da2d79103bcb247f5af47a37abfd43faf9032ea844ddf6c3e18dc81cL35-R35): Updated the MCP server image reference from `sha-7aced2b` to `sha-6d69797`.
* [`src/mcp/install-mcp-server.ts`](diffhunk://#diff-fae2af9c6efcec18e8950ea2c93cbeead839e89ffc8f617475a8f51908ca188fL65-R65): Updated the MCP server image reference from `sha-e9f748f` (v0.4.0) to `sha-6d69797` (v0.5.0).

### Reference
Github MCP Server 0.5.0 release note: https://github.com/github/github-mcp-server/releases/tag/v0.5.0