### PR TITLE
fix: allow direct_prompt with issue assignment without requiring assignee_trigger

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -242,7 +242,7 @@ export function prepareContext(
       }
 
       if (eventAction === "assigned") {
-        if (!assigneeTrigger) {
+        if (!assigneeTrigger && !directPrompt) {
           throw new Error(
             "ASSIGNEE_TRIGGER is required for issue assigned event",
           );
@@ -254,7 +254,7 @@ export function prepareContext(
           issueNumber,
           baseBranch,
           claudeBranch,
-          assigneeTrigger,
+          ...(assigneeTrigger && { assigneeTrigger }),
         };
       } else if (eventAction === "opened") {
         eventData = {
@@ -331,7 +331,9 @@ export function getEventTypeAndContext(envVars: PreparedContext): {
       }
       return {
         eventType: "ISSUE_ASSIGNED",
-        triggerContext: `issue assigned to '${eventData.assigneeTrigger}'`,
+        triggerContext: eventData.assigneeTrigger
+          ? `issue assigned to '${eventData.assigneeTrigger}'`
+          : `issue assigned event`,
       };
 
     case "pull_request":

--- a/src/create-prompt/types.ts
+++ b/src/create-prompt/types.ts
@@ -65,7 +65,7 @@ type IssueAssignedEvent = {
   issueNumber: string;
   baseBranch: string;
   claudeBranch: string;
-  assigneeTrigger: string;
+  assigneeTrigger?: string;
 };
 
 type PullRequestEvent = {

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -614,6 +614,29 @@ describe("getEventTypeAndContext", () => {
     expect(result.eventType).toBe("ISSUE_ASSIGNED");
     expect(result.triggerContext).toBe("issue assigned to 'claude-bot'");
   });
+
+  test("should return correct type and context for issue assigned without assigneeTrigger", () => {
+    const envVars: PreparedContext = {
+      repository: "owner/repo",
+      claudeCommentId: "12345",
+      triggerPhrase: "@claude",
+      directPrompt: "Please assess this issue",
+      eventData: {
+        eventName: "issues",
+        eventAction: "assigned",
+        isPR: false,
+        issueNumber: "999",
+        baseBranch: "main",
+        claudeBranch: "claude/issue-999-20240101_120000",
+        // No assigneeTrigger when using directPrompt
+      },
+    };
+
+    const result = getEventTypeAndContext(envVars);
+
+    expect(result.eventType).toBe("ISSUE_ASSIGNED");
+    expect(result.triggerContext).toBe("issue assigned event");
+  });
 });
 
 describe("buildAllowedToolsString", () => {


### PR DESCRIPTION
## Description

### Summary
Fixes issue #113 where `direct_prompt` workflows were failing on issue assignment events with "ASSIGNEE_TRIGGER is required for issue assigned event" error.

### Problem
When using `direct_prompt` for automated issue assessment workflows, the action was unconditionally requiring `assignee_trigger` for issue assignment events, even though `direct_prompt` bypasses normal trigger logic and should work independently.

### Solution
- Modified validation logic in `src/create-prompt/index.ts` to only require `assignee_trigger` when `direct_prompt` is not provided
- Updated `IssueAssignedEvent` type to make `assignee_trigger` optional
- Enhanced context generation to gracefully handle missing `assignee_trigger`

Closes #113