### PR TITLE
feat: add fallback_model input to enable automatic model fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ jobs:
 | `use_sticky_comment`  | Use just one comment to deliver PR comments (only applies for pull_request event workflows)                          | No       | `false`   |
 | `github_token`        | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!** | No       | -         |
 | `model`               | Model to use (provider-specific format required for Bedrock/Vertex)                                                  | No       | -         |
+| `fallback_model`      | Enable automatic fallback to specified model when primary model is unavailable                                       | No       | -         |
 | `anthropic_model`     | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                | No       | -         |
 | `use_bedrock`         | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                          | No       | `false`   |
 | `use_vertex`          | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                        | No       | `false`   |

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   anthropic_model:
     description: "DEPRECATED: Use 'model' instead. Model to use (provider-specific format required for Bedrock/Vertex)"
     required: false
+  fallback_model:
+    description: "Enable automatic fallback to specified model when primary model is unavailable"
+    required: false
   allowed_tools:
     description: "Additional tools for Claude to use (the base GitHub tools will always be included)"
     required: false
@@ -133,6 +136,7 @@ runs:
         timeout_minutes: ${{ inputs.timeout_minutes }}
         max_turns: ${{ inputs.max_turns }}
         model: ${{ inputs.model || inputs.anthropic_model }}
+        fallback_model: ${{ inputs.fallback_model }}
         mcp_config: ${{ steps.prepare.outputs.mcp_config }}
         use_bedrock: ${{ inputs.use_bedrock }}
         use_vertex: ${{ inputs.use_vertex }}


### PR DESCRIPTION
- Add fallback_model input to action.yml matching claude-code-base-action
- Pass fallback_model through to the base action
- Document the new input in README.md inputs table
- Enables automatic fallback when primary model is unavailable

🤖 Generated with [Claude Code](https://claude.ai/code)