### PR TITLE
fix: use GITHUB_SERVER_URL to determine email domain for GitHub Enterprise

### DIFF
--- a/src/github/operations/git-config.ts
+++ b/src/github/operations/git-config.ts
@@ -21,6 +21,12 @@ export async function configureGitAuth(
 ) {
   console.log("Configuring git authentication for non-signing mode");
 
+  // Determine the noreply email domain based on GITHUB_SERVER_URL
+  const serverUrl = new URL(GITHUB_SERVER_URL);
+  const noreplyDomain = serverUrl.hostname === "github.com" 
+    ? "users.noreply.github.com" 
+    : `users.noreply.${serverUrl.hostname}`;
+
   // Configure git user based on the comment creator
   console.log("Configuring git user...");
   if (user) {
@@ -28,12 +34,12 @@ export async function configureGitAuth(
     const botId = user.id;
     console.log(`Setting git user as ${botName}...`);
     await $`git config user.name "${botName}"`;
-    await $`git config user.email "${botId}+${botName}@users.noreply.github.com"`;
+    await $`git config user.email "${botId}+${botName}@${noreplyDomain}"`;
     console.log(`✓ Set git user as ${botName}`);
   } else {
     console.log("No user data in comment, using default bot user");
     await $`git config user.name "github-actions[bot]"`;
-    await $`git config user.email "41898282+github-actions[bot]@users.noreply.github.com"`;
+    await $`git config user.email "41898282+github-actions[bot]@${noreplyDomain}"`;
   }
 
   // Remove the authorization header that actions/checkout sets

--- a/src/github/operations/git-config.ts
+++ b/src/github/operations/git-config.ts
@@ -23,9 +23,10 @@ export async function configureGitAuth(
 
   // Determine the noreply email domain based on GITHUB_SERVER_URL
   const serverUrl = new URL(GITHUB_SERVER_URL);
-  const noreplyDomain = serverUrl.hostname === "github.com" 
-    ? "users.noreply.github.com" 
-    : `users.noreply.${serverUrl.hostname}`;
+  const noreplyDomain =
+    serverUrl.hostname === "github.com"
+      ? "users.noreply.github.com"
+      : `users.noreply.${serverUrl.hostname}`;
 
   // Configure git user based on the comment creator
   console.log("Configuring git user...");
@@ -53,7 +54,6 @@ export async function configureGitAuth(
 
   // Update the remote URL to include the token for authentication
   console.log("Updating remote URL with authentication...");
-  const serverUrl = new URL(GITHUB_SERVER_URL);
   const remoteUrl = `https://x-access-token:${githubToken}@${serverUrl.host}/${context.repository.owner}/${context.repository.repo}.git`;
   await $`git remote set-url origin ${remoteUrl}`;
   console.log("✓ Updated remote URL with authentication token");


### PR DESCRIPTION
Fixes #288

This PR updates the hardcoded email domain in `configureGitAuth` to dynamically determine the correct domain based on `GITHUB_SERVER_URL`.

## Changes
- Extract hostname from `GITHUB_SERVER_URL` environment variable
- Use `users.noreply.github.com` for GitHub.com
- Use `users.noreply.{hostname}` for GitHub Enterprise instances

Generated with [Claude Code](https://claude.ai/code)