### PR TITLE
chore: update MCP server image to version 0.9.0

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -32,7 +32,7 @@ jobs:
                   "--rm",
                   "-e",
                   "GITHUB_PERSONAL_ACCESS_TOKEN",
-                  "ghcr.io/github/github-mcp-server:sha-721fd3e"
+                  "ghcr.io/github/github-mcp-server:sha-efef8ae"
                 ],
                 "env": {
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_TOKEN }}"

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -156,7 +156,7 @@ export async function prepareMcpConfig(
           "--rm",
           "-e",
           "GITHUB_PERSONAL_ACCESS_TOKEN",
-          "ghcr.io/github/github-mcp-server:sha-721fd3e", // https://github.com/github/github-mcp-server/releases/tag/v0.6.0
+          "ghcr.io/github/github-mcp-server:sha-efef8ae", // https://github.com/github/github-mcp-server/releases/tag/v0.9.0
         ],
         env: {
           GITHUB_PERSONAL_ACCESS_TOKEN: githubToken,


### PR DESCRIPTION
Updates the GitHub MCP server from v0.6.0 (sha-721fd3e) to v0.9.0 (sha-efef8ae) across all
  configuration files.

  ## Changes
  - Updated Docker image tag in `src/mcp/install-mcp-server.ts`
  - Updated Docker image tag in `.github/workflows/issue-triage.yml`

  ## What's new in v0.9.0
  - New tools for sub-issues management: `add_sub_issue`, `list_sub_issues`, `remove_sub_issue`,
  `reprioritize_sub_issue`
  - Improved pagination for tools
  - Enhanced `list_discussions` tool with additional fields (`updatedAt`, `author.login`) and ordering
  capabilities

  Release notes: https://github.com/github/github-mcp-server/releases/tag/v0.9.0

  No breaking changes - this is a straightforward version bump that adds new functionality while
  maintaining backward compatibility.