### PR TITLE
feat: Skip initial comment creation when override_prompt is set

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -805,7 +805,9 @@ export async function createPrompt(
     let claudeCommentId: string = "";
     if (mode.name === "tag") {
       if (!modeContext.commentId) {
-        throw new Error("Tag mode requires a comment ID for prompt generation");
+        throw new Error(
+          "Tag mode requires a comment ID for prompt generation unless you're using override_prompt",
+        );
       }
       claudeCommentId = modeContext.commentId.toString();
     }

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -28,6 +28,10 @@ export async function createInitialComment(
   octokit: Octokit,
   context: ParsedGitHubContext,
 ) {
+  // If override_prompt is set, the prompt doesn't have an instruction
+  // that enforces the use of mcp__github_comment__update_claude_comment
+  // to update the initial comment.
+  // So we don't need to create an initial comment in this case.
   if (context.inputs.overridePrompt) {
     return null;
   }

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -16,17 +16,29 @@ import type { Octokit } from "@octokit/rest";
 
 const CLAUDE_APP_BOT_ID = 209825114;
 
+type CommentResponseBody = {
+  id: number;
+  user: {
+    id: number;
+    login: string;
+  } | null;
+};
+
 export async function createInitialComment(
   octokit: Octokit,
   context: ParsedGitHubContext,
 ) {
+  if (context.inputs.overridePrompt) {
+    return null;
+  }
+
   const { owner, repo } = context.repository;
 
   const jobRunLink = createJobRunLink(owner, repo, context.runId);
   const initialBody = createCommentBody(jobRunLink);
 
   try {
-    let response;
+    let response: { data: CommentResponseBody };
 
     if (
       context.inputs.useStickyComment &&

--- a/src/github/operations/git-config.ts
+++ b/src/github/operations/git-config.ts
@@ -8,16 +8,12 @@
 import { $ } from "bun";
 import type { ParsedGitHubContext } from "../context";
 import { GITHUB_SERVER_URL } from "../api/config";
-
-type GitUser = {
-  login: string;
-  id: number;
-};
+import { Octokit } from "@octokit/rest";
 
 export async function configureGitAuth(
+  octokit: Octokit,
   githubToken: string,
   context: ParsedGitHubContext,
-  user: GitUser | null,
 ) {
   console.log("Configuring git authentication for non-signing mode");
 
@@ -30,6 +26,8 @@ export async function configureGitAuth(
 
   // Configure git user based on the comment creator
   console.log("Configuring git user...");
+  const userResponse = await octokit.rest.users.getAuthenticated();
+  const user = userResponse.data;
   if (user) {
     const botName = user.login;
     const botId = user.id;

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -72,22 +72,24 @@ export async function prepareMcpConfig(
       mcpServers: {},
     };
 
-    // Always include comment server for updating Claude comments
-    baseMcpConfig.mcpServers.github_comment = {
-      command: "bun",
-      args: [
-        "run",
-        `${process.env.GITHUB_ACTION_PATH}/src/mcp/github-comment-server.ts`,
-      ],
-      env: {
-        GITHUB_TOKEN: githubToken,
-        REPO_OWNER: owner,
-        REPO_NAME: repo,
-        ...(claudeCommentId && { CLAUDE_COMMENT_ID: claudeCommentId }),
-        GITHUB_EVENT_NAME: process.env.GITHUB_EVENT_NAME || "",
-        GITHUB_API_URL: GITHUB_API_URL,
-      },
-    };
+    // Include comment server  for updating Claude comments when claudeCommentId is provided
+    if (claudeCommentId) {
+      baseMcpConfig.mcpServers.github_comment = {
+        command: "bun",
+        args: [
+          "run",
+          `${process.env.GITHUB_ACTION_PATH}/src/mcp/github-comment-server.ts`,
+        ],
+        env: {
+          GITHUB_TOKEN: githubToken,
+          REPO_OWNER: owner,
+          REPO_NAME: repo,
+          CLAUDE_COMMENT_ID: claudeCommentId,
+          GITHUB_EVENT_NAME: process.env.GITHUB_EVENT_NAME || "",
+          GITHUB_API_URL: GITHUB_API_URL,
+        },
+      };
+    }
 
     // Include file ops server when commit signing is enabled
     if (context.inputs.useCommitSigning) {

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -82,7 +82,7 @@ export const tagMode: Mode = {
     // Configure git authentication if not using commit signing
     if (!context.inputs.useCommitSigning) {
       try {
-        await configureGitAuth(githubToken, context, commentData.user);
+        await configureGitAuth(octokit.rest, githubToken, context);
       } catch (error) {
         console.error("Failed to configure git authentication:", error);
         throw error;

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -66,7 +66,7 @@ export const tagMode: Mode = {
 
     // Create initial tracking comment
     const commentData = await createInitialComment(octokit.rest, context);
-    const commentId = commentData.id;
+    const commentId = commentData?.id;
 
     const githubData = await fetchGitHubData({
       octokits: octokit,
@@ -107,7 +107,7 @@ export const tagMode: Mode = {
       branch: branchInfo.claudeBranch || branchInfo.currentBranch,
       baseBranch: branchInfo.baseBranch,
       additionalMcpConfig,
-      claudeCommentId: commentId.toString(),
+      claudeCommentId: commentId?.toString(),
       allowedTools: context.inputs.allowedTools,
       context,
     });

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -84,13 +84,14 @@ describe("prepareMcpConfig", () => {
     processExitSpy.mockRestore();
   });
 
-  test("should return comment server when commit signing is disabled", async () => {
+  test("should return comment server when commit signing is disabled and claudeCommentId is provided", async () => {
     const result = await prepareMcpConfig({
       githubToken: "test-token",
       owner: "test-owner",
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "12345",
       allowedTools: [],
       context: mockContext,
     });
@@ -105,6 +106,25 @@ describe("prepareMcpConfig", () => {
     );
     expect(parsed.mcpServers.github_comment.env.REPO_OWNER).toBe("test-owner");
     expect(parsed.mcpServers.github_comment.env.REPO_NAME).toBe("test-repo");
+    expect(parsed.mcpServers.github_comment.env.CLAUDE_COMMENT_ID).toBe("12345");
+  });
+
+  test("should not include comment server when claudeCommentId is not provided", async () => {
+    const result = await prepareMcpConfig({
+      githubToken: "test-token",
+      owner: "test-owner",
+      repo: "test-repo",
+      branch: "test-branch",
+      baseBranch: "main",
+      allowedTools: [],
+      context: mockContext,
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.mcpServers.github).not.toBeDefined();
+    expect(parsed.mcpServers.github_file_ops).not.toBeDefined();
+    expect(parsed.mcpServers.github_comment).not.toBeDefined();
   });
 
   test("should return file ops server when commit signing is enabled", async () => {
@@ -122,6 +142,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "12345",
       allowedTools: [],
       context: contextWithSigning,
     });
@@ -152,6 +173,7 @@ describe("prepareMcpConfig", () => {
         "mcp__github__create_issue",
         "mcp__github_file_ops__commit_files",
       ],
+      claudeCommentId: "12345",
       context: mockContext,
     });
 
@@ -201,6 +223,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       allowedTools: ["Edit", "Read", "Write"],
+      claudeCommentId: "12345",
       context: mockContext,
     });
 
@@ -219,6 +242,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: "",
+      claudeCommentId: "12345",
       allowedTools: [],
       context: mockContext,
     });
@@ -238,6 +262,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: "   \n\t  ",
+      claudeCommentId: "12345",
       allowedTools: [],
       context: mockContext,
     });

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -106,7 +106,9 @@ describe("prepareMcpConfig", () => {
     );
     expect(parsed.mcpServers.github_comment.env.REPO_OWNER).toBe("test-owner");
     expect(parsed.mcpServers.github_comment.env.REPO_NAME).toBe("test-repo");
-    expect(parsed.mcpServers.github_comment.env.CLAUDE_COMMENT_ID).toBe("12345");
+    expect(parsed.mcpServers.github_comment.env.CLAUDE_COMMENT_ID).toBe(
+      "12345",
+    );
   });
 
   test("should not include comment server when claudeCommentId is not provided", async () => {


### PR DESCRIPTION
### Summary

This PR improves the behavior when `override_prompt` is set by making the initial Claude comment creation conditional. When using `override_prompt`, the standard prompt instructions that enforce comment updates using `mcp__github_comment__update_claude_comment` are not included, so creating an initial comment becomes unnecessary.

### Changes

- **Conditional comment creation**: Skip initial comment creation when `override_prompt` is set
- **Optional comment ID handling**: Update tag mode to handle cases where comment ID may be null
- **Conditional MCP comment server**: Only include the GitHub comment MCP server when a Claude comment ID is provided
- **Improved error message**: Clarify that comment ID is required for tag mode "unless you're using override_prompt"
- **Git config refactoring**: Update `configureGitAuth` to fetch user data directly via Octokit instead of passing it as a parameter

### Test Updates

- Add test coverage for the conditional inclusion of the comment server based on whether `claudeCommentId` is provided
- Update existing tests to provide `claudeCommentId` where needed

### Benefits

1. **Cleaner execution**: Avoids creating unnecessary comments when using `override_prompt`
2. **Better resource usage**: Only includes MCP servers that are actually needed
3. **Improved flexibility**: Allows more streamlined workflows when using custom prompts

### Breaking Changes

None - this change is backward compatible and only affects behavior when `override_prompt` is explicitly set.