### PR TITLE
feat: defer remote branch creation until first commit

### DIFF
--- a/src/entrypoints/prepare.ts
+++ b/src/entrypoints/prepare.ts
@@ -12,7 +12,6 @@ import { checkHumanActor } from "../github/validation/actor";
 import { checkWritePermissions } from "../github/validation/permissions";
 import { createInitialComment } from "../github/operations/comments/create-initial";
 import { setupBranch } from "../github/operations/branch";
-import { updateTrackingComment } from "../github/operations/comments/update-with-branch";
 import { configureGitAuth } from "../github/operations/git-config";
 import { prepareMcpConfig } from "../mcp/install-mcp-server";
 import { createPrompt } from "../create-prompt";
@@ -67,15 +66,8 @@ async function run() {
     // Step 8: Setup branch
     const branchInfo = await setupBranch(octokit, githubData, context);
 
-    // Step 9: Update initial comment with branch link (only for issues that created a new branch)
-    if (branchInfo.claudeBranch) {
-      await updateTrackingComment(
-        octokit,
-        context,
-        commentId,
-        branchInfo.claudeBranch,
-      );
-    }
+    // Step 9: Skip branch link update - branch will be created on remote when Claude pushes
+    // The branch link will be added in the final comment update
 
     // Step 10: Configure git authentication if not using commit signing
     if (!context.inputs.useCommitSigning) {

--- a/src/entrypoints/prepare.ts
+++ b/src/entrypoints/prepare.ts
@@ -66,10 +66,7 @@ async function run() {
     // Step 8: Setup branch
     const branchInfo = await setupBranch(octokit, githubData, context);
 
-    // Step 9: Skip branch link update - branch will be created on remote when Claude pushes
-    // The branch link will be added in the final comment update
-
-    // Step 10: Configure git authentication if not using commit signing
+    // Step 9: Configure git authentication if not using commit signing
     if (!context.inputs.useCommitSigning) {
       try {
         await configureGitAuth(githubToken, context, commentData.user);
@@ -79,7 +76,7 @@ async function run() {
       }
     }
 
-    // Step 11: Create prompt file
+    // Step 10: Create prompt file
     await createPrompt(
       commentId,
       branchInfo.baseBranch,
@@ -88,7 +85,7 @@ async function run() {
       context,
     );
 
-    // Step 12: Get MCP configuration
+    // Step 11: Get MCP configuration
     const additionalMcpConfig = process.env.MCP_CONFIG || "";
     const mcpConfig = await prepareMcpConfig({
       githubToken,

--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -201,7 +201,7 @@ async function run() {
       jobUrl,
       branchLink,
       prLink,
-      branchName: shouldDeleteBranch ? undefined : claudeBranch,
+      branchName: shouldDeleteBranch || !branchLink ? undefined : claudeBranch,
       triggerUsername,
       errorDetails,
     };

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -84,12 +84,8 @@ export async function setupBranch(
     sourceBranch = repoResponse.data.default_branch;
   }
 
-  // Creating a new branch for either an issue or closed/merged PR
+  // Generate branch name for either an issue or closed/merged PR
   const entityType = isPR ? "pr" : "issue";
-  console.log(
-    `Creating new branch for ${entityType} #${entityNumber} from source branch: ${sourceBranch}...`,
-  );
-
   const timestamp = new Date()
     .toISOString()
     .replace(/[:-]/g, "")
@@ -100,7 +96,7 @@ export async function setupBranch(
   const newBranch = `${branchPrefix}${entityType}-${entityNumber}-${timestamp}`;
 
   try {
-    // Get the SHA of the source branch
+    // Get the SHA of the source branch to verify it exists
     const sourceBranchRef = await octokits.rest.git.getRef({
       owner,
       repo,
@@ -108,23 +104,34 @@ export async function setupBranch(
     });
 
     const currentSHA = sourceBranchRef.data.object.sha;
+    console.log(`Source branch SHA: ${currentSHA}`);
 
-    console.log(`Current SHA: ${currentSHA}`);
+    // For commit signing, defer branch creation to the file ops server
+    if (context.inputs.useCommitSigning) {
+      console.log(
+        `Branch name generated: ${newBranch} (will be created by file ops server on first commit)`,
+      );
 
-    // Create branch using GitHub API
-    await octokits.rest.git.createRef({
-      owner,
-      repo,
-      ref: `refs/heads/${newBranch}`,
-      sha: currentSHA,
-    });
+      // Set outputs for GitHub Actions
+      core.setOutput("CLAUDE_BRANCH", newBranch);
+      core.setOutput("BASE_BRANCH", sourceBranch);
+      return {
+        baseBranch: sourceBranch,
+        claudeBranch: newBranch,
+        currentBranch: sourceBranch, // Stay on source branch for now
+      };
+    }
 
-    // Checkout the new branch (shallow fetch for performance)
-    await $`git fetch origin --depth=1 ${newBranch}`;
-    await $`git checkout ${newBranch}`;
+    // For non-signing case, create and checkout the branch locally only
+    console.log(
+      `Creating local branch ${newBranch} for ${entityType} #${entityNumber} from source branch: ${sourceBranch}...`,
+    );
+
+    // Create and checkout the new branch locally
+    await $`git checkout -b ${newBranch}`;
 
     console.log(
-      `Successfully created and checked out new branch: ${newBranch}`,
+      `Successfully created and checked out local branch: ${newBranch}`,
     );
 
     // Set outputs for GitHub Actions
@@ -136,7 +143,7 @@ export async function setupBranch(
       currentBranch: newBranch,
     };
   } catch (error) {
-    console.error("Error creating branch:", error);
+    console.error("Error in branch setup:", error);
     process.exit(1);
   }
 }

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -100,6 +100,7 @@ export async function prepareMcpConfig(
           REPO_OWNER: owner,
           REPO_NAME: repo,
           BRANCH_NAME: branch,
+          BASE_BRANCH: process.env.BASE_BRANCH || "",
           REPO_DIR: process.env.GITHUB_WORKSPACE || process.cwd(),
           GITHUB_EVENT_NAME: process.env.GITHUB_EVENT_NAME || "",
           IS_PR: process.env.IS_PR || "false",

--- a/test/branch-cleanup.test.ts
+++ b/test/branch-cleanup.test.ts
@@ -21,6 +21,7 @@ describe("checkAndCommitOrDeleteBranch", () => {
   const createMockOctokit = (
     compareResponse?: any,
     deleteRefError?: Error,
+    branchExists: boolean = true,
   ): Octokits => {
     return {
       rest: {
@@ -28,6 +29,14 @@ describe("checkAndCommitOrDeleteBranch", () => {
           compareCommitsWithBasehead: async () => ({
             data: compareResponse || { total_commits: 0 },
           }),
+          getBranch: async () => {
+            if (!branchExists) {
+              const error: any = new Error("Not Found");
+              error.status = 404;
+              throw error;
+            }
+            return { data: {} };
+          },
         },
         git: {
           deleteRef: async () => {
@@ -102,6 +111,7 @@ describe("checkAndCommitOrDeleteBranch", () => {
           compareCommitsWithBasehead: async () => {
             throw new Error("API error");
           },
+          getBranch: async () => ({ data: {} }), // Branch exists
         },
         git: {
           deleteRef: async () => ({ data: {} }),
@@ -123,7 +133,7 @@ describe("checkAndCommitOrDeleteBranch", () => {
       `\n[View branch](${GITHUB_SERVER_URL}/owner/repo/tree/claude/issue-123-20240101_123456)`,
     );
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      "Error checking for commits on Claude branch:",
+      "Error comparing commits on Claude branch:",
       expect.any(Error),
     );
   });
@@ -146,6 +156,32 @@ describe("checkAndCommitOrDeleteBranch", () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       "Failed to delete branch claude/issue-123-20240101_123456:",
       deleteError,
+    );
+  });
+
+  test("should return no branch link when branch doesn't exist remotely", async () => {
+    const mockOctokit = createMockOctokit(
+      { total_commits: 0 },
+      undefined,
+      false, // branch doesn't exist
+    );
+
+    const result = await checkAndCommitOrDeleteBranch(
+      mockOctokit,
+      "owner",
+      "repo",
+      "claude/issue-123-20240101_123456",
+      "main",
+      false,
+    );
+
+    expect(result.shouldDeleteBranch).toBe(false);
+    expect(result.branchLink).toBe("");
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "Branch claude/issue-123-20240101_123456 does not exist remotely",
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      "Branch claude/issue-123-20240101_123456 does not exist remotely, no branch link will be added",
     );
   });
 });

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "bun:test";
-import { updateCommentBody } from "../src/github/operations/comment-logic";
+import {
+  updateCommentBody,
+  type CommentUpdateInput,
+} from "../src/github/operations/comment-logic";
 
 describe("updateCommentBody", () => {
   const baseInput = {
@@ -416,6 +419,28 @@ describe("updateCommentBody", () => {
       expect(result).toContain(
         "• [Create PR ➔](https://github.com/owner/repo/compare/main...claude/issue-123-20240101_120000)",
       );
+    });
+
+    it("should not show branch name when branch doesn't exist remotely", () => {
+      const input: CommentUpdateInput = {
+        currentBody: "@claude can you help with this?",
+        actionFailed: false,
+        executionDetails: { duration_ms: 90000 },
+        jobUrl: "https://github.com/owner/repo/actions/runs/123",
+        branchLink: "", // Empty branch link means branch doesn't exist remotely
+        branchName: undefined, // Should be undefined when branchLink is empty
+        triggerUsername: "claude",
+        prLink: "",
+      };
+
+      const result = updateCommentBody(input);
+
+      expect(result).toContain("Claude finished @claude's task in 1m 30s");
+      expect(result).toContain(
+        "[View job](https://github.com/owner/repo/actions/runs/123)",
+      );
+      expect(result).not.toContain("claude/issue-123");
+      expect(result).not.toContain("tree/claude/issue-123");
     });
   });
 });


### PR DESCRIPTION
- For commit signing: branches are created remotely by github-file-ops-server on first commit
- For non-signing: branches are created locally with 'git checkout -b' and pushed when needed
- Consolidated duplicate branch creation logic in github-file-ops-server into a shared helper function
- Claude is unaware of these implementation details and simply sees it's on the correct branch
- No branch links are shown in initial comments since branches don't exist remotely yet