### PR TITLE
fix: use `gh` to checkout PR (which works for forks)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -129,6 +129,11 @@ runs:
       id: prepare
       shell: bash
       run: |
+        # Change to CLAUDE_PREPARE_DIR if set (for running in custom directories)
+        if [ -n "$CLAUDE_PREPARE_DIR" ]; then
+          echo "Changing directory to CLAUDE_PREPARE_DIR: $CLAUDE_PREPARE_DIR"
+          cd "$CLAUDE_PREPARE_DIR"
+        fi
         bun run ${GITHUB_ACTION_PATH}/src/entrypoints/prepare.ts
       env:
         MODE: ${{ inputs.mode }}

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -45,17 +45,8 @@ export async function setupBranch(
 
       const branchName = prData.headRefName;
 
-      // Determine optimal fetch depth based on PR commit count, with a minimum of 20
-      const commitCount = prData.commits.totalCount;
-      const fetchDepth = Math.max(commitCount, 20);
-
-      console.log(
-        `PR #${entityNumber}: ${commitCount} commits, using fetch depth ${fetchDepth}`,
-      );
-
       // Execute git commands to checkout PR branch (dynamic depth based on PR size)
-      await $`git fetch origin --depth=${fetchDepth} ${branchName}`;
-      await $`git checkout ${branchName} --`;
+      await $`gh pr checkout ${entityNumber}`;
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);
 


### PR DESCRIPTION
resolves #46, #223

This PR is incomplete now. Because, to make `gh` to work, environment variables `GH_TOKEN` is also needed.
If this PR is ok, I can setup those.
