### PR TITLE
chore: use bun install instead of npm for Claude Code installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -193,7 +193,7 @@ runs:
       shell: bash
       run: |
         # Install Claude Code globally
-        npm install -g @anthropic-ai/claude-code@1.0.57
+        bun install -g @anthropic-ai/claude-code@1.0.57
 
         # Run the base-action
         cd ${GITHUB_ACTION_PATH}/base-action


### PR DESCRIPTION
Replace npm install with bun install for consistency with the rest of the project's package management.

fixes https://github.com/anthropics/claude-code-action/issues/321#issuecomment-3100668092

🤖 Generated with [Claude Code](https://claude.ai/code)