### PR TITLE
Avoid ambiguous name that can be either a branch or a file

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -55,7 +55,7 @@ export async function setupBranch(
 
       // Execute git commands to checkout PR branch (dynamic depth based on PR size)
       await $`git fetch origin --depth=${fetchDepth} ${branchName}`;
-      await $`git checkout ${branchName}`;
+      await $`git checkout -- ${branchName}`;
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);
 


### PR DESCRIPTION
git-checkout takes either branch, commit, or pathspec. https://git-scm.com/docs/git-checkout
The line in this pull request tries to checkout a branch, but when you have a branch which name is the same as an existing file/dir it can cause a runtime error. It's recommended to use `--` for argument disambiguation[^1].

[^1]: https://git-scm.com/docs/git-checkout#_argument_disambiguation