### PR TITLE
fix: add model parameter support to base-action

### DIFF
--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -26,6 +26,7 @@ async function run() {
       appendSystemPrompt: process.env.INPUT_APPEND_SYSTEM_PROMPT,
       claudeEnv: process.env.INPUT_CLAUDE_ENV,
       fallbackModel: process.env.INPUT_FALLBACK_MODEL,
+      model: process.env.ANTHROPIC_MODEL,
     });
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`);

--- a/base-action/src/run-claude.ts
+++ b/base-action/src/run-claude.ts
@@ -21,6 +21,7 @@ export type ClaudeOptions = {
   claudeEnv?: string;
   fallbackModel?: string;
   timeoutMinutes?: string;
+  model?: string;
 };
 
 type PreparedConfig = {
@@ -93,6 +94,9 @@ export function prepareRunConfig(
   }
   if (options.fallbackModel) {
     claudeArgs.push("--fallback-model", options.fallbackModel);
+  }
+  if (options.model) {
+    claudeArgs.push("--model", options.model);
   }
   if (options.timeoutMinutes) {
     const timeoutMinutesNum = parseInt(options.timeoutMinutes, 10);


### PR DESCRIPTION
## Summary
This PR fixes a bug where the `model` parameter specified in the action configuration was not being passed to the Claude CLI.

## Problem
- The `ANTHROPIC_MODEL` environment variable was set in `action.yml` but not consumed by the base-action
- This caused the model specification to be ignored, leading to unexpected model usage
- Users experiencing unexpected model switching (e.g., from Opus to Sonnet) when using the action

## Solution
- Added `model` field to `ClaudeOptions` type in `base-action/src/run-claude.ts`
- Updated `base-action/src/index.ts` to pass `ANTHROPIC_MODEL` env var to the `runClaude` function
- Modified `prepareRunConfig` to handle the `--model` argument and pass it to Claude CLI

## Changes
- `base-action/src/run-claude.ts`: Added `model?: string` to ClaudeOptions type and handling in prepareRunConfig
- `base-action/src/index.ts`: Added `model: process.env.ANTHROPIC_MODEL` to runClaude call

## Test plan
- [x] Verify that specifying `model` in action configuration correctly passes it to Claude CLI
- [x] Test with both `model` and `anthropic_model` inputs (model should take precedence)
- [x] Ensure fallback_model still works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)