### PR TITLE
fix(github): fixing claude login user name

### DIFF
--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -14,6 +14,8 @@ import {
 } from "../../context";
 import type { Octokit } from "@octokit/rest";
 
+const CLAUDE_APP_BOT_ID = 209825114;
+
 export async function createInitialComment(
   octokit: Octokit,
   context: ParsedGitHubContext,
@@ -37,7 +39,7 @@ export async function createInitialComment(
         issue_number: context.entityNumber,
       });
       const existingComment = comments.data.find((comment) => {
-        const idMatch = comment.user?.id === 209825114;
+        const idMatch = comment.user?.id === CLAUDE_APP_BOT_ID;
         const botNameMatch =
           comment.user?.type === "Bot" &&
           comment.user?.login.toLowerCase().includes("claude");

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -36,11 +36,15 @@ export async function createInitialComment(
         repo,
         issue_number: context.entityNumber,
       });
-      const existingComment = comments.data.find(
-        (comment) =>
-          comment.user?.login.indexOf("claude") !== -1 ||
-          comment.body === initialBody,
-      );
+      const existingComment = comments.data.find((comment) => {
+        const idMatch = comment.user?.id === 209825114;
+        const botNameMatch =
+          comment.user?.type === "Bot" &&
+          comment.user?.login.toLowerCase().includes("claude");
+        const bodyMatch = comment.body === initialBody;
+
+        return idMatch || botNameMatch || bodyMatch;
+      });
       if (existingComment) {
         response = await octokit.rest.issues.updateComment({
           owner,

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -38,7 +38,7 @@ export async function createInitialComment(
       });
       const existingComment = comments.data.find(
         (comment) =>
-          comment.user?.login.indexOf("claude[bot]") !== -1 ||
+          comment.user?.login.indexOf("claude") !== -1 ||
           comment.body === initialBody,
       );
       if (existingComment) {


### PR DESCRIPTION
Simply fixing claude's login name change to match when doing sticky comments.

Following a fix from a [previous PR](https://github.com/anthropics/claude-code-action/pull/211) to allow sticky comments, one unwanted change was applied, and this PR aims to revert that change.
