### PR TITLE
Add retry logic for intermittent 403 errors in MCP file operations

### DIFF
--- a/src/github/token.ts
+++ b/src/github/token.ts
@@ -1,47 +1,7 @@
 #!/usr/bin/env bun
 
 import * as core from "@actions/core";
-
-type RetryOptions = {
-  maxAttempts?: number;
-  initialDelayMs?: number;
-  maxDelayMs?: number;
-  backoffFactor?: number;
-};
-
-async function retryWithBackoff<T>(
-  operation: () => Promise<T>,
-  options: RetryOptions = {},
-): Promise<T> {
-  const {
-    maxAttempts = 3,
-    initialDelayMs = 5000,
-    maxDelayMs = 20000,
-    backoffFactor = 2,
-  } = options;
-
-  let delayMs = initialDelayMs;
-  let lastError: Error | undefined;
-
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      console.log(`Attempt ${attempt} of ${maxAttempts}...`);
-      return await operation();
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
-      console.error(`Attempt ${attempt} failed:`, lastError.message);
-
-      if (attempt < maxAttempts) {
-        console.log(`Retrying in ${delayMs / 1000} seconds...`);
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-        delayMs = Math.min(delayMs * backoffFactor, maxDelayMs);
-      }
-    }
-  }
-
-  console.error(`Operation failed after ${maxAttempts} attempts`);
-  throw lastError;
-}
+import { retryWithBackoff } from "../utils/retry";
 
 async function getOidcToken(): Promise<string> {
   try {

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,40 @@
+export type RetryOptions = {
+  maxAttempts?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  backoffFactor?: number;
+};
+
+export async function retryWithBackoff<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const {
+    maxAttempts = 3,
+    initialDelayMs = 5000,
+    maxDelayMs = 20000,
+    backoffFactor = 2,
+  } = options;
+
+  let delayMs = initialDelayMs;
+  let lastError: Error | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      console.log(`Attempt ${attempt} of ${maxAttempts}...`);
+      return await operation();
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      console.error(`Attempt ${attempt} failed:`, lastError.message);
+
+      if (attempt < maxAttempts) {
+        console.log(`Retrying in ${delayMs / 1000} seconds...`);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        delayMs = Math.min(delayMs * backoffFactor, maxDelayMs);
+      }
+    }
+  }
+
+  console.error(`Operation failed after ${maxAttempts} attempts`);
+  throw lastError;
+}


### PR DESCRIPTION
- Extract retry logic to shared utility in src/utils/retry.ts
- Update token.ts to use shared retry utility
- Add retry with exponential backoff to git reference updates
- Only retry on 403 errors, fail immediately on other errors
- Use shorter delays (1-5s) for transient GitHub API failures

This handles intermittent 403 'Resource not accessible by integration' errors transparently without requiring workflow permission changes.