### PR TITLE
Remove empty XML tags in Issue context to reduce token usage

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -587,13 +587,21 @@ ${formattedBody}
 ${formattedComments || "No comments"}
 </comments>
 
-${eventData.isPR ? `<review_comments>
+${
+  eventData.isPR
+    ? `<review_comments>
 ${formattedReviewComments || "No review comments"}
-</review_comments>` : ""}
+</review_comments>`
+    : ""
+}
 
-${eventData.isPR ? `<changed_files>
+${
+  eventData.isPR
+    ? `<changed_files>
 ${formattedChangedFiles || "No files changed"}
-</changed_files>` : ""}${imagesInfo}
+</changed_files>`
+    : ""
+}${imagesInfo}
 
 <event_type>${eventType}</event_type>
 <is_pr>${eventData.isPR ? "true" : "false"}</is_pr>

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -587,23 +587,20 @@ ${formattedBody}
 ${formattedComments || "No comments"}
 </comments>
 
-<review_comments>
-${eventData.isPR ? formattedReviewComments || "No review comments" : ""}
-</review_comments>
+${eventData.isPR ? `<review_comments>
+${formattedReviewComments || "No review comments"}
+</review_comments>` : ""}
 
-<changed_files>
-${eventData.isPR ? formattedChangedFiles || "No files changed" : ""}
-</changed_files>${imagesInfo}
+${eventData.isPR ? `<changed_files>
+${formattedChangedFiles || "No files changed"}
+</changed_files>` : ""}${imagesInfo}
 
 <event_type>${eventType}</event_type>
 <is_pr>${eventData.isPR ? "true" : "false"}</is_pr>
 <trigger_context>${triggerContext}</trigger_context>
 <repository>${context.repository}</repository>
-${
-  eventData.isPR
-    ? `<pr_number>${eventData.prNumber}</pr_number>`
-    : `<issue_number>${eventData.issueNumber ?? ""}</issue_number>`
-}
+${eventData.isPR && eventData.prNumber ? `<pr_number>${eventData.prNumber}</pr_number>` : ""}
+${!eventData.isPR && eventData.issueNumber ? `<issue_number>${eventData.issueNumber}</issue_number>` : ""}
 <claude_comment_id>${context.claudeCommentId}</claude_comment_id>
 <trigger_username>${context.triggerUsername ?? "Unknown"}</trigger_username>
 <trigger_display_name>${githubData.triggerDisplayName ?? context.triggerUsername ?? "Unknown"}</trigger_display_name>


### PR DESCRIPTION
## Description

### Summary
Fixed an issue where unnecessary empty XML tags were being generated in Issue context, implementing an optimization to reduce token usage.

### Changes Made
- Modified the `generatePrompt` function in `src/create-prompt/index.ts`
- Completely removed `<review_comments>` and `<changed_files>` sections in Issue context (`eventData.isPR = false`)
- Optimized PR/Issue number tags to only generate when values are present
- Maintained existing behavior for PR context

### Problem Before Fix
```xml
<!-- Empty tags were generated even in Issue context -->
<review_comments>
</review_comments>

<changed_files>
</changed_files>
```

### Solution After Fix
```typescript
// Conditionally exclude empty sections in Issue context
${eventData.isPR ? `<review_comments>
${formattedReviewComments || "No review comments"}
</review_comments>` : ""}

${eventData.isPR ? `<changed_files>
${formattedChangedFiles || "No files changed"}
</changed_files>` : ""}
```