### PR TITLE
fix: add missing LABEL_TRIGGER environment variable to prepare step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,7 @@ runs:
       env:
         TRIGGER_PHRASE: ${{ inputs.trigger_phrase }}
         ASSIGNEE_TRIGGER: ${{ inputs.assignee_trigger }}
+        LABEL_TRIGGER: ${{ inputs.label_trigger }}
         BASE_BRANCH: ${{ inputs.base_branch }}
         BRANCH_PREFIX: ${{ inputs.branch_prefix }}
         ALLOWED_TOOLS: ${{ inputs.allowed_tools }}


### PR DESCRIPTION
The label_trigger input was defined but not passed as an environment variable to the prepare step, causing it to be undefined in the prepare script. This adds the missing LABEL_TRIGGER environment variable mapping.

## Problem
The \`label_trigger\` input parameter is defined in \`action.yml\` but not passed as an environment variable to the prepare step.

## Solution  
Add the missing \`LABEL_TRIGGER: \${{ inputs.label_trigger }}\` environment variable mapping.

## Testing
- [x] Ran \`bun test\`
- [x] Ran \`bun run typecheck\` 
- [x] Ran \`bun run format:check\`
- [x] Tested functionality locally

## Impact
- ✅ Fixes label trigger functionality
- ✅ No breaking changes
- ✅ Backward compatible

## Related Issues
Fixes https://github.com/anthropics/claude-code-action/issues/210