### PR TITLE
feat: add option to disable user mentions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -118,6 +118,10 @@ inputs:
     description: "Restrict network access to these domains only (newline-separated). If not set, no restrictions are applied. Provider domains are auto-detected."
     required: false
     default: ""
+  disable_user_mentions:
+    description: "Disable @username mentions in Claude comment headers"
+    required: false
+    default: "false"
 
 outputs:
   execution_file:
@@ -266,6 +270,7 @@ runs:
         PREPARE_ERROR: ${{ steps.prepare.outputs.prepare_error || '' }}
         USE_STICKY_COMMENT: ${{ inputs.use_sticky_comment }}
         USE_COMMIT_SIGNING: ${{ inputs.use_commit_signing }}
+        DISABLE_USER_MENTIONS: ${{ inputs.disable_user_mentions }}
 
     - name: Display Claude Code Report
       if: steps.prepare.outputs.contains_trigger == 'true' && steps.claude-code.outputs.execution_file != ''

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,6 +79,7 @@ jobs:
 | `experimental_allowed_domains` | Restrict network access to these domains only (newline-separated).                                                                    | No       | ""        |
 | `use_commit_signing`           | Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands                     | No       | `false`   |
 | `allowed_bots`                 | Comma-separated list of allowed bot usernames, or '\*' to allow all bots. Empty string (default) allows no bots                       | No       | ""        |
+| `disable_user_mentions`        | Disable @username mentions in Claude comment headers                                                                                  | No       | `false`   |
 
 \*Required when using direct Anthropic API (default and when not using Bedrock or Vertex)
 

--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -22,6 +22,7 @@ async function run() {
     const claudeBranch = process.env.CLAUDE_BRANCH;
     const baseBranch = process.env.BASE_BRANCH || "main";
     const triggerUsername = process.env.TRIGGER_USERNAME;
+    const disableUserMentions = process.env.DISABLE_USER_MENTIONS === "true";
 
     const context = parseGitHubContext();
 
@@ -212,6 +213,7 @@ async function run() {
       branchName: shouldDeleteBranch || !branchLink ? undefined : claudeBranch,
       triggerUsername,
       errorDetails,
+      disableUserMentions,
     };
 
     const updatedBody = updateCommentBody(commentInput);

--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -16,6 +16,7 @@ export type CommentUpdateInput = {
   branchName?: string;
   triggerUsername?: string;
   errorDetails?: string;
+  disableUserMentions?: boolean;
 };
 
 export function ensureProperlyEncodedUrl(url: string): string | null {
@@ -77,6 +78,7 @@ export function updateCommentBody(input: CommentUpdateInput): string {
     branchName,
     triggerUsername,
     errorDetails,
+    disableUserMentions,
   } = input;
 
   // Extract content from the original comment body
@@ -124,7 +126,9 @@ export function updateCommentBody(input: CommentUpdateInput): string {
     const username =
       triggerUsername || (usernameMatch ? usernameMatch[1] : "user");
 
-    header = `**Claude finished @${username}'s task`;
+    header = disableUserMentions
+      ? "**Claude finished the task"
+      : `**Claude finished @${username}'s task`;
     if (durationStr) {
       header += ` in ${durationStr}`;
     }

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -443,4 +443,35 @@ describe("updateCommentBody", () => {
       expect(result).not.toContain("tree/claude/issue-123");
     });
   });
+
+  describe("disable user mentions", () => {
+    it("disables @username mentions when flag is true", () => {
+      const input = {
+        ...baseInput,
+        currentBody: "Claude Code is working…",
+        executionDetails: { duration_ms: 74000 }, // 1m 14s
+        triggerUsername: "trigger-user",
+        disableUserMentions: true,
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).toContain("**Claude finished the task in 1m 14s**");
+      expect(result).not.toContain("@trigger-user's task");
+    });
+
+    it("includes @username mentions when flag is false or undefined", () => {
+      const input = {
+        ...baseInput,
+        currentBody: "Claude Code is working…",
+        executionDetails: { duration_ms: 74000 }, // 1m 14s
+        triggerUsername: "trigger-user",
+        disableUserMentions: false,
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).toContain(
+        "**Claude finished @trigger-user's task in 1m 14s**",
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Context

Currently Claude tags the user when it finishes a task.  These notifications can become noisy for busy repositories or workflows. This PR adds the ability to disable user mentions to reduce noise. 

## Changes

 - Introduces `disable_user_mentions` input parameter, defaults to false.
 - Updates `comment-logic.ts` to optionally disable user mentions.
 - Updates `README.md` to reflect the new configuration option.

## Testing

- Adds tests to `comment-logic.tests.ts` to reflect new behavior.
- Manually tested via workflow runs.

 Closes #254, Closes #240.