### PR TITLE
fix: The “Cost” in the Final Result of the Claude Code Report is always showing as $0.0000

### DIFF
--- a/src/entrypoints/format-turns.ts
+++ b/src/entrypoints/format-turns.ts
@@ -393,7 +393,7 @@ export function formatGroupedContent(groupedContent: GroupedContent[]): string {
       markdown += "---\n\n";
     } else if (itemType === "final_result") {
       const data = item.data || {};
-      const cost = (data as any).cost_usd || 0;
+      const cost = (data as any).total_cost_usd || (data as any).cost_usd || 0;
       const duration = (data as any).duration_ms || 0;
       const resultText = (data as any).result || "";
 


### PR DESCRIPTION
The actual result log was as follows. Taking compatibility into consideration, we prioritized total_cost_usd and left cost_usd as is.

```
{
  "type": "result",
  "subtype": "error_during_execution",
  "duration_ms": 185041,
  "duration_api_ms": 184154,
  "is_error": false,
  "num_turns": 0,
  "session_id": "xxxxxxxxx",
  "total_cost_usd": 0.6571631500000001,
  "usage": {
    "input_tokens": 112,
    "cache_creation_input_tokens": 58211,
    "cache_read_input_tokens": 1120129,
    "output_tokens": 6814,
    "server_tool_use": {
      "web_search_requests": 0
    },
    "service_tier": "standard"
  }
}
```