### PR TITLE
chore: update MCP server image to version 0.6.0

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -32,7 +32,7 @@ jobs:
                   "--rm",
                   "-e",
                   "GITHUB_PERSONAL_ACCESS_TOKEN",
-                  "ghcr.io/github/github-mcp-server:sha-6d69797"
+                  "ghcr.io/github/github-mcp-server:sha-721fd3e"
                 ],
                 "env": {
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_TOKEN }}"

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -134,7 +134,7 @@ export async function prepareMcpConfig(
           "--rm",
           "-e",
           "GITHUB_PERSONAL_ACCESS_TOKEN",
-          "ghcr.io/github/github-mcp-server:sha-6d69797", // https://github.com/github/github-mcp-server/releases/tag/v0.5.0
+          "ghcr.io/github/github-mcp-server:sha-721fd3e", // https://github.com/github/github-mcp-server/releases/tag/v0.6.0
         ],
         env: {
           GITHUB_PERSONAL_ACCESS_TOKEN: githubToken,


### PR DESCRIPTION
Updates the GitHub MCP server from v0.5.0 (sha-6d69797) to v0.6.0 (sha-721fd3e) in both the issue triage workflow and the MCP server installation script.

release tag: https://github.com/github/github-mcp-server/releases/tag/v0.6.0

