### PR TITLE
chore: run cd command before git commands

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -53,6 +53,11 @@ export async function setupBranch(
         `PR #${entityNumber}: ${commitCount} commits, using fetch depth ${fetchDepth}`,
       );
 
+      if (!process.env.GITHUB_WORKSPACE) {
+        throw new Error("GITHUB_WORKSPACE environment variable is required");
+      }
+      process.chdir(process.env.GITHUB_WORKSPACE);
+
       // Execute git commands to checkout PR branch (dynamic depth based on PR size)
       await $`git fetch origin --depth=${fetchDepth} ${branchName}`;
       await $`git checkout ${branchName}`;


### PR DESCRIPTION
When running this action on a Self-hosted runner, the following error occurs:

```bash
fatal: not a git repository (or any of the parent directories): .git
```

This error happens because git commands were executed in the wrong directory. To resolve this issue, the git commands are explicitly executed in the directory specified by process.env.GITHUB_WORKSPACE.

This fix ensures the git operations always run within the correct repository context, eliminating the error and ensuring compatibility with self-hosted runner environments.

