### PR TITLE
fix: run Claude from workflow directory instead of base-action directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -193,7 +193,8 @@ runs:
         # Run the base-action
         cd ${GITHUB_ACTION_PATH}/base-action
         bun install
-        bun run src/index.ts
+        cd -
+        bun run ${GITHUB_ACTION_PATH}/base-action/src/index.ts
       env:
         # Base-action inputs
         CLAUDE_CODE_ACTION: "1"


### PR DESCRIPTION
Changed the action to cd back to the original directory after installing dependencies, ensuring Claude runs in the context of the user's workflow rather than the base-action subdirectory.

fixes https://github.com/anthropics/claude-code-action/issues/303

🤖 Generated with [Claude Code](https://claude.ai/code)