### PR TITLE
fix: update GitHub MCP server tool name for PR review comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,4 +30,4 @@ jobs:
 
             Be constructive and specific in your feedback. Give inline comments where applicable.
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_tools: "mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+          allowed_tools: "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"

--- a/examples/claude-auto-review.yml
+++ b/examples/claude-auto-review.yml
@@ -35,4 +35,4 @@ jobs:
 
             Provide constructive feedback with specific suggestions for improvement.
             Use inline comments to highlight specific areas of concern.
-          # allowed_tools: "mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
+          # allowed_tools: "mcp__github__create_pending_pull_request_review,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"


### PR DESCRIPTION
This PR updates the GitHub MCP server tool name from
  `add_pull_request_review_comment_to_pending_review` to `add_comment_to_pending_review` following the
  upstream change in github/github-mcp-server#697.

  ## Changes

  - Updated `.github/workflows/claude-review.yml` - Changed the tool name in `allowed_tools` parameter
  - Updated `examples/claude-auto-review.yml` - Changed the tool name in the commented `allowed_tools`
  example
