### PR TITLE
feat: add MIRROR_DISCLAIMER.md for claude-code-base-action sync

### DIFF
--- a/.github/workflows/sync-base-action.yml
+++ b/.github/workflows/sync-base-action.yml
@@ -56,6 +56,12 @@ jobs:
           # Copy all contents from base-action
           cp -r ../base-action/. .
 
+          # Prepend mirror disclaimer to README if both files exist
+          if [ -f "README.md" ] && [ -f "MIRROR_DISCLAIMER.md" ]; then
+            cat MIRROR_DISCLAIMER.md README.md > README.tmp
+            mv README.tmp README.md
+          fi
+
           # Check if there are any changes
           if git diff --quiet && git diff --staged --quiet; then
             echo "No changes to sync"

--- a/base-action/MIRROR_DISCLAIMER.md
+++ b/base-action/MIRROR_DISCLAIMER.md
@@ -1,0 +1,11 @@
+# ⚠️ This is a Mirror Repository
+
+This repository is an automated mirror of the `base-action` directory from [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action).
+
+**Do not submit PRs or issues to this repository.** Instead, please contribute to the main repository:
+
+- 🐛 [Report issues](https://github.com/anthropics/claude-code-action/issues)
+- 🔧 [Submit pull requests](https://github.com/anthropics/claude-code-action/pulls)
+- 📖 [View documentation](https://github.com/anthropics/claude-code-action#readme)
+
+---


### PR DESCRIPTION
## Summary
- Added MIRROR_DISCLAIMER.md file to base-action directory
- Updated sync workflow to concatenate disclaimer with README when syncing

## Changes
1. **Mirror Disclaimer** (`base-action/MIRROR_DISCLAIMER.md`):
   - Clear notice about mirror repository status
   - Directs users to main repository for issues/PRs
   - Gets prepended to README.md during sync

2. **Sync Workflow Update** (`.github/workflows/sync-base-action.yml`):
   - Now concatenates MIRROR_DISCLAIMER.md with README.md
   - Cleaner approach than embedding content in workflow

## Test plan
- [x] Tests pass
- [x] Formatting checks pass
- [ ] Manual test of sync workflow after merge

🤖 Generated with [Claude Code](https://claude.ai/code)