### PR TITLE
feat: add GITHUB_HOST to github-mcp-server for GitHub Enterprise Server

### DIFF
--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -1,5 +1,5 @@
 import * as core from "@actions/core";
-import { GITHUB_API_URL } from "../github/api/config";
+import { GITHUB_API_URL, GITHUB_SERVER_URL } from "../github/api/config";
 import type { ParsedGitHubContext } from "../github/context";
 import { Octokit } from "@octokit/rest";
 
@@ -157,9 +157,12 @@ export async function prepareMcpConfig(
           "-e",
           "GITHUB_PERSONAL_ACCESS_TOKEN",
           "ghcr.io/github/github-mcp-server:sha-efef8ae", // https://github.com/github/github-mcp-server/releases/tag/v0.9.0
+          "-e",
+          "GITHUB_HOST",
         ],
         env: {
           GITHUB_PERSONAL_ACCESS_TOKEN: githubToken,
+          GITHUB_HOST: GITHUB_SERVER_URL,
         },
       };
     }


### PR DESCRIPTION
I'd like to use `github-mcp-server` with GitHub Enterprise Server.
To support that, I added support for the `GITHUB_HOST` environment variable when running the Docker container.

I've tested the changes using GitHub.com (Cloud).

This change is intended to support the setup described here:
https://github.com/github/github-mcp-server?tab=readme-ov-file#github-enterprise-server-and-enterprise-cloud-with-data-residency-ghecom
