### PR TITLE
fix: include cache tokens in token usage display

### DIFF
--- a/src/entrypoints/format-turns.ts
+++ b/src/entrypoints/format-turns.ts
@@ -372,8 +372,11 @@ export function formatGroupedContent(groupedContent: GroupedContent[]): string {
       const usage = item.usage || {};
       if (Object.keys(usage).length > 0) {
         const inputTokens = usage.input_tokens || 0;
+        const cacheCreationTokens = usage.cache_creation_input_tokens || 0;
+        const cacheReadTokens = usage.cache_read_input_tokens || 0;
+        const totalInputTokens = inputTokens + cacheCreationTokens + cacheReadTokens;
         const outputTokens = usage.output_tokens || 0;
-        markdown += `*Token usage: ${inputTokens} input, ${outputTokens} output*\n\n`;
+        markdown += `*Token usage: ${totalInputTokens.toLocaleString()} input, ${outputTokens.toLocaleString()} output*\n\n`;
       }
 
       // Only add separator if this section had content

--- a/src/entrypoints/format-turns.ts
+++ b/src/entrypoints/format-turns.ts
@@ -376,7 +376,7 @@ export function formatGroupedContent(groupedContent: GroupedContent[]): string {
         const cacheReadTokens = usage.cache_read_input_tokens || 0;
         const totalInputTokens = inputTokens + cacheCreationTokens + cacheReadTokens;
         const outputTokens = usage.output_tokens || 0;
-        markdown += `*Token usage: ${totalInputTokens.toLocaleString()} input, ${outputTokens.toLocaleString()} output*\n\n`;
+        markdown += `*Token usage: ${totalInputTokens} input, ${outputTokens} output*\n\n`;
       }
 
       // Only add separator if this section had content

--- a/src/entrypoints/format-turns.ts
+++ b/src/entrypoints/format-turns.ts
@@ -374,7 +374,8 @@ export function formatGroupedContent(groupedContent: GroupedContent[]): string {
         const inputTokens = usage.input_tokens || 0;
         const cacheCreationTokens = usage.cache_creation_input_tokens || 0;
         const cacheReadTokens = usage.cache_read_input_tokens || 0;
-        const totalInputTokens = inputTokens + cacheCreationTokens + cacheReadTokens;
+        const totalInputTokens =
+          inputTokens + cacheCreationTokens + cacheReadTokens;
         const outputTokens = usage.output_tokens || 0;
         markdown += `*Token usage: ${totalInputTokens} input, ${outputTokens} output*\n\n`;
       }

--- a/test/fixtures/sample-turns-expected-output.md
+++ b/test/fixtures/sample-turns-expected-output.md
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     print(result)
 ```
 
-*Token usage: 100 input, 75 output*
+*Token usage: 150 input, 75 output*
 
 ---
 
@@ -47,7 +47,7 @@ I can see the debug print statement that needs to be removed. Let me fix this by
 
 **→** File successfully edited. The debug print statement has been removed.
 
-*Token usage: 200 input, 50 output*
+*Token usage: 300 input, 50 output*
 
 ---
 
@@ -70,7 +70,7 @@ Perfect! I've successfully removed the debug print statement from the function. 
 
 **→** Successfully posted review comment to PR #123
 
-*Token usage: 150 input, 80 output*
+*Token usage: 225 input, 80 output*
 
 ---
 
@@ -82,7 +82,7 @@ Great! I've successfully completed the requested task:
 
 The debug print statement has been removed as requested by the reviewers.
 
-*Token usage: 180 input, 60 output*
+*Token usage: 270 input, 60 output*
 
 ---
 
@@ -91,5 +91,3 @@ The debug print statement has been removed as requested by the reviewers.
 Successfully removed debug print statement from file and added review comment to document the change.
 
 **Cost:** $0.0347 | **Duration:** 18.8s
-
-


### PR DESCRIPTION
## Summary

This PR fixes the token usage display in GitHub Action summaries to include cache tokens in the total input token count. Previously, only `input_tokens` and `output_tokens` were displayed, which resulted in misleadingly low token counts.

## Changes

- Modified `formatGroupedContent()` in `src/entrypoints/format-turns.ts` to calculate total input tokens including:
  - `input_tokens`
  - `cache_creation_input_tokens`
  - `cache_read_input_tokens`