### PR TITLE
feat: exclude hidden (minimized) comments from GitHub Issues and PRs

### DIFF
--- a/src/github/api/queries/github.ts
+++ b/src/github/api/queries/github.ts
@@ -46,6 +46,7 @@ export const PR_QUERY = `
               login
             }
             createdAt
+            isMinimized
           }
         }
         reviews(first: 100) {
@@ -69,6 +70,7 @@ export const PR_QUERY = `
                   login
                 }
                 createdAt
+                isMinimized
               }
             }
           }
@@ -98,6 +100,7 @@ export const ISSUE_QUERY = `
               login
             }
             createdAt
+            isMinimized
           }
         }
       }

--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -134,7 +134,7 @@ export async function fetchGitHubData({
 
   // Prepare all comments for image processing
   const issueComments: CommentWithImages[] = comments
-    .filter((c) => c.body)
+    .filter((c) => c.body && !c.isMinimized)
     .map((c) => ({
       type: "issue_comment" as const,
       id: c.databaseId,
@@ -154,7 +154,7 @@ export async function fetchGitHubData({
   const reviewComments: CommentWithImages[] =
     reviewData?.nodes
       ?.flatMap((r) => r.comments?.nodes ?? [])
-      .filter((c) => c.body)
+      .filter((c) => c.body && !c.isMinimized)
       .map((c) => ({
         type: "review_comment" as const,
         id: c.databaseId,

--- a/src/github/data/formatter.ts
+++ b/src/github/data/formatter.ts
@@ -50,6 +50,7 @@ export function formatComments(
   imageUrlMap?: Map<string, string>,
 ): string {
   return comments
+    .filter((comment) => !comment.isMinimized)
     .map((comment) => {
       let body = comment.body;
 
@@ -96,6 +97,7 @@ export function formatReviewComments(
       review.comments.nodes.length > 0
     ) {
       const comments = review.comments.nodes
+        .filter((comment) => !comment.isMinimized)
         .map((comment) => {
           let body = comment.body;
 

--- a/src/github/data/formatter.ts
+++ b/src/github/data/formatter.ts
@@ -112,7 +112,9 @@ export function formatReviewComments(
           return `  [Comment on ${comment.path}:${comment.line || "?"}]: ${body}`;
         })
         .join("\n");
-      reviewOutput += `\n${comments}`;
+      if (comments) {
+        reviewOutput += `\n${comments}`;
+      }
     }
 
     return reviewOutput;

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -10,6 +10,7 @@ export type GitHubComment = {
   body: string;
   author: GitHubAuthor;
   createdAt: string;
+  isMinimized?: boolean;
 };
 
 export type GitHubReviewComment = GitHubComment & {


### PR DESCRIPTION
## Description
### Summary
This PR adds support for filtering out hidden (minimized) comments from GitHub Issues and Pull Requests when generating prompts for Claude. Hidden comments are those that have been minimized by GitHub due to being marked as spam, abuse, or off-topic.

### Changes
- Added `isMinimized` field to GraphQL queries for both PR and Issue comments, including review comments
- Updated `GitHubComment` type to include optional `isMinimized` boolean field
- Modified `formatComments()` function to filter out comments where `isMinimized` is true
- Updated `formatReviewComments()` function to filter out minimized review comments
- Updated comment filtering in `fetchGitHubData()` to exclude minimized comments from image processing
- Added comprehensive test cases for minimized comment filtering

### Implementation Details
1. **GraphQL Query Updates** (`src/github/api/queries/github.ts`):
   - Added `isMinimized` field to comment nodes in both `PR_QUERY` and `ISSUE_QUERY`
   - Added `isMinimized` field to review comment nodes in `PR_QUERY`

2. **Type Definition** (`src/github/types.ts`):
   - Extended `GitHubComment` type with optional `isMinimized?: boolean` field
   - Review comments inherit this field through `GitHubReviewComment` extending `GitHubComment`

3. **Comment Formatting** (`src/github/data/formatter.ts`):
   - Added filter `.filter((comment) => !comment.isMinimized)` in `formatComments()` function
   - Added filter `.filter((comment) => !comment.isMinimized)` in `formatReviewComments()` function for review comments

4. **Image Processing** (`src/github/data/fetcher.ts`):
   - Updated comment filtering to exclude minimized comments: `.filter((c) => c.body && !c.isMinimized)`
   - Updated review comment filtering to exclude minimized review comments

5. **Test Coverage** (`test/data-formatter.test.ts`):
   - Added test cases for filtering minimized comments in `formatComments()`
   - Added test cases for filtering minimized review comments in `formatReviewComments()`
   - Added edge cases for when all comments are minimized
   - Added test cases for mixed scenarios with both minimized and normal comments

### Benefits
- Cleaner prompts for Claude by excluding irrelevant or problematic comments
- Reduced noise from spam or off-topic discussions
- More focused context for AI interactions

### Testing
The changes maintain backward compatibility as the `isMinimized` field is optional. Comments without this field will be included as before.
