### PR TITLE
chore: update Claude Code installation to use bun and version 1.0.61

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -172,7 +172,7 @@ runs:
         echo "Base-action dependencies installed"
         cd -
         # Install Claude Code globally
-        bun install -g @anthropic-ai/claude-code@1.0.59
+        bun install -g @anthropic-ai/claude-code@1.0.61
 
     - name: Setup Network Restrictions
       if: steps.prepare.outputs.contains_trigger == 'true' && inputs.experimental_allowed_domains != ''

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -115,7 +115,7 @@ runs:
 
     - name: Install Claude Code
       shell: bash
-      run: npm install -g @anthropic-ai/claude-code@1.0.61
+      run: bun install -g @anthropic-ai/claude-code@1.0.61
 
     - name: Run Claude Code Action
       shell: bash


### PR DESCRIPTION
- Switch from npm to bun for Claude Code installation in base-action
- Update Claude Code version from 1.0.59 to 1.0.61 in main action
- Ensures consistent package manager usage across both action files

🤖 Generated with [Claude Code](https://claude.ai/code)