### PR TITLE
feat: Add configuration option to delete the progress/results comment at the end of the workflow

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,10 @@ inputs:
     description: "Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands"
     required: false
     default: "false"
+  delete_comment_on_completion:
+    description: "Delete the Claude Code comment on completion of the workflow. This may be useful when utilizing direct prompts where the results are not needed as a PR comment."
+    required: false
+    default: "false"
 
 outputs:
   execution_file:
@@ -227,6 +231,15 @@ runs:
           cat "${{ steps.claude-code.outputs.execution_file }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
         fi
+
+    - name:
+      if: always() && inputs.delete_comment_on_completion == 'true'
+      shell: bash
+      run: |
+         bun run ${GITHUB_ACTION_PATH}/src/entrypoints/delete-comment.ts
+      env:
+        CLAUDE_COMMENT_ID: ${{ steps.prepare.outputs.claude_comment_id }}
+        GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
 
     - name: Revoke app token
       if: always() && inputs.github_token == ''

--- a/src/entrypoints/delete-comment.ts
+++ b/src/entrypoints/delete-comment.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env bun
+
+import { createOctokit } from "../github/api/client";
+import {
+  parseGitHubContext,
+} from "../github/context";
+import { deleteClaudeComment } from "../github/operations/comments/delete-claude-comment";
+
+async function run() {
+  try {
+    const commentId = parseInt(process.env.CLAUDE_COMMENT_ID!);
+    const githubToken = process.env.GITHUB_TOKEN!;
+
+    const context = parseGitHubContext();
+    const { owner, repo } = context.repository;
+    const octokit = createOctokit(githubToken);
+
+    let isPRReviewComment = false;
+
+ 
+    try {
+      await deleteClaudeComment(octokit.rest, {
+        owner,
+        repo,
+        commentId,
+        isPullRequestReviewComment: isPRReviewComment,
+      });
+      console.log(
+        `✅ Deleted ${isPRReviewComment ? "PR review" : "issue"} comment ${commentId}`,
+      );
+    } catch (updateError) {
+      console.error(
+        `Failed to delete ${isPRReviewComment ? "PR review" : "issue"} comment:`,
+        updateError,
+      );
+      throw updateError;
+    }
+
+    process.exit(0);
+  } catch (error) {
+    console.error("Error updating comment with job link:", error);
+    process.exit(1);
+  }
+}
+
+run();

--- a/src/github/operations/comments/delete-claude-comment.ts
+++ b/src/github/operations/comments/delete-claude-comment.ts
@@ -1,0 +1,55 @@
+import { Octokit } from "@octokit/rest";
+
+export type DeleteClaudeCommentParams = {
+  owner: string;
+  repo: string;
+  commentId: number;
+  isPullRequestReviewComment: boolean;
+};
+
+/**
+ * Delete a Claude comment on GitHub (either an issue/PR comment or a PR review comment)
+ *
+ * @param octokit - Authenticated Octokit instance
+ * @param params - Parameters for deleting the comment
+ * @returns void
+ * @throws Error if the deletion fails
+ */
+export async function deleteClaudeComment(
+  octokit: Octokit,
+  params: DeleteClaudeCommentParams,
+): Promise<void> {
+  const { owner, repo, commentId, isPullRequestReviewComment } = params;
+
+  try {
+    if (isPullRequestReviewComment) {
+      // Try PR review comment API first
+      await octokit.rest.pulls.deleteReviewComment({
+        owner,
+        repo,
+        comment_id: commentId,
+
+      });
+    } else {
+      // Use issue comment API (works for both issues and PR general comments)
+      await octokit.rest.issues.deleteComment({
+        owner,
+        repo,
+        comment_id: commentId,
+      });
+    }
+  } catch (error: any) {
+    // If PR review comment deletion fails with 404, fall back to issue comment API
+    if (isPullRequestReviewComment && error.status === 404) {
+      await octokit.rest.issues.deleteComment({
+        owner,
+        repo,
+        comment_id: commentId,
+      });
+    } else {
+      throw error;
+    }
+  }
+
+  return;
+}


### PR DESCRIPTION
We are using the Claude code action to automatically generate the PR body/description for developers by leveraging `direct_prompt` to run `gh pr edit --body`.

As a result the comment left by this workflow has very little value for us and just takes up space / makes noise on the PR screen.

This changes provides the ability to have the claude-code-action workflow delete the comment at the end of the workflow when users set `delete_comment_on_completion: true`, so the resulting experience is that they see progress reports in the comment while the workflow runs, but it's cleaned up by the end.