### PR TITLE
Proposal: Optimize prompt generation through modular refactoring of create-prompt/index.ts

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -23,7 +23,7 @@ import { GITHUB_SERVER_URL } from "../github/api/config";
 import type { Mode, ModeContext } from "../modes/types";
 export type { CommonFields, PreparedContext } from "./types";
 
-// 型定義の追加
+// Type definitions for prompt sections
 interface PromptSections {
   identity: string;
   context: string;
@@ -417,7 +417,7 @@ export function getEventTypeAndContext(envVars: PreparedContext): {
   }
 }
 
-// セクション生成関数の実装
+// Section generation function implementations
 function generateIdentitySection(): string {
   return `You are Claude, an AI assistant designed to help with GitHub issues and pull requests. Think carefully as you analyze the context and respond appropriately.`;
 }
@@ -896,7 +896,7 @@ export function generatePrompt(
     );
   }
 
-  // プロンプトを論理的なセクションに分割
+  // Divide prompt into logical sections
   const sections: PromptSections = {
     identity: generateIdentitySection(),
     context: generateContextSection(context, githubData),
@@ -908,7 +908,7 @@ export function generatePrompt(
     custom: context.customInstructions || "",
   };
 
-  // 条件に応じて必要なセクションのみを含める
+  // Include only necessary sections based on conditions
   return buildPrompt(sections, context.eventData);
 }
 


### PR DESCRIPTION
## Overview

This PR proposes a refactoring of `src/create-prompt/index.ts` to reduce token consumption and improve maintainability while preserving all existing functionality. I thought it would be clearer to present what I envision as the final version, so I went ahead and wrote some code. After discussion and alignment, I plan to create incremental pull requests to implement the changes, aiming to modify the prompts as little as possible throughout the process.

## Motivation

The current implementation contains several areas of duplication that increase token usage:
- Communication rules repeated in 3 locations
- PR-specific reminders duplicated in 4 places  
- Tool usage examples appearing multiple times
- Estimated unnecessary token consumption: ~400-600 tokens (5-7%)

## Proposed Approach

### Phase 1: Pure Refactoring (Identical Output)
- Extract prompt sections into dedicated functions
- Introduce type definitions for better structure
- **Ensure generated prompts remain byte-for-byte identical**
- Add tests to verify output equivalence

### Phase 2: Content Optimization (Minimal Changes)  
- Unify communication rules into single source of truth
- Consolidate tool usage examples
- Remove clear redundancies while preserving intentional emphasis
- Each change will be traceable and reversible

Looking forward to your feedback on this approach!