### PR TITLE
fix: move env var before image name in docker run for github-mcp-server

### DIFF
--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -1,5 +1,5 @@
 import * as core from "@actions/core";
-import { GITHUB_API_URL } from "../github/api/config";
+import { GITHUB_API_URL, GITHUB_SERVER_URL } from "../github/api/config";
 import type { ParsedGitHubContext } from "../github/context";
 import { Octokit } from "@octokit/rest";
 
@@ -156,10 +156,13 @@ export async function prepareMcpConfig(
           "--rm",
           "-e",
           "GITHUB_PERSONAL_ACCESS_TOKEN",
+          "-e",
+          "GITHUB_HOST",
           "ghcr.io/github/github-mcp-server:sha-efef8ae", // https://github.com/github/github-mcp-server/releases/tag/v0.9.0
         ],
         env: {
           GITHUB_PERSONAL_ACCESS_TOKEN: githubToken,
+          GITHUB_HOST: GITHUB_SERVER_URL,
         },
       };
     }


### PR DESCRIPTION
Fixes #343.

When I rebased the previous change (https://github.com/anthropics/claude-code-action/pull/343#issuecomment-3130194832), I mistakenly placed the GITHUB_HOST variable *after* the image name in the Docker run command, which caused a runtime error.

This PR fixes the variable placement so that it is correctly passed into the container.

Here are the test results from the GitHub Actions runs:

<img width="1047" height="155" alt="スクリーンショット 2025-07-30 7 52 06" src="https://github.com/user-attachments/assets/4675575e-c96d-471b-a7ea-fc639c40e73c" />

<img width="998" height="355" alt="スクリーンショット 2025-07-30 7 52 47" src="https://github.com/user-attachments/assets/895f5ea1-5f50-45ff-889a-35e02ee8fb09" />

<img width="1046" height="207" alt="スクリーンショット 2025-07-30 7 52 59" src="https://github.com/user-attachments/assets/8bb3b13e-6950-4c2f-83eb-2d769370d5e1" />

