### PR TITLE
feat: add DETAILED_PERMISSION_MESSAGES env var to Claude Code invocation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -216,6 +216,7 @@ runs:
         ANTHROPIC_MODEL: ${{ inputs.model || inputs.anthropic_model }}
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
         NODE_VERSION: ${{ env.NODE_VERSION }}
+        DETAILED_PERMISSION_MESSAGES: "1"
 
         # Provider configuration
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}


### PR DESCRIPTION
Enables detailed permission messages in Claude Code by setting the DETAILED_PERMISSION_MESSAGES environment variable to '1' in the Run Claude Code step.

🤖 Generated with [Claude Code](https://claude.ai/code)