### PR TITLE
feat: forward NODE_VERSION environment variable to base action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -146,6 +146,7 @@ runs:
         # Model configuration
         ANTHROPIC_MODEL: ${{ inputs.model || inputs.anthropic_model }}
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
+        NODE_VERSION: ${{ env.NODE_VERSION }}
 
         # Provider configuration
         ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}


### PR DESCRIPTION
This PR fixes #229 by forwarding the NODE_VERSION environment variable to the base action.

This allows users to override the default Node version by setting the NODE_VERSION environment variable in their workflow.

Generated with [Claude Code](https://claude.ai/code)