### PR TITLE
feat: add use_commit_signing input with default false

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,10 @@ inputs:
     description: "Use just one comment to deliver issue/PR comments"
     required: false
     default: "false"
+  use_commit_signing:
+    description: "Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands"
+    required: false
+    default: "false"
 
 outputs:
   execution_file:
@@ -133,6 +137,7 @@ runs:
         USE_STICKY_COMMENT: ${{ inputs.use_sticky_comment }}
         ACTIONS_TOKEN: ${{ github.token }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
+        USE_COMMIT_SIGNING: ${{ inputs.use_commit_signing }}
 
     - name: Run Claude Code
       id: claude-code

--- a/action.yml
+++ b/action.yml
@@ -206,6 +206,7 @@ runs:
         PREPARE_SUCCESS: ${{ steps.prepare.outcome == 'success' }}
         PREPARE_ERROR: ${{ steps.prepare.outputs.prepare_error || '' }}
         USE_STICKY_COMMENT: ${{ inputs.use_sticky_comment }}
+        USE_COMMIT_SIGNING: ${{ inputs.use_commit_signing }}
 
     - name: Display Claude Code Report
       if: steps.prepare.outputs.contains_trigger == 'true' && steps.claude-code.outputs.execution_file != ''

--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -11,7 +11,7 @@ import {
   isPullRequestReviewCommentEvent,
 } from "../github/context";
 import { GITHUB_SERVER_URL } from "../github/api/config";
-import { checkAndDeleteEmptyBranch } from "../github/operations/branch-cleanup";
+import { checkAndCommitOrDeleteBranch } from "../github/operations/branch-cleanup";
 import { updateClaudeComment } from "../github/operations/comments/update-claude-comment";
 
 async function run() {
@@ -88,13 +88,16 @@ async function run() {
     const currentBody = comment.body ?? "";
 
     // Check if we need to add branch link for new branches
-    const { shouldDeleteBranch, branchLink } = await checkAndDeleteEmptyBranch(
-      octokit,
-      owner,
-      repo,
-      claudeBranch,
-      baseBranch,
-    );
+    const useCommitSigning = process.env.USE_COMMIT_SIGNING === "true";
+    const { shouldDeleteBranch, branchLink } =
+      await checkAndCommitOrDeleteBranch(
+        octokit,
+        owner,
+        repo,
+        claudeBranch,
+        baseBranch,
+        useCommitSigning,
+      );
 
     // Check if we need to add PR URL when we have a new branch
     let prLink = "";

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -38,6 +38,7 @@ export type ParsedGitHubContext = {
     branchPrefix: string;
     useStickyComment: boolean;
     additionalPermissions: Map<string, string>;
+    useCommitSigning: boolean;
   };
 };
 
@@ -68,6 +69,7 @@ export function parseGitHubContext(): ParsedGitHubContext {
       additionalPermissions: parseAdditionalPermissions(
         process.env.ADDITIONAL_PERMISSIONS ?? "",
       ),
+      useCommitSigning: process.env.USE_COMMIT_SIGNING === "true",
     },
   };
 

--- a/src/github/operations/branch-cleanup.ts
+++ b/src/github/operations/branch-cleanup.ts
@@ -1,12 +1,14 @@
 import type { Octokits } from "../api/client";
 import { GITHUB_SERVER_URL } from "../api/config";
+import { $ } from "bun";
 
-export async function checkAndDeleteEmptyBranch(
+export async function checkAndCommitOrDeleteBranch(
   octokit: Octokits,
   owner: string,
   repo: string,
   claudeBranch: string | undefined,
   baseBranch: string,
+  useCommitSigning: boolean,
 ): Promise<{ shouldDeleteBranch: boolean; branchLink: string }> {
   let branchLink = "";
   let shouldDeleteBranch = false;
@@ -21,12 +23,58 @@ export async function checkAndDeleteEmptyBranch(
           basehead: `${baseBranch}...${claudeBranch}`,
         });
 
-      // If there are no commits, mark branch for deletion
+      // If there are no commits, check for uncommitted changes if not using commit signing
       if (comparison.total_commits === 0) {
-        console.log(
-          `Branch ${claudeBranch} has no commits from Claude, will delete it`,
-        );
-        shouldDeleteBranch = true;
+        if (!useCommitSigning) {
+          console.log(
+            `Branch ${claudeBranch} has no commits from Claude, checking for uncommitted changes...`,
+          );
+
+          // Check for uncommitted changes using git status
+          try {
+            const gitStatus = await $`git status --porcelain`.quiet();
+            const hasUncommittedChanges =
+              gitStatus.stdout.toString().trim().length > 0;
+
+            if (hasUncommittedChanges) {
+              console.log("Found uncommitted changes, committing them...");
+
+              // Add all changes
+              await $`git add -A`;
+
+              // Commit with a descriptive message
+              const runId = process.env.GITHUB_RUN_ID || "unknown";
+              const commitMessage = `Auto-commit: Save uncommitted changes from Claude\n\nRun ID: ${runId}`;
+              await $`git commit -m ${commitMessage}`;
+
+              // Push the changes
+              await $`git push origin ${claudeBranch}`;
+
+              console.log(
+                "✅ Successfully committed and pushed uncommitted changes",
+              );
+
+              // Set branch link since we now have commits
+              const branchUrl = `${GITHUB_SERVER_URL}/${owner}/${repo}/tree/${claudeBranch}`;
+              branchLink = `\n[View branch](${branchUrl})`;
+            } else {
+              console.log(
+                "No uncommitted changes found, marking branch for deletion",
+              );
+              shouldDeleteBranch = true;
+            }
+          } catch (gitError) {
+            console.error("Error checking/committing changes:", gitError);
+            // If we can't check git status, assume the branch might have changes
+            const branchUrl = `${GITHUB_SERVER_URL}/${owner}/${repo}/tree/${claudeBranch}`;
+            branchLink = `\n[View branch](${branchUrl})`;
+          }
+        } else {
+          console.log(
+            `Branch ${claudeBranch} has no commits from Claude, will delete it`,
+          );
+          shouldDeleteBranch = true;
+        }
       } else {
         // Only add branch link if there are commits
         const branchUrl = `${GITHUB_SERVER_URL}/${owner}/${repo}/tree/${claudeBranch}`;

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -86,7 +86,7 @@ export async function createInitialComment(
     const githubOutput = process.env.GITHUB_OUTPUT!;
     appendFileSync(githubOutput, `claude_comment_id=${response.data.id}\n`);
     console.log(`✅ Created initial comment with ID: ${response.data.id}`);
-    return response.data.id;
+    return response.data;
   } catch (error) {
     console.error("Error in initial comment:", error);
 
@@ -102,7 +102,7 @@ export async function createInitialComment(
       const githubOutput = process.env.GITHUB_OUTPUT!;
       appendFileSync(githubOutput, `claude_comment_id=${response.data.id}\n`);
       console.log(`✅ Created fallback comment with ID: ${response.data.id}`);
-      return response.data.id;
+      return response.data;
     } catch (fallbackError) {
       console.error("Error creating fallback comment:", fallbackError);
       throw fallbackError;

--- a/src/github/operations/git-config.ts
+++ b/src/github/operations/git-config.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+
+/**
+ * Configure git authentication for non-signing mode
+ * Sets up git user and authentication to work with GitHub App tokens
+ */
+
+import { $ } from "bun";
+import type { ParsedGitHubContext } from "../context";
+import { GITHUB_SERVER_URL } from "../api/config";
+
+type GitUser = {
+  login: string;
+  id: number;
+};
+
+export async function configureGitAuth(
+  githubToken: string,
+  context: ParsedGitHubContext,
+  user: GitUser | null,
+) {
+  console.log("Configuring git authentication for non-signing mode");
+
+  // Configure git user based on the comment creator
+  console.log("Configuring git user...");
+  if (user) {
+    const botName = user.login;
+    const botId = user.id;
+    console.log(`Setting git user as ${botName}...`);
+    await $`git config user.name "${botName}"`;
+    await $`git config user.email "${botId}+${botName}@users.noreply.github.com"`;
+    console.log(`✓ Set git user as ${botName}`);
+  } else {
+    console.log("No user data in comment, using default bot user");
+    await $`git config user.name "github-actions[bot]"`;
+    await $`git config user.email "41898282+github-actions[bot]@users.noreply.github.com"`;
+  }
+
+  // Remove the authorization header that actions/checkout sets
+  console.log("Removing existing git authentication headers...");
+  try {
+    await $`git config --unset-all http.${GITHUB_SERVER_URL}/.extraheader`;
+    console.log("✓ Removed existing authentication headers");
+  } catch (e) {
+    console.log("No existing authentication headers to remove");
+  }
+
+  // Update the remote URL to include the token for authentication
+  console.log("Updating remote URL with authentication...");
+  const serverUrl = new URL(GITHUB_SERVER_URL);
+  const remoteUrl = `https://x-access-token:${githubToken}@${serverUrl.host}/${context.repository.owner}/${context.repository.repo}.git`;
+  await $`git remote set-url origin ${remoteUrl}`;
+  console.log("✓ Updated remote URL with authentication token");
+
+  console.log("Git authentication configured successfully");
+}

--- a/src/mcp/github-comment-server.ts
+++ b/src/mcp/github-comment-server.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// GitHub Comment MCP Server - Minimal server that only provides comment update functionality
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { GITHUB_API_URL } from "../github/api/config";
+import { Octokit } from "@octokit/rest";
+import { updateClaudeComment } from "../github/operations/comments/update-claude-comment";
+
+// Get repository information from environment variables
+const REPO_OWNER = process.env.REPO_OWNER;
+const REPO_NAME = process.env.REPO_NAME;
+
+if (!REPO_OWNER || !REPO_NAME) {
+  console.error(
+    "Error: REPO_OWNER and REPO_NAME environment variables are required",
+  );
+  process.exit(1);
+}
+
+const server = new McpServer({
+  name: "GitHub Comment Server",
+  version: "0.0.1",
+});
+
+server.tool(
+  "update_claude_comment",
+  "Update the Claude comment with progress and results (automatically handles both issue and PR comments)",
+  {
+    body: z.string().describe("The updated comment content"),
+  },
+  async ({ body }) => {
+    try {
+      const githubToken = process.env.GITHUB_TOKEN;
+      const claudeCommentId = process.env.CLAUDE_COMMENT_ID;
+      const eventName = process.env.GITHUB_EVENT_NAME;
+
+      if (!githubToken) {
+        throw new Error("GITHUB_TOKEN environment variable is required");
+      }
+      if (!claudeCommentId) {
+        throw new Error("CLAUDE_COMMENT_ID environment variable is required");
+      }
+
+      const owner = REPO_OWNER;
+      const repo = REPO_NAME;
+      const commentId = parseInt(claudeCommentId, 10);
+
+      const octokit = new Octokit({
+        auth: githubToken,
+        baseUrl: GITHUB_API_URL,
+      });
+
+      const isPullRequestReviewComment =
+        eventName === "pull_request_review_comment";
+
+      const result = await updateClaudeComment(octokit, {
+        owner,
+        repo,
+        commentId,
+        body,
+        isPullRequestReviewComment,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: ${errorMessage}`,
+          },
+        ],
+        error: errorMessage,
+        isError: true,
+      };
+    }
+  },
+);
+
+async function runServer() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  process.on("exit", () => {
+    server.close();
+  });
+}
+
+runServer().catch(console.error);

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -133,7 +133,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     expect(prompt).toContain("You are Claude, an AI assistant");
     expect(prompt).toContain("<event_type>GENERAL_COMMENT</event_type>");
@@ -161,7 +161,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     expect(prompt).toContain("<event_type>PR_REVIEW</event_type>");
     expect(prompt).toContain("<is_pr>true</is_pr>");
@@ -187,7 +187,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     expect(prompt).toContain("<event_type>ISSUE_CREATED</event_type>");
     expect(prompt).toContain(
@@ -215,7 +215,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     expect(prompt).toContain("<event_type>ISSUE_ASSIGNED</event_type>");
     expect(prompt).toContain(
@@ -242,7 +242,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     expect(prompt).toContain("<event_type>ISSUE_LABELED</event_type>");
     expect(prompt).toContain(
@@ -269,7 +269,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     expect(prompt).toContain("<direct_prompt>");
     expect(prompt).toContain("Fix the bug in the login form");
@@ -292,7 +292,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     expect(prompt).toContain("<event_type>PULL_REQUEST</event_type>");
     expect(prompt).toContain("<is_pr>true</is_pr>");
@@ -317,7 +317,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     expect(prompt).toContain("CUSTOM INSTRUCTIONS:\nAlways use TypeScript");
   });
@@ -339,11 +339,12 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     expect(prompt).toContain("<trigger_username>johndoe</trigger_username>");
+    // With commit signing disabled, co-author info appears in git commit instructions
     expect(prompt).toContain(
-      'Use: "Co-authored-by: johndoe <johndoe@users.noreply.github.com>"',
+      "Co-authored-by: johndoe <johndoe@users.noreply.github.com>",
     );
   });
 
@@ -360,12 +361,10 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
-    // Should contain PR-specific instructions
-    expect(prompt).toContain(
-      "Push directly using mcp__github_file_ops__commit_files to the existing branch",
-    );
+    // Should contain PR-specific instructions (git commands when not using signing)
+    expect(prompt).toContain("git push");
     expect(prompt).toContain(
       "Always push to the existing branch when triggered on a PR",
     );
@@ -393,7 +392,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     // Should contain Issue-specific instructions
     expect(prompt).toContain(
@@ -432,7 +431,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     // Should contain the actual branch name with timestamp
     expect(prompt).toContain(
@@ -462,7 +461,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     // Should contain branch-specific instructions like issues
     expect(prompt).toContain(
@@ -500,12 +499,10 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
-    // Should contain open PR instructions
-    expect(prompt).toContain(
-      "Push directly using mcp__github_file_ops__commit_files to the existing branch",
-    );
+    // Should contain open PR instructions (git commands when not using signing)
+    expect(prompt).toContain("git push");
     expect(prompt).toContain(
       "Always push to the existing branch when triggered on a PR",
     );
@@ -533,7 +530,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     // Should contain new branch instructions
     expect(prompt).toContain(
@@ -561,7 +558,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     // Should contain new branch instructions
     expect(prompt).toContain(
@@ -589,7 +586,7 @@ describe("generatePrompt", () => {
       },
     };
 
-    const prompt = generatePrompt(envVars, mockGitHubData);
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
 
     // Should contain new branch instructions
     expect(prompt).toContain(
@@ -597,6 +594,61 @@ describe("generatePrompt", () => {
     );
     expect(prompt).toContain("Create a PR](https://github.com/");
     expect(prompt).toContain("Reference to the original PR");
+  });
+
+  test("should include git commands when useCommitSigning is false", () => {
+    const envVars: PreparedContext = {
+      repository: "owner/repo",
+      claudeCommentId: "12345",
+      triggerPhrase: "@claude",
+      eventData: {
+        eventName: "issue_comment",
+        commentId: "67890",
+        isPR: true,
+        prNumber: "123",
+        commentBody: "@claude fix the bug",
+      },
+    };
+
+    const prompt = generatePrompt(envVars, mockGitHubData, false);
+
+    // Should have git command instructions
+    expect(prompt).toContain("Use git commands via the Bash tool");
+    expect(prompt).toContain("git add");
+    expect(prompt).toContain("git commit");
+    expect(prompt).toContain("git push");
+
+    // Should use the minimal comment tool
+    expect(prompt).toContain("mcp__github_comment__update_claude_comment");
+
+    // Should not have commit signing tool references
+    expect(prompt).not.toContain("mcp__github_file_ops__commit_files");
+  });
+
+  test("should include commit signing tools when useCommitSigning is true", () => {
+    const envVars: PreparedContext = {
+      repository: "owner/repo",
+      claudeCommentId: "12345",
+      triggerPhrase: "@claude",
+      eventData: {
+        eventName: "issue_comment",
+        commentId: "67890",
+        isPR: true,
+        prNumber: "123",
+        commentBody: "@claude fix the bug",
+      },
+    };
+
+    const prompt = generatePrompt(envVars, mockGitHubData, true);
+
+    // Should have commit signing tool instructions
+    expect(prompt).toContain("mcp__github_file_ops__commit_files");
+    expect(prompt).toContain("mcp__github_file_ops__delete_files");
+    // Comment tool should always be from comment server, not file ops
+    expect(prompt).toContain("mcp__github_comment__update_claude_comment");
+
+    // Should not have git command instructions
+    expect(prompt).not.toContain("Use git commands via the Bash tool");
   });
 });
 
@@ -689,7 +741,7 @@ describe("getEventTypeAndContext", () => {
 });
 
 describe("buildAllowedToolsString", () => {
-  test("should return issue comment tool for regular events", () => {
+  test("should return correct tools for regular events (default no signing)", () => {
     const result = buildAllowedToolsString();
 
     // The base tools should be in the result
@@ -699,15 +751,20 @@ describe("buildAllowedToolsString", () => {
     expect(result).toContain("LS");
     expect(result).toContain("Read");
     expect(result).toContain("Write");
-    expect(result).toContain("mcp__github_file_ops__update_claude_comment");
-    expect(result).not.toContain("mcp__github__update_issue_comment");
-    expect(result).not.toContain("mcp__github__update_pull_request_comment");
-    expect(result).toContain("mcp__github_file_ops__commit_files");
-    expect(result).toContain("mcp__github_file_ops__delete_files");
+
+    // Default is no commit signing, so should have specific Bash git commands
+    expect(result).toContain("Bash(git add:*)");
+    expect(result).toContain("Bash(git commit:*)");
+    expect(result).toContain("Bash(git push:*)");
+    expect(result).toContain("mcp__github_comment__update_claude_comment");
+
+    // Should not have commit signing tools
+    expect(result).not.toContain("mcp__github_file_ops__commit_files");
+    expect(result).not.toContain("mcp__github_file_ops__delete_files");
   });
 
-  test("should return PR comment tool for inline review comments", () => {
-    const result = buildAllowedToolsString();
+  test("should return correct tools with default parameters", () => {
+    const result = buildAllowedToolsString([], false, false);
 
     // The base tools should be in the result
     expect(result).toContain("Edit");
@@ -716,11 +773,15 @@ describe("buildAllowedToolsString", () => {
     expect(result).toContain("LS");
     expect(result).toContain("Read");
     expect(result).toContain("Write");
-    expect(result).toContain("mcp__github_file_ops__update_claude_comment");
-    expect(result).not.toContain("mcp__github__update_issue_comment");
-    expect(result).not.toContain("mcp__github__update_pull_request_comment");
-    expect(result).toContain("mcp__github_file_ops__commit_files");
-    expect(result).toContain("mcp__github_file_ops__delete_files");
+
+    // Should have specific Bash git commands for non-signing mode
+    expect(result).toContain("Bash(git add:*)");
+    expect(result).toContain("Bash(git commit:*)");
+    expect(result).toContain("mcp__github_comment__update_claude_comment");
+
+    // Should not have commit signing tools
+    expect(result).not.toContain("mcp__github_file_ops__commit_files");
+    expect(result).not.toContain("mcp__github_file_ops__delete_files");
   });
 
   test("should append custom tools when provided", () => {
@@ -772,6 +833,79 @@ describe("buildAllowedToolsString", () => {
     expect(result).toContain("mcp__github_ci__get_ci_status");
     expect(result).toContain("mcp__github_ci__get_workflow_run_details");
     expect(result).toContain("mcp__github_ci__download_job_log");
+  });
+
+  test("should include commit signing tools when useCommitSigning is true", () => {
+    const result = buildAllowedToolsString([], false, true);
+
+    // Base tools should be present
+    expect(result).toContain("Edit");
+    expect(result).toContain("Glob");
+    expect(result).toContain("Grep");
+    expect(result).toContain("LS");
+    expect(result).toContain("Read");
+    expect(result).toContain("Write");
+
+    // Commit signing tools should be included
+    expect(result).toContain("mcp__github_file_ops__commit_files");
+    expect(result).toContain("mcp__github_file_ops__delete_files");
+    // Comment tool should always be from github_comment server
+    expect(result).toContain("mcp__github_comment__update_claude_comment");
+
+    // Bash should NOT be included when using commit signing (except in comment tool name)
+    expect(result).not.toContain("Bash(");
+  });
+
+  test("should include specific Bash git commands when useCommitSigning is false", () => {
+    const result = buildAllowedToolsString([], false, false);
+
+    // Base tools should be present
+    expect(result).toContain("Edit");
+    expect(result).toContain("Glob");
+    expect(result).toContain("Grep");
+    expect(result).toContain("LS");
+    expect(result).toContain("Read");
+    expect(result).toContain("Write");
+
+    // Specific Bash git commands should be included
+    expect(result).toContain("Bash(git add:*)");
+    expect(result).toContain("Bash(git commit:*)");
+    expect(result).toContain("Bash(git push:*)");
+    expect(result).toContain("Bash(git status:*)");
+    expect(result).toContain("Bash(git diff:*)");
+    expect(result).toContain("Bash(git log:*)");
+    expect(result).toContain("Bash(git rm:*)");
+    expect(result).toContain("Bash(git config user.name:*)");
+    expect(result).toContain("Bash(git config user.email:*)");
+
+    // Comment tool from minimal server should be included
+    expect(result).toContain("mcp__github_comment__update_claude_comment");
+
+    // Commit signing tools should NOT be included
+    expect(result).not.toContain("mcp__github_file_ops__commit_files");
+    expect(result).not.toContain("mcp__github_file_ops__delete_files");
+  });
+
+  test("should handle all combinations of options", () => {
+    const customTools = ["CustomTool1", "CustomTool2"];
+    const result = buildAllowedToolsString(customTools, true, false);
+
+    // Base tools should be present
+    expect(result).toContain("Edit");
+    expect(result).toContain("Bash(git add:*)");
+
+    // Custom tools should be included
+    expect(result).toContain("CustomTool1");
+    expect(result).toContain("CustomTool2");
+
+    // GitHub Actions tools should be included
+    expect(result).toContain("mcp__github_ci__get_ci_status");
+
+    // Comment tool from minimal server should be included
+    expect(result).toContain("mcp__github_comment__update_claude_comment");
+
+    // Commit signing tools should NOT be included
+    expect(result).not.toContain("mcp__github_file_ops__commit_files");
   });
 });
 

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -22,6 +22,7 @@ const defaultInputs = {
   branchPrefix: "claude/",
   useStickyComment: false,
   additionalPermissions: new Map<string, string>(),
+  useCommitSigning: false,
 };
 
 const defaultRepository = {

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -70,6 +70,7 @@ describe("checkWritePermissions", () => {
       branchPrefix: "claude/",
       useStickyComment: false,
       additionalPermissions: new Map(),
+      useCommitSigning: false,
     },
   });
 

--- a/test/trigger-validation.test.ts
+++ b/test/trigger-validation.test.ts
@@ -38,6 +38,7 @@ describe("checkContainsTrigger", () => {
           branchPrefix: "claude/",
           useStickyComment: false,
           additionalPermissions: new Map(),
+          useCommitSigning: false,
         },
       });
       expect(checkContainsTrigger(context)).toBe(true);
@@ -68,6 +69,7 @@ describe("checkContainsTrigger", () => {
           branchPrefix: "claude/",
           useStickyComment: false,
           additionalPermissions: new Map(),
+          useCommitSigning: false,
         },
       });
       expect(checkContainsTrigger(context)).toBe(false);
@@ -282,6 +284,7 @@ describe("checkContainsTrigger", () => {
           branchPrefix: "claude/",
           useStickyComment: false,
           additionalPermissions: new Map(),
+          useCommitSigning: false,
         },
       });
       expect(checkContainsTrigger(context)).toBe(true);
@@ -313,6 +316,7 @@ describe("checkContainsTrigger", () => {
           branchPrefix: "claude/",
           useStickyComment: false,
           additionalPermissions: new Map(),
+          useCommitSigning: false,
         },
       });
       expect(checkContainsTrigger(context)).toBe(true);
@@ -344,6 +348,7 @@ describe("checkContainsTrigger", () => {
           branchPrefix: "claude/",
           useStickyComment: false,
           additionalPermissions: new Map(),
+          useCommitSigning: false,
         },
       });
       expect(checkContainsTrigger(context)).toBe(false);


### PR DESCRIPTION
- Add new input 'use_commit_signing' to action.yml (defaults to false)
- Separate comment update functionality into standalone github-comment-server.ts
- Update MCP server configuration to conditionally load servers based on signing preference
- When commit signing is disabled, use specific Bash git commands (e.g., Bash(git add:*))
- When commit signing is enabled, use github-file-ops-server for atomic commits with signing
- Always include github-comment-server for comment updates regardless of signing mode
- Update prompt generation to provide appropriate instructions based on signing preference
- Add comprehensive test coverage for new functionality

This change simplifies the default setup for users who don't need commit signing, while maintaining the option to enable it for those who require GitHub's commit signature verification.

🤖 Generated with [Claude Code](https://claude.ai/code)