### PR TITLE
fix: checkout base branch before creating new branches

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -116,6 +116,11 @@ export async function setupBranch(
         `Branch name generated: ${newBranch} (will be created by file ops server on first commit)`,
       );
 
+      // Ensure we're on the source branch
+      console.log(`Fetching and checking out source branch: ${sourceBranch}`);
+      await $`git fetch origin ${sourceBranch} --depth=1`;
+      await $`git checkout ${sourceBranch}`;
+
       // Set outputs for GitHub Actions
       core.setOutput("CLAUDE_BRANCH", newBranch);
       core.setOutput("BASE_BRANCH", sourceBranch);
@@ -131,7 +136,12 @@ export async function setupBranch(
       `Creating local branch ${newBranch} for ${entityType} #${entityNumber} from source branch: ${sourceBranch}...`,
     );
 
-    // Create and checkout the new branch locally
+    // Fetch and checkout the source branch first to ensure we branch from the correct base
+    console.log(`Fetching and checking out source branch: ${sourceBranch}`);
+    await $`git fetch origin ${sourceBranch} --depth=1`;
+    await $`git checkout ${sourceBranch}`;
+
+    // Create and checkout the new branch from the source branch
     await $`git checkout -b ${newBranch}`;
 
     console.log(


### PR DESCRIPTION
- Fix bug where base_branch parameter was not being respected
- Add git fetch and checkout of source branch before creating new branch
- Ensures new branches are created from specified base_branch instead of current HEAD
- Fixes issue #268

🤖 Generated with [Claude Code](https://claude.ai/code)