### PR TITLE
fix: add GITHUB_API_URL to all Octokit client instantiations

### DIFF
--- a/src/mcp/github-actions-server.ts
+++ b/src/mcp/github-actions-server.ts
@@ -3,6 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { GITHUB_API_URL } from "../github/api/config";
 import { mkdir, writeFile } from "fs/promises";
 import { Octokit } from "@octokit/rest";
 
@@ -54,6 +55,7 @@ server.tool(
     try {
       const client = new Octokit({
         auth: GITHUB_TOKEN,
+        baseUrl: GITHUB_API_URL,
       });
 
       // Get the PR to find the head SHA
@@ -142,6 +144,7 @@ server.tool(
     try {
       const client = new Octokit({
         auth: GITHUB_TOKEN,
+        baseUrl: GITHUB_API_URL,
       });
 
       // Get jobs for this workflow run
@@ -209,6 +212,7 @@ server.tool(
     try {
       const client = new Octokit({
         auth: GITHUB_TOKEN,
+        baseUrl: GITHUB_API_URL,
       });
 
       const response = await client.actions.downloadJobLogsForWorkflowRun({

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -20,7 +20,7 @@ async function checkActionsReadPermission(
   repo: string,
 ): Promise<boolean> {
   try {
-    const client = new Octokit({ auth: token });
+    const client = new Octokit({ auth: token, baseUrl: GITHUB_API_URL });
 
     // Try to list workflow runs - this requires actions:read
     // We use per_page=1 to minimize the response size


### PR DESCRIPTION
Not all Octokit client instantiations were respecting GITHUB_API_URL, so
these tools would fail on enterprise.
