### PR TITLE
Expose the created branch for downstream usage

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,10 @@ outputs:
   execution_file:
     description: "Path to the Claude Code execution output file"
     value: ${{ steps.claude-code.outputs.execution_file }}
-
+  branch_name:
+    description: "The branch created by Claude Code for this execution"
+    value: ${{ steps.prepare.outputs.CLAUDE_BRANCH }}
+    
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ outputs:
   branch_name:
     description: "The branch created by Claude Code for this execution"
     value: ${{ steps.prepare.outputs.CLAUDE_BRANCH }}
-    
+
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
I have a use case where I need the generated branch name for additional steps in my workflow.

This exports the branch_name so I can reference it like so

```yml
      - name: Do custom stuff with branch
        id: do-custom-stuff
        if: steps.claude.outputs.branch_name
        run: |
          BRANCH_NAME="${{ steps.claude.outputs.branch_name }}"
```