### PR TITLE
fix: add Bedrock base URL fallback to match base-action configuration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -226,7 +226,7 @@ runs:
         AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
         AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
-        ANTHROPIC_BEDROCK_BASE_URL: ${{ env.ANTHROPIC_BEDROCK_BASE_URL }}
+        ANTHROPIC_BEDROCK_BASE_URL: ${{ env.ANTHROPIC_BEDROCK_BASE_URL || (env.AWS_REGION && format('https://bedrock-runtime.{0}.amazonaws.com', env.AWS_REGION)) }}
 
         # GCP configuration
         ANTHROPIC_VERTEX_PROJECT_ID: ${{ env.ANTHROPIC_VERTEX_PROJECT_ID }}


### PR DESCRIPTION
The action.yml was missing the fallback logic to construct the Bedrock endpoint URL from AWS_REGION when ANTHROPIC_BEDROCK_BASE_URL is not explicitly set. This matches the configuration in claude-code-base-action.

🤖 Generated with [Claude Code](https://claude.ai/code)