### PR TITLE
docs: add custom GitHub App setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,86 @@ This command will guide you through setting up the GitHub app and required secre
    - Or `CLAUDE_CODE_OAUTH_TOKEN` for OAuth token authentication (Pro and Max users can generate this by running `claude setup-token` locally)
 3. Copy the workflow file from [`examples/claude.yml`](./examples/claude.yml) into your repository's `.github/workflows/`
 
+### Using a Custom GitHub App
+
+If you prefer not to install the official Claude app, you can create your own GitHub App to use with this action. This gives you complete control over permissions and access.
+
+**When you may want to use a custom GitHub App:**
+
+- You need more restrictive permissions than the official app
+- Organization policies prevent installing third-party apps
+- You're using AWS Bedrock or Google Vertex AI
+
+**Steps to create and use a custom GitHub App:**
+
+1. **Create a new GitHub App:**
+
+   - Go to https://github.com/settings/apps (for personal apps) or your organization's settings
+   - Click "New GitHub App"
+   - Configure the app with these minimum permissions:
+     - **Repository permissions:**
+       - Contents: Read & Write
+       - Issues: Read & Write
+       - Pull requests: Read & Write
+     - **Account permissions:** None required
+   - Set "Where can this GitHub App be installed?" to your preference
+   - Create the app
+
+2. **Generate and download a private key:**
+
+   - After creating the app, scroll down to "Private keys"
+   - Click "Generate a private key"
+   - Download the `.pem` file (keep this secure!)
+
+3. **Install the app on your repository:**
+
+   - Go to the app's settings page
+   - Click "Install App"
+   - Select the repositories where you want to use Claude
+
+4. **Add the app credentials to your repository secrets:**
+
+   - Go to your repository's Settings → Secrets and variables → Actions
+   - Add these secrets:
+     - `APP_ID`: Your GitHub App's ID (found in the app settings)
+     - `APP_PRIVATE_KEY`: The contents of the downloaded `.pem` file
+
+5. **Update your workflow to use the custom app:**
+
+   ```yaml
+   name: Claude with Custom App
+   on:
+     issue_comment:
+       types: [created]
+     # ... other triggers
+
+   jobs:
+     claude-response:
+       runs-on: ubuntu-latest
+       steps:
+         # Generate a token from your custom app
+         - name: Generate GitHub App token
+           id: app-token
+           uses: actions/create-github-app-token@v1
+           with:
+             app-id: ${{ secrets.APP_ID }}
+             private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+         # Use Claude with your custom app's token
+         - uses: anthropics/claude-code-action@beta
+           with:
+             anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+             github_token: ${{ steps.app-token.outputs.token }}
+             # ... other configuration
+   ```
+
+**Important notes:**
+
+- The custom app must have read/write permissions for Issues, Pull Requests, and Contents
+- Your app's token will have the exact permissions you configured, nothing more
+
+For more information on creating GitHub Apps, see the [GitHub documentation](https://docs.github.com/en/apps/creating-github-apps).
+
 ## 📚 FAQ
 
 Having issues or questions? Check out our [Frequently Asked Questions](./FAQ.md) for solutions to common problems and detailed explanations of Claude's capabilities and limitations.


### PR DESCRIPTION
Add comprehensive section explaining how to create and use a custom GitHub App instead of the official Claude app. This is particularly useful for users with restrictive organization policies or those using AWS Bedrock/Google Vertex AI.

🤖 Generated with [Claude Code](https://claude.ai/code)