### PR TITLE
feat: add create_pull_request tool to GitHub MCP server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,9 @@ bun test
 # Formatting
 bun run format          # Format code with prettier
 bun run format:check    # Check code formatting
+
+# Type checking
+bun run typecheck       # Run TypeScript type checking
 ```
 
 ## Architecture Overview

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A general-purpose [Claude Code](https://claude.ai/code) action for GitHub PRs an
 - 💬 **PR/Issue Integration**: Works seamlessly with GitHub comments and PR reviews
 - 🛠️ **Flexible Tool Access**: Access to GitHub APIs and file operations (additional tools can be enabled via configuration)
 - 📋 **Progress Tracking**: Visual progress indicators with checkboxes that dynamically update as Claude completes tasks
+- 🚀 **Pull Request Creation**: Can create pull requests to propose changes (requires explicit tool permission)
 - 🏃 **Runs on Your Infrastructure**: The action executes entirely on your own GitHub runner (Anthropic API calls go to your chosen provider)
 
 ## Quickstart


### PR DESCRIPTION
## Summary

Hi maintainers. I'm obsessed with Claude Code and the Github Action as well. 
I like that Claude will pus to a branch and comment with a link to open a pull request, but I think it'd be nice if you could just have Claude open the PR instead. 


Ok, now here's the bit Claude wrote about it's own code:

---

This PR adds a new `create_pull_request` tool to the GitHub MCP server, enabling Claude to create pull requests as part of its workflow capabilities.

### What's Added

- **New MCP Tool**: `create_pull_request` with complete schema validation
- **Flexible Configuration**: Supports title, body, base/head branches, and draft status
- **Comprehensive Testing**: Unit tests covering tool configuration scenarios
- **Documentation Updates**: README and CLAUDE.md improvements

### Tool Schema

```typescript
{
  title: string,              // Pull request title
  body: string,               // Pull request description
  base: string,               // Target branch (e.g. 'main')
  head?: string,              // Source branch (defaults to current)
  draft?: boolean             // Create as draft PR (defaults to false)
}
```

### Use Cases

- **Issue Resolution**: Claude can create PRs to close issues after implementing fixes
- **Feature Implementation**: End-to-end workflow from code changes to PR creation
- **Draft PRs**: Create draft PRs for review before finalizing changes

### Testing Evidence

Successfully tested on Stetson's fork and invoked via [this issue](https://github.com/stets/claude-code-action/issues/4): 

Yes, I accidentally ran two Github actions, but the one that won created the PR without a problem. 
https://github.com/stets/claude-code-action/pull/5

- Claude created files and opened a working PR
- All CI checks passing (209 tests ✅)
- TypeScript validation ✅  
- Code formatting ✅

### Integration

Tool requires explicit permission via `allowed_tools: "mcp__github_file_ops__create_pull_request"` in workflow configuration, maintaining security through opt-in usage.

🤖 Generated with [Claude Code](https://claude.ai/code)