### PR TITLE
feat: expand GitHub attachment support beyond images to all file types

### DIFF
--- a/src/github/utils/attachment-downloader.ts
+++ b/src/github/utils/attachment-downloader.ts
@@ -1,0 +1,402 @@
+import fs from "fs/promises";
+import type { Octokits } from "../api/client";
+import {
+  detectAllAttachments,
+  isSupportedFileType,
+  type FileTypeInfo,
+} from "./file-type-detector";
+import {
+  processImageFile,
+  type ImageProcessResult,
+} from "./attachment-processors/image-processor";
+import {
+  processDocumentFile,
+  type DocumentProcessResult,
+} from "./attachment-processors/document-processor";
+import {
+  processTextFile,
+  type TextProcessResult,
+} from "./attachment-processors/text-processor";
+import {
+  processMediaFile,
+  type MediaProcessResult,
+} from "./attachment-processors/media-processor";
+import { extractFilenameFromUrl } from "./url-utils";
+import {
+  type GitHubCommentResponse,
+  type GitHubReviewResponse,
+  type GitHubIssueResponse,
+  type GitHubPullRequestResponse,
+  hasBodyHtml,
+} from "./github-api-types";
+
+// Import and re-export types from image-downloader for backward compatibility
+import type { CommentWithImages } from "./image-downloader";
+export type { CommentWithImages } from "./image-downloader";
+
+export interface AttachmentInfo {
+  type:
+    | "image"
+    | "document"
+    | "text"
+    | "video"
+    | "archive"
+    | "development"
+    | "unknown";
+  localPath?: string;
+  fileSize?: number;
+  metadata?: any;
+  error?: string;
+  downloadSkipped?: boolean;
+}
+
+export interface AttachmentResult {
+  attachments: Map<string, AttachmentInfo>;
+  summary: {
+    total: number;
+    successful: number;
+    failed: number;
+    skipped: number;
+    byType: Record<string, number>;
+  };
+}
+
+/**
+ * Download all types of attachments from GitHub comments
+ */
+export async function downloadCommentAttachments(
+  octokits: Octokits,
+  owner: string,
+  repo: string,
+  comments: CommentWithImages[],
+): Promise<AttachmentResult> {
+  const attachments = new Map<string, AttachmentInfo>();
+  const downloadsDir = "/tmp/github-attachments";
+
+  await fs.mkdir(downloadsDir, { recursive: true });
+
+  const commentsWithAttachments: Array<{
+    comment: CommentWithImages;
+    attachments: Array<{ url: string; type: FileTypeInfo }>;
+  }> = [];
+
+  // Detect all attachments in comments
+  for (const comment of comments) {
+    const detectedAttachments = detectAllAttachments(comment.body);
+
+    if (detectedAttachments.length > 0) {
+      commentsWithAttachments.push({
+        comment,
+        attachments: detectedAttachments,
+      });
+      const id =
+        comment.type === "issue_body"
+          ? comment.issueNumber
+          : comment.type === "pr_body"
+            ? comment.pullNumber
+            : comment.id;
+
+      const supportedCount = detectedAttachments.filter((a) =>
+        isSupportedFileType(a.type),
+      ).length;
+      const unsupportedCount = detectedAttachments.length - supportedCount;
+
+      console.log(
+        `Found ${detectedAttachments.length} attachment(s) in ${comment.type} ${id}`,
+      );
+      if (unsupportedCount > 0) {
+        console.log(
+          `  - ${supportedCount} supported, ${unsupportedCount} unsupported`,
+        );
+      }
+    }
+  }
+
+  // Process each comment with attachments
+  for (const {
+    comment,
+    attachments: commentAttachments,
+  } of commentsWithAttachments) {
+    try {
+      let bodyHtml: string | undefined;
+
+      // Get the HTML version based on comment type
+      switch (comment.type) {
+        case "issue_comment": {
+          const response: GitHubCommentResponse =
+            await octokits.rest.issues.getComment({
+              owner,
+              repo,
+              comment_id: parseInt(comment.id),
+              mediaType: {
+                format: "full+json",
+              },
+            });
+          bodyHtml = response.data.body_html;
+          break;
+        }
+        case "review_comment": {
+          const response: GitHubCommentResponse =
+            await octokits.rest.pulls.getReviewComment({
+              owner,
+              repo,
+              comment_id: parseInt(comment.id),
+              mediaType: {
+                format: "full+json",
+              },
+            });
+          bodyHtml = response.data.body_html;
+          break;
+        }
+        case "review_body": {
+          const response: GitHubReviewResponse =
+            await octokits.rest.pulls.getReview({
+              owner,
+              repo,
+              pull_number: parseInt(comment.pullNumber),
+              review_id: parseInt(comment.id),
+              mediaType: {
+                format: "full+json",
+              },
+            });
+          bodyHtml = response.data.body_html;
+          break;
+        }
+        case "issue_body": {
+          const response: GitHubIssueResponse = await octokits.rest.issues.get({
+            owner,
+            repo,
+            issue_number: parseInt(comment.issueNumber),
+            mediaType: {
+              format: "full+json",
+            },
+          });
+          bodyHtml = response.data.body_html;
+          break;
+        }
+        case "pr_body": {
+          const response: GitHubPullRequestResponse =
+            await octokits.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: parseInt(comment.pullNumber),
+              mediaType: {
+                format: "full+json",
+              },
+            });
+          bodyHtml = hasBodyHtml(response)
+            ? response.data.body_html
+            : undefined;
+          break;
+        }
+      }
+
+      if (!bodyHtml) {
+        const id =
+          comment.type === "issue_body"
+            ? comment.issueNumber
+            : comment.type === "pr_body"
+              ? comment.pullNumber
+              : comment.id;
+        console.warn(`No HTML body found for ${comment.type} ${id}`);
+        continue;
+      }
+
+      // Extract signed URLs from HTML
+      const signedUrlRegex =
+        /https:\/\/private-user-images\.githubusercontent\.com\/[^"]+\?jwt=[^"]+/g;
+      const signedUrls = bodyHtml.match(signedUrlRegex) || [];
+
+      // Process each attachment
+      for (
+        let i = 0;
+        i < Math.min(signedUrls.length, commentAttachments.length);
+        i++
+      ) {
+        const signedUrl = signedUrls[i];
+        const attachment = commentAttachments[i];
+
+        if (!signedUrl || !attachment) {
+          continue;
+        }
+
+        const { url: originalUrl, type: typeInfo } = attachment;
+
+        // Check if we've already processed this URL
+        if (attachments.has(originalUrl)) {
+          continue;
+        }
+
+        // Process based on file type
+        const result = await processAttachment(
+          originalUrl,
+          signedUrl,
+          typeInfo,
+          downloadsDir,
+          i,
+        );
+
+        attachments.set(originalUrl, result);
+      }
+    } catch (error) {
+      const id =
+        comment.type === "issue_body"
+          ? comment.issueNumber
+          : comment.type === "pr_body"
+            ? comment.pullNumber
+            : comment.id;
+      console.error(
+        `Failed to process attachments for ${comment.type} ${id}:`,
+        error,
+      );
+    }
+  }
+
+  // Generate summary
+  const summary = generateSummary(attachments);
+
+  return {
+    attachments,
+    summary,
+  };
+}
+
+/**
+ * Process a single attachment based on its type
+ */
+async function processAttachment(
+  url: string,
+  signedUrl: string,
+  typeInfo: FileTypeInfo,
+  downloadsDir: string,
+  index: number,
+): Promise<AttachmentInfo> {
+  // Check if file type is supported
+  if (!isSupportedFileType(typeInfo)) {
+    console.warn(`⚠️ Unsupported file type: ${url} (${typeInfo.extension})`);
+    return {
+      type: "unknown",
+      error: `Unsupported file type: ${typeInfo.extension}`,
+      metadata: {
+        filename: extractFilenameFromUrl(url),
+        originalUrl: url,
+      },
+    };
+  }
+
+  try {
+    let result:
+      | ImageProcessResult
+      | DocumentProcessResult
+      | TextProcessResult
+      | MediaProcessResult;
+
+    switch (typeInfo.category) {
+      case "image":
+        result = await processImageFile(
+          url,
+          signedUrl,
+          typeInfo,
+          downloadsDir,
+          index,
+        );
+        break;
+      case "document":
+        result = await processDocumentFile(
+          url,
+          signedUrl,
+          typeInfo,
+          downloadsDir,
+          index,
+        );
+        break;
+      case "text":
+        result = await processTextFile(
+          url,
+          signedUrl,
+          typeInfo,
+          downloadsDir,
+          index,
+        );
+        break;
+      case "video":
+      case "archive":
+      case "development":
+        result = await processMediaFile(
+          url,
+          signedUrl,
+          typeInfo,
+          downloadsDir,
+          index,
+        );
+        break;
+      default:
+        throw new Error(`Unhandled file category: ${typeInfo.category}`);
+    }
+
+    if (result.success) {
+      return {
+        type: typeInfo.category,
+        localPath: result.localPath,
+        fileSize: result.fileSize,
+        metadata: result.metadata,
+        downloadSkipped:
+          "metadata" in result
+            ? (result.metadata as any)?.downloadSkipped
+            : undefined,
+      };
+    } else {
+      return {
+        type: typeInfo.category,
+        error: result.error,
+        metadata: {
+          filename: extractFilenameFromUrl(url),
+          originalUrl: url,
+        },
+      };
+    }
+  } catch (error) {
+    console.error(
+      `✗ Failed to process ${typeInfo.category} file ${url}:`,
+      error,
+    );
+    return {
+      type: typeInfo.category,
+      error: error instanceof Error ? error.message : String(error),
+      metadata: {
+        filename: extractFilenameFromUrl(url),
+        originalUrl: url,
+      },
+    };
+  }
+}
+
+/**
+ * Generate summary statistics
+ */
+function generateSummary(attachments: Map<string, AttachmentInfo>) {
+  const summary = {
+    total: attachments.size,
+    successful: 0,
+    failed: 0,
+    skipped: 0,
+    byType: {} as Record<string, number>,
+  };
+
+  for (const attachment of attachments.values()) {
+    // Count by result
+    if (attachment.error) {
+      summary.failed++;
+    } else if (attachment.downloadSkipped) {
+      summary.skipped++;
+    } else {
+      summary.successful++;
+    }
+
+    // Count by type
+    summary.byType[attachment.type] =
+      (summary.byType[attachment.type] || 0) + 1;
+  }
+
+  return summary;
+}

--- a/src/github/utils/attachment-processors/document-processor.ts
+++ b/src/github/utils/attachment-processors/document-processor.ts
@@ -1,0 +1,91 @@
+import fs from "fs/promises";
+import path from "path";
+import type { FileTypeInfo } from "../file-type-detector";
+import { extractFilenameFromUrl } from "../url-utils";
+
+export interface DocumentProcessResult {
+  success: boolean;
+  localPath?: string;
+  error?: string;
+  fileSize?: number;
+  metadata?: {
+    filename: string;
+    type: string;
+  };
+}
+
+/**
+ * Process and download document files (PDF, Office, OpenDocument)
+ */
+export async function processDocumentFile(
+  url: string,
+  signedUrl: string,
+  typeInfo: FileTypeInfo,
+  downloadsDir: string,
+  index: number,
+): Promise<DocumentProcessResult> {
+  try {
+    console.log(`Downloading document ${url}...`);
+
+    const response = await fetch(signedUrl);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Check file size
+    if (buffer.length > typeInfo.sizeLimit) {
+      throw new Error(
+        `File size ${buffer.length} bytes exceeds limit of ${typeInfo.sizeLimit} bytes`,
+      );
+    }
+
+    const originalFilename = extractFilenameFromUrl(url);
+    const filename = `document-${Date.now()}-${index}${typeInfo.extension}`;
+    const localPath = path.join(downloadsDir, filename);
+
+    await fs.writeFile(localPath, buffer);
+    console.log(`✓ Saved document: ${localPath}`);
+
+    return {
+      success: true,
+      localPath,
+      fileSize: buffer.length,
+      metadata: {
+        filename: originalFilename || filename,
+        type: typeInfo.category,
+      },
+    };
+  } catch (error) {
+    console.error(`✗ Failed to download document ${url}:`, error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Check if file is a supported document type
+ */
+export function isSupportedDocument(extension: string): boolean {
+  const supportedExtensions = [
+    ".pdf",
+    ".docx",
+    ".pptx",
+    ".xlsx",
+    ".xls",
+    ".odt",
+    ".fodt",
+    ".ods",
+    ".fods",
+    ".odp",
+    ".fodp",
+    ".odg",
+    ".fodg",
+    ".odf",
+  ];
+  return supportedExtensions.includes(extension.toLowerCase());
+}

--- a/src/github/utils/attachment-processors/image-processor.ts
+++ b/src/github/utils/attachment-processors/image-processor.ts
@@ -1,0 +1,82 @@
+import fs from "fs/promises";
+import path from "path";
+import type { FileTypeInfo } from "../file-type-detector";
+
+export interface ImageProcessResult {
+  success: boolean;
+  localPath?: string;
+  error?: string;
+  fileSize?: number;
+  metadata?: {
+    filename: string;
+    type: string;
+  };
+}
+
+/**
+ * Process and download image files
+ */
+export async function processImageFile(
+  url: string,
+  signedUrl: string,
+  typeInfo: FileTypeInfo,
+  downloadsDir: string,
+  index: number,
+): Promise<ImageProcessResult> {
+  try {
+    console.log(`Downloading ${url}...`);
+
+    const imageResponse = await fetch(signedUrl);
+    if (!imageResponse.ok) {
+      throw new Error(
+        `HTTP ${imageResponse.status}: ${imageResponse.statusText}`,
+      );
+    }
+
+    const arrayBuffer = await imageResponse.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Check file size
+    if (buffer.length > typeInfo.sizeLimit) {
+      throw new Error(
+        `File size ${buffer.length} bytes exceeds limit of ${typeInfo.sizeLimit} bytes`,
+      );
+    }
+
+    const filename = `image-${Date.now()}-${index}${typeInfo.extension}`;
+    const localPath = path.join(downloadsDir, filename);
+
+    await fs.writeFile(localPath, buffer);
+    console.log(`✓ Saved: ${localPath}`);
+
+    return {
+      success: true,
+      localPath,
+      fileSize: buffer.length,
+      metadata: {
+        filename,
+        type: "image",
+      },
+    };
+  } catch (error) {
+    console.error(`✗ Failed to download ${url}:`, error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Extract file extension for images (backward compatibility)
+ */
+export function getImageExtension(url: string): string {
+  const urlParts = url.split("/");
+  const filename = urlParts[urlParts.length - 1];
+  if (!filename) {
+    throw new Error("Invalid URL: No filename found");
+  }
+
+  const match = filename.match(/\.(png|jpg|jpeg|gif|webp|svg)$/i);
+  return match ? match[0] : ".png";
+}

--- a/src/github/utils/attachment-processors/media-processor.ts
+++ b/src/github/utils/attachment-processors/media-processor.ts
@@ -1,0 +1,161 @@
+import fs from "fs/promises";
+import path from "path";
+import type { FileTypeInfo } from "../file-type-detector";
+import { extractFilenameFromUrl } from "../url-utils";
+import { ERROR_MESSAGES } from "../constants";
+
+export interface MediaProcessResult {
+  success: boolean;
+  localPath?: string;
+  error?: string;
+  fileSize?: number;
+  metadata?: {
+    filename: string;
+    type: string;
+    downloadSkipped?: boolean;
+    reason?: string;
+  };
+}
+
+/**
+ * Process media files (videos, archives, development files)
+ */
+export async function processMediaFile(
+  url: string,
+  signedUrl: string,
+  typeInfo: FileTypeInfo,
+  downloadsDir: string,
+  index: number,
+): Promise<MediaProcessResult> {
+  try {
+    const originalFilename = extractFilenameFromUrl(url);
+
+    // For video files, we might want to skip download and just save metadata
+    if (typeInfo.category === "video") {
+      return processVideoFile(url, originalFilename, typeInfo);
+    }
+
+    // For archives and development files, download them
+    return await downloadMediaFile(
+      url,
+      signedUrl,
+      typeInfo,
+      downloadsDir,
+      index,
+      originalFilename,
+    );
+  } catch (error) {
+    console.error(`✗ Failed to process media file ${url}:`, error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Process video files (usually just metadata, not actual download)
+ */
+function processVideoFile(
+  url: string,
+  originalFilename: string | null,
+  typeInfo: FileTypeInfo,
+): MediaProcessResult {
+  console.log(`📹 Video file detected: ${url}`);
+  console.log(`   File type: ${typeInfo.extension}`);
+  console.log(
+    `   Note: Video files are not downloaded, please view directly on GitHub`,
+  );
+
+  return {
+    success: true,
+    metadata: {
+      filename: originalFilename || `video${typeInfo.extension}`,
+      type: "video",
+      downloadSkipped: true,
+      reason: ERROR_MESSAGES.VIDEO_SKIP_REASON,
+    },
+  };
+}
+
+/**
+ * Download archive and development files
+ */
+async function downloadMediaFile(
+  url: string,
+  signedUrl: string,
+  typeInfo: FileTypeInfo,
+  downloadsDir: string,
+  index: number,
+  originalFilename: string | null,
+): Promise<MediaProcessResult> {
+  console.log(`Downloading ${typeInfo.category} file ${url}...`);
+
+  const response = await fetch(signedUrl);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  // Check file size
+  if (buffer.length > typeInfo.sizeLimit) {
+    throw new Error(
+      `File size ${buffer.length} bytes exceeds limit of ${typeInfo.sizeLimit} bytes`,
+    );
+  }
+
+  const filename = `${typeInfo.category}-${Date.now()}-${index}${typeInfo.extension}`;
+  const localPath = path.join(downloadsDir, filename);
+
+  await fs.writeFile(localPath, buffer);
+  console.log(`✓ Saved ${typeInfo.category} file: ${localPath}`);
+
+  return {
+    success: true,
+    localPath,
+    fileSize: buffer.length,
+    metadata: {
+      filename: originalFilename || filename,
+      type: typeInfo.category,
+    },
+  };
+}
+
+/**
+ * Check if file is a supported video type
+ */
+export function isSupportedVideo(extension: string): boolean {
+  const supportedExtensions = [".mp4", ".mov", ".webm"];
+  return supportedExtensions.includes(extension.toLowerCase());
+}
+
+/**
+ * Check if file is a supported archive type
+ */
+export function isSupportedArchive(extension: string): boolean {
+  const supportedExtensions = [".zip", ".gz", ".tgz"];
+  return supportedExtensions.includes(extension.toLowerCase());
+}
+
+/**
+ * Check if file is a supported development file type
+ */
+export function isSupportedDevelopmentFile(extension: string): boolean {
+  const supportedExtensions = [".patch", ".cpuprofile", ".dmp"];
+  return supportedExtensions.includes(extension.toLowerCase());
+}
+
+/**
+ * Get file category description
+ */
+export function getMediaFileDescription(category: string): string {
+  const descriptions: Record<string, string> = {
+    video: "Video file (not downloaded due to size)",
+    archive: "Archive file",
+    development: "Development/debugging file",
+  };
+
+  return descriptions[category] || "Media file";
+}

--- a/src/github/utils/attachment-processors/text-processor.ts
+++ b/src/github/utils/attachment-processors/text-processor.ts
@@ -1,0 +1,136 @@
+import fs from "fs/promises";
+import path from "path";
+import type { FileTypeInfo } from "../file-type-detector";
+import { extractFilenameFromUrl } from "../url-utils";
+import { MAX_TEXT_CONTENT_LENGTH, ERROR_MESSAGES } from "../constants";
+
+export interface TextProcessResult {
+  success: boolean;
+  localPath?: string;
+  error?: string;
+  fileSize?: number;
+  content?: string;
+  metadata?: {
+    filename: string;
+    encoding: string;
+    lineCount?: number;
+  };
+}
+
+/**
+ * Process and download text files (txt, md, csv, json, log, etc.)
+ */
+export async function processTextFile(
+  url: string,
+  signedUrl: string,
+  typeInfo: FileTypeInfo,
+  downloadsDir: string,
+  index: number,
+): Promise<TextProcessResult> {
+  try {
+    console.log(`Downloading text file ${url}...`);
+
+    const response = await fetch(signedUrl);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Check file size
+    if (buffer.length > typeInfo.sizeLimit) {
+      throw new Error(
+        `File size ${buffer.length} bytes exceeds limit of ${typeInfo.sizeLimit} bytes`,
+      );
+    }
+
+    // Try to decode as UTF-8 text
+    const content = buffer.toString("utf-8");
+
+    // Validate that it's actually text (not binary)
+    if (!isValidText(content)) {
+      throw new Error(ERROR_MESSAGES.BINARY_FILE_DETECTED);
+    }
+
+    const originalFilename = extractFilenameFromUrl(url);
+    const filename = `text-${Date.now()}-${index}${typeInfo.extension}`;
+    const localPath = path.join(downloadsDir, filename);
+
+    await fs.writeFile(localPath, buffer);
+    console.log(`✓ Saved text file: ${localPath}`);
+
+    const lineCount = content.split("\n").length;
+
+    return {
+      success: true,
+      localPath,
+      fileSize: buffer.length,
+      content:
+        content.length > MAX_TEXT_CONTENT_LENGTH
+          ? content.substring(0, MAX_TEXT_CONTENT_LENGTH) + "..."
+          : content,
+      metadata: {
+        filename: originalFilename || filename,
+        encoding: "utf-8",
+        lineCount,
+      },
+    };
+  } catch (error) {
+    console.error(`✗ Failed to download text file ${url}:`, error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Check if content is valid text (not binary)
+ */
+function isValidText(content: string): boolean {
+  // Check for null bytes (common in binary files)
+  if (content.includes("\0")) {
+    return false;
+  }
+
+  // Check for excessive non-printable characters
+  const nonPrintableCount = (
+    content.match(/[\x00-\x08\x0E-\x1F\x7F-\x9F]/g) || []
+  ).length;
+  const nonPrintableRatio = nonPrintableCount / content.length;
+
+  // If more than 5% of characters are non-printable, likely binary
+  return nonPrintableRatio < 0.05;
+}
+
+/**
+ * Check if file is a supported text type
+ */
+export function isSupportedTextFile(extension: string): boolean {
+  const supportedExtensions = [
+    ".txt",
+    ".md",
+    ".csv",
+    ".json",
+    ".jsonc",
+    ".log",
+  ];
+  return supportedExtensions.includes(extension.toLowerCase());
+}
+
+/**
+ * Get appropriate MIME type for text file
+ */
+export function getTextMimeType(extension: string): string {
+  const mimeTypes: Record<string, string> = {
+    ".txt": "text/plain",
+    ".md": "text/markdown",
+    ".csv": "text/csv",
+    ".json": "application/json",
+    ".jsonc": "application/json",
+    ".log": "text/plain",
+  };
+
+  return mimeTypes[extension.toLowerCase()] || "text/plain";
+}

--- a/src/github/utils/constants.ts
+++ b/src/github/utils/constants.ts
@@ -1,0 +1,27 @@
+/**
+ * Maximum length for text content sent to LLM to optimize token usage
+ */
+export const MAX_TEXT_CONTENT_LENGTH = 10000;
+
+/**
+ * File size limits for different file types (in bytes)
+ */
+export const FILE_SIZE_LIMITS = {
+  IMAGE: 10 * 1024 * 1024, // 10MB
+  DOCUMENT: 25 * 1024 * 1024, // 25MB
+  TEXT: 25 * 1024 * 1024, // 25MB
+  ARCHIVE: 25 * 1024 * 1024, // 25MB
+  DEVELOPMENT: 25 * 1024 * 1024, // 25MB
+} as const;
+
+/**
+ * Error messages for different scenarios
+ */
+export const ERROR_MESSAGES = {
+  VIDEO_SKIP_REASON:
+    "Video files are not downloaded to optimize bandwidth and storage usage",
+  FILE_SIZE_EXCEEDED: "File size exceeds the allowed limit",
+  BINARY_FILE_DETECTED: "File appears to be binary, not text",
+  INVALID_URL: "Invalid URL: No filename found",
+  HTTP_ERROR: "HTTP request failed",
+} as const;

--- a/src/github/utils/file-type-detector.ts
+++ b/src/github/utils/file-type-detector.ts
@@ -1,0 +1,196 @@
+export interface FileTypeInfo {
+  category:
+    | "image"
+    | "document"
+    | "text"
+    | "video"
+    | "archive"
+    | "development"
+    | "unknown";
+  extension: string;
+  mimeType?: string;
+  sizeLimit: number; // bytes
+}
+
+export const SUPPORTED_FILE_TYPES = {
+  images: [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"],
+  documents: [".pdf", ".docx", ".pptx", ".xlsx", ".xls"],
+  openDocument: [
+    ".odt",
+    ".fodt",
+    ".ods",
+    ".fods",
+    ".odp",
+    ".fodp",
+    ".odg",
+    ".fodg",
+    ".odf",
+  ],
+  text: [".txt", ".md", ".csv", ".json", ".jsonc", ".log"],
+  videos: [".mp4", ".mov", ".webm"],
+  archives: [".zip", ".gz", ".tgz"],
+  development: [".patch", ".cpuprofile", ".dmp"],
+} as const;
+
+export const FILE_SIZE_LIMITS = {
+  images: 10 * 1024 * 1024, // 10MB
+  videos: 10 * 1024 * 1024, // 10MB (free plan)
+  documents: 25 * 1024 * 1024, // 25MB
+  text: 25 * 1024 * 1024, // 25MB
+  archives: 25 * 1024 * 1024, // 25MB
+  development: 25 * 1024 * 1024, // 25MB
+  default: 25 * 1024 * 1024, // 25MB
+} as const;
+
+export const URL_PATTERNS = {
+  // Existing image patterns (assets)
+  MARKDOWN_ASSETS:
+    /!\[[^\]]*\]\((https:\/\/github\.com\/user-attachments\/assets\/[^)]+)\)/g,
+  IMG_TAG_ASSETS:
+    /<img[^>]+src="(https:\/\/github\.com\/user-attachments\/assets\/[^"]+)"[^>]*>/g,
+
+  // New file attachment patterns (files)
+  MARKDOWN_FILES:
+    /\[[^\]]+\]\((https:\/\/github\.com\/user-attachments\/files\/[^)]+)\)/g,
+  IMG_TAG_FILES:
+    /<img[^>]+src="(https:\/\/github\.com\/user-attachments\/files\/[^"]+)"[^>]*>/g,
+
+  // General file attachment links
+  FILE_ATTACHMENT:
+    /\[[^\]]+\]\((https:\/\/github\.com\/user-attachments\/(?:assets|files)\/[^)]+)\)/g,
+} as const;
+
+/**
+ * Extract file extension from URL
+ */
+export function extractFileExtension(url: string): string {
+  const urlParts = url.split("/");
+  const filename = urlParts[urlParts.length - 1];
+  if (!filename) {
+    return ".unknown";
+  }
+
+  const match = filename.match(/\.([a-zA-Z0-9]+)$/i);
+  return match ? `.${match[1]!.toLowerCase()}` : ".unknown";
+}
+
+/**
+ * Get file type information from file extension
+ */
+export function getFileTypeInfo(url: string): FileTypeInfo {
+  const extension = extractFileExtension(url);
+
+  // Image files
+  if (SUPPORTED_FILE_TYPES.images.includes(extension as any)) {
+    return {
+      category: "image",
+      extension,
+      sizeLimit: FILE_SIZE_LIMITS.images,
+    };
+  }
+
+  // PDF and Office documents
+  if (
+    SUPPORTED_FILE_TYPES.documents.includes(extension as any) ||
+    SUPPORTED_FILE_TYPES.openDocument.includes(extension as any)
+  ) {
+    return {
+      category: "document",
+      extension,
+      sizeLimit: FILE_SIZE_LIMITS.documents,
+    };
+  }
+
+  // Text files
+  if (SUPPORTED_FILE_TYPES.text.includes(extension as any)) {
+    return {
+      category: "text",
+      extension,
+      sizeLimit: FILE_SIZE_LIMITS.text,
+    };
+  }
+
+  // Video files
+  if (SUPPORTED_FILE_TYPES.videos.includes(extension as any)) {
+    return {
+      category: "video",
+      extension,
+      sizeLimit: FILE_SIZE_LIMITS.videos,
+    };
+  }
+
+  // Archive files
+  if (SUPPORTED_FILE_TYPES.archives.includes(extension as any)) {
+    return {
+      category: "archive",
+      extension,
+      sizeLimit: FILE_SIZE_LIMITS.archives,
+    };
+  }
+
+  // Development files
+  if (SUPPORTED_FILE_TYPES.development.includes(extension as any)) {
+    return {
+      category: "development",
+      extension,
+      sizeLimit: FILE_SIZE_LIMITS.development,
+    };
+  }
+
+  // Unsupported files
+  return {
+    category: "unknown",
+    extension,
+    sizeLimit: FILE_SIZE_LIMITS.default,
+  };
+}
+
+/**
+ * Detect all attachment URLs from comment body
+ */
+export function detectAllAttachments(
+  body: string,
+): Array<{ url: string; type: FileTypeInfo }> {
+  const urls = new Set<string>();
+  const attachments: Array<{ url: string; type: FileTypeInfo }> = [];
+
+  // Detect URLs with each pattern
+  const patterns = [
+    URL_PATTERNS.MARKDOWN_ASSETS,
+    URL_PATTERNS.IMG_TAG_ASSETS,
+    URL_PATTERNS.MARKDOWN_FILES,
+    URL_PATTERNS.IMG_TAG_FILES,
+    URL_PATTERNS.FILE_ATTACHMENT,
+  ];
+
+  for (const pattern of patterns) {
+    const matches = [...body.matchAll(pattern)];
+    for (const match of matches) {
+      const url = match[1];
+      if (url && !urls.has(url)) {
+        urls.add(url);
+        const typeInfo = getFileTypeInfo(url);
+        attachments.push({ url, type: typeInfo });
+      }
+    }
+  }
+
+  return attachments;
+}
+
+/**
+ * Check file size (when possible before actual download)
+ */
+export function validateFileSize(
+  fileSize: number,
+  typeInfo: FileTypeInfo,
+): boolean {
+  return fileSize <= typeInfo.sizeLimit;
+}
+
+/**
+ * Check if file type is supported
+ */
+export function isSupportedFileType(typeInfo: FileTypeInfo): boolean {
+  return typeInfo.category !== "unknown";
+}

--- a/src/github/utils/github-api-types.ts
+++ b/src/github/utils/github-api-types.ts
@@ -1,0 +1,42 @@
+/**
+ * GitHub API response types for attachment processing
+ */
+
+export interface GitHubCommentResponse {
+  data: {
+    body_html?: string;
+    [key: string]: any;
+  };
+}
+
+export interface GitHubReviewResponse {
+  data: {
+    body_html?: string;
+    [key: string]: any;
+  };
+}
+
+export interface GitHubIssueResponse {
+  data: {
+    body_html?: string;
+    [key: string]: any;
+  };
+}
+
+export interface GitHubPullRequestResponse {
+  data: {
+    body_html?: string;
+    [key: string]: any;
+  };
+}
+
+/**
+ * Type guard to check if response has body_html
+ */
+export function hasBodyHtml(
+  response: any,
+): response is { data: { body_html: string } } {
+  return (
+    response && response.data && typeof response.data.body_html === "string"
+  );
+}

--- a/src/github/utils/url-utils.ts
+++ b/src/github/utils/url-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Extract original filename from URL
+ */
+export function extractFilenameFromUrl(url: string): string | null {
+  try {
+    const urlParts = url.split("/");
+    const filename = urlParts[urlParts.length - 1];
+
+    // Remove query parameters if present
+    const cleanFilename = filename?.split("?")[0];
+    return cleanFilename || null;
+  } catch {
+    return null;
+  }
+}

--- a/test/attachment-downloader.test.ts
+++ b/test/attachment-downloader.test.ts
@@ -1,0 +1,569 @@
+import {
+  describe,
+  test,
+  expect,
+  spyOn,
+  beforeEach,
+  afterEach,
+  jest,
+  setSystemTime,
+} from "bun:test";
+import fs from "fs/promises";
+import { downloadCommentAttachments } from "../src/github/utils/attachment-downloader";
+import type { CommentWithImages } from "../src/github/utils/image-downloader";
+import type { Octokits } from "../src/github/api/client";
+
+describe("downloadCommentAttachments", () => {
+  let consoleLogSpy: any;
+  let consoleWarnSpy: any;
+  let consoleErrorSpy: any;
+  let fsMkdirSpy: any;
+  let fsWriteFileSpy: any;
+  let fetchSpy: any;
+
+  beforeEach(() => {
+    // Spy on console methods
+    consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+    consoleWarnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    // Spy on fs methods
+    fsMkdirSpy = spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    fsWriteFileSpy = spyOn(fs, "writeFile").mockResolvedValue(undefined);
+
+    // Set fake system time for consistent filenames
+    setSystemTime(new Date("2024-01-01T00:00:00.000Z")); // 1704067200000
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    fsMkdirSpy.mockRestore();
+    fsWriteFileSpy.mockRestore();
+    if (fetchSpy) fetchSpy.mockRestore();
+    setSystemTime(); // Reset to real time
+  });
+
+  const createMockOctokit = (): Octokits => {
+    return {
+      rest: {
+        issues: {
+          getComment: jest.fn(),
+          get: jest.fn(),
+        },
+        pulls: {
+          getReviewComment: jest.fn(),
+          getReview: jest.fn(),
+          get: jest.fn(),
+        },
+      },
+    } as any as Octokits;
+  };
+
+  test("should create download directory", async () => {
+    const mockOctokit = createMockOctokit();
+    const comments: CommentWithImages[] = [];
+
+    await downloadCommentAttachments(mockOctokit, "owner", "repo", comments);
+
+    expect(fsMkdirSpy).toHaveBeenCalledWith("/tmp/github-attachments", {
+      recursive: true,
+    });
+  });
+
+  test("should handle comments without attachments", async () => {
+    const mockOctokit = createMockOctokit();
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "123",
+        body: "This is a comment without attachments",
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(result.attachments.size).toBe(0);
+    expect(result.summary.total).toBe(0);
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Found"),
+    );
+  });
+
+  test("should detect and download images from issue comments", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl =
+      "https://github.com/user-attachments/assets/test-image.png";
+    const signedUrl =
+      "https://private-user-images.githubusercontent.com/test.png?jwt=token";
+
+    // Mock octokit response
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl}">`,
+      },
+    });
+
+    // Mock fetch for image download
+    const mockArrayBuffer = new ArrayBuffer(8);
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => mockArrayBuffer,
+    } as Response);
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "123",
+        body: `Here's an image: ![test](${imageUrl})`,
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(result.attachments.size).toBe(1);
+    const attachment = result.attachments.get(imageUrl);
+    expect(attachment?.type).toBe("image");
+    expect(attachment?.localPath).toBe(
+      "/tmp/github-attachments/image-1704067200000-0.png",
+    );
+    expect(attachment?.fileSize).toBe(8);
+    expect(attachment?.error).toBeUndefined();
+
+    expect(result.summary.total).toBe(1);
+    expect(result.summary.successful).toBe(1);
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.byType.image).toBe(1);
+  });
+
+  test("should detect img tag format", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl =
+      "https://github.com/user-attachments/assets/test-image.jpg";
+    const signedUrl =
+      "https://private-user-images.githubusercontent.com/test.jpg?jwt=token";
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl}">`,
+      },
+    });
+
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(8),
+    } as Response);
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "123",
+        body: `Here's an image: <img src="${imageUrl}" alt="test">`,
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(result.attachments.size).toBe(1);
+    const attachment = result.attachments.get(imageUrl);
+    expect(attachment?.type).toBe("image");
+    expect(attachment?.localPath).toBe(
+      "/tmp/github-attachments/image-1704067200000-0.jpg",
+    );
+  });
+
+  test("should handle PDF documents", async () => {
+    const mockOctokit = createMockOctokit();
+    const pdfUrl = "https://github.com/user-attachments/files/document.pdf";
+    const signedUrl =
+      "https://private-user-images.githubusercontent.com/doc.pdf?jwt=token";
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<a href="${signedUrl}">document.pdf</a>`,
+      },
+    });
+
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(1024),
+    } as Response);
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "123",
+        body: `Document: [document.pdf](${pdfUrl})`,
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(result.attachments.size).toBe(1);
+    const attachment = result.attachments.get(pdfUrl);
+    expect(attachment?.type).toBe("document");
+    expect(attachment?.localPath).toBe(
+      "/tmp/github-attachments/document-1704067200000-0.pdf",
+    );
+    expect(attachment?.fileSize).toBe(1024);
+  });
+
+  test("should handle text files", async () => {
+    const mockOctokit = createMockOctokit();
+    const csvUrl = "https://github.com/user-attachments/files/data.csv";
+    const signedUrl =
+      "https://private-user-images.githubusercontent.com/data.csv?jwt=token";
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<a href="${signedUrl}">data.csv</a>`,
+      },
+    });
+
+    const csvContent = "name,age\nJohn,30\nJane,25";
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new TextEncoder().encode(csvContent).buffer,
+    } as Response);
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "123",
+        body: `Data: [data.csv](${csvUrl})`,
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(result.attachments.size).toBe(1);
+    const attachment = result.attachments.get(csvUrl);
+    expect(attachment?.type).toBe("text");
+    expect(attachment?.localPath).toBe(
+      "/tmp/github-attachments/text-1704067200000-0.csv",
+    );
+  });
+
+  test("should handle video files (metadata only)", async () => {
+    const mockOctokit = createMockOctokit();
+    const videoUrl = "https://github.com/user-attachments/assets/video.mp4";
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<a href="https://private-user-images.githubusercontent.com/video.mp4?jwt=token">video.mp4</a>`,
+      },
+    });
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "123",
+        body: `Video: [video.mp4](${videoUrl})`,
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(result.attachments.size).toBe(1);
+    const attachment = result.attachments.get(videoUrl);
+    expect(attachment?.type).toBe("video");
+    expect(attachment?.downloadSkipped).toBe(true);
+    expect(attachment?.localPath).toBeUndefined();
+    expect(result.summary.skipped).toBe(1);
+  });
+
+  test("should handle multiple file types in single comment", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl = "https://github.com/user-attachments/assets/image.png";
+    const pdfUrl = "https://github.com/user-attachments/files/doc.pdf";
+    const videoUrl = "https://github.com/user-attachments/assets/video.mp4";
+
+    const signedUrl1 =
+      "https://private-user-images.githubusercontent.com/img.png?jwt=token1";
+    const signedUrl2 =
+      "https://private-user-images.githubusercontent.com/doc.pdf?jwt=token2";
+    const signedUrl3 =
+      "https://private-user-images.githubusercontent.com/video.mp4?jwt=token3";
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl1}"><a href="${signedUrl2}">doc.pdf</a><a href="${signedUrl3}">video.mp4</a>`,
+      },
+    });
+
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(512),
+    } as Response);
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "123",
+        body: `Mixed: ![img](${imageUrl}) [doc.pdf](${pdfUrl}) [video.mp4](${videoUrl})`,
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(result.attachments.size).toBe(3);
+    expect(result.summary.total).toBe(3);
+    expect(result.summary.successful).toBe(2); // image and document
+    expect(result.summary.skipped).toBe(1); // video
+    expect(result.summary.byType.image).toBe(1);
+    expect(result.summary.byType.document).toBe(1);
+    expect(result.summary.byType.video).toBe(1);
+  });
+
+  test("should handle unsupported file types", async () => {
+    const mockOctokit = createMockOctokit();
+    const unknownUrl = "https://github.com/user-attachments/files/file.xyz";
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<a href="https://private-user-images.githubusercontent.com/file.xyz?jwt=token">file.xyz</a>`,
+      },
+    });
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "123",
+        body: `Unknown: [file.xyz](${unknownUrl})`,
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(result.attachments.size).toBe(1);
+    const attachment = result.attachments.get(unknownUrl);
+    expect(attachment?.type).toBe("unknown");
+    expect(attachment?.error).toContain("Unsupported file type");
+    expect(result.summary.failed).toBe(1);
+  });
+
+  test("should handle file size limits", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl = "https://github.com/user-attachments/assets/large.png";
+    const signedUrl =
+      "https://private-user-images.githubusercontent.com/large.png?jwt=token";
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl}">`,
+      },
+    });
+
+    // Mock a file larger than 10MB (image limit)
+    const largeBuffer = new ArrayBuffer(15 * 1024 * 1024); // 15MB
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => largeBuffer,
+    } as Response);
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "123",
+        body: `Large image: ![large](${imageUrl})`,
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(result.attachments.size).toBe(1);
+    const attachment = result.attachments.get(imageUrl);
+    expect(attachment?.type).toBe("image");
+    expect(attachment?.error).toContain("exceeds limit");
+    expect(result.summary.failed).toBe(1);
+  });
+
+  test("should skip already processed URLs", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl = "https://github.com/user-attachments/assets/duplicate.png";
+    const signedUrl =
+      "https://private-user-images.githubusercontent.com/dup.png?jwt=token";
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl}">`,
+      },
+    });
+
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(8),
+    } as Response);
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "111",
+        body: `First: ![dup](${imageUrl})`,
+      },
+      {
+        type: "issue_comment",
+        id: "222",
+        body: `Second: ![dup](${imageUrl})`,
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1); // Only downloaded once
+    expect(result.attachments.size).toBe(1);
+    expect(result.summary.successful).toBe(1);
+  });
+
+  test("should handle fetch errors", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl = "https://github.com/user-attachments/assets/error.png";
+    const signedUrl =
+      "https://private-user-images.githubusercontent.com/error.png?jwt=token";
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl}">`,
+      },
+    });
+
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    } as Response);
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "444",
+        body: `Error image: ![error](${imageUrl})`,
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(result.attachments.size).toBe(1);
+    const attachment = result.attachments.get(imageUrl);
+    expect(attachment?.type).toBe("image");
+    expect(attachment?.error).toContain("HTTP 404");
+    expect(result.summary.failed).toBe(1);
+  });
+
+  test("should generate correct summary", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl = "https://github.com/user-attachments/assets/success.png";
+    const videoUrl = "https://github.com/user-attachments/assets/video.mp4";
+    const unknownUrl = "https://github.com/user-attachments/files/unknown.xyz";
+
+    const signedUrl1 =
+      "https://private-user-images.githubusercontent.com/success.png?jwt=token1";
+    const signedUrl2 =
+      "https://private-user-images.githubusercontent.com/video.mp4?jwt=token2";
+    const signedUrl3 =
+      "https://private-user-images.githubusercontent.com/unknown.xyz?jwt=token3";
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl1}"><a href="${signedUrl2}">video.mp4</a><a href="${signedUrl3}">unknown.xyz</a>`,
+      },
+    });
+
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new ArrayBuffer(8),
+    } as Response);
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_comment",
+        id: "123",
+        body: `Mixed: ![img](${imageUrl}) [video.mp4](${videoUrl}) [unknown.xyz](${unknownUrl})`,
+      },
+    ];
+
+    const result = await downloadCommentAttachments(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(result.summary.total).toBe(3);
+    expect(result.summary.successful).toBe(1); // image
+    expect(result.summary.failed).toBe(1); // unknown
+    expect(result.summary.skipped).toBe(1); // video
+    expect(result.summary.byType).toEqual({
+      image: 1,
+      video: 1,
+      unknown: 1,
+    });
+  });
+});

--- a/test/file-type-detector.test.ts
+++ b/test/file-type-detector.test.ts
@@ -1,0 +1,294 @@
+import { describe, test, expect } from "bun:test";
+import {
+  extractFileExtension,
+  getFileTypeInfo,
+  detectAllAttachments,
+  validateFileSize,
+  isSupportedFileType,
+  SUPPORTED_FILE_TYPES,
+  FILE_SIZE_LIMITS,
+} from "../src/github/utils/file-type-detector";
+
+describe("file-type-detector", () => {
+  describe("extractFileExtension", () => {
+    test("should extract extension from URL", () => {
+      expect(
+        extractFileExtension(
+          "https://github.com/user-attachments/assets/test.png",
+        ),
+      ).toBe(".png");
+      expect(
+        extractFileExtension(
+          "https://github.com/user-attachments/assets/document.pdf",
+        ),
+      ).toBe(".pdf");
+      expect(
+        extractFileExtension(
+          "https://github.com/user-attachments/files/data.csv",
+        ),
+      ).toBe(".csv");
+    });
+
+    test("should handle URLs without extension", () => {
+      expect(
+        extractFileExtension(
+          "https://github.com/user-attachments/assets/noextension",
+        ),
+      ).toBe(".unknown");
+    });
+
+    test("should handle empty filename", () => {
+      expect(
+        extractFileExtension("https://github.com/user-attachments/assets/"),
+      ).toBe(".unknown");
+    });
+
+    test("should handle case insensitive extensions", () => {
+      expect(
+        extractFileExtension(
+          "https://github.com/user-attachments/assets/test.PNG",
+        ),
+      ).toBe(".png");
+      expect(
+        extractFileExtension(
+          "https://github.com/user-attachments/assets/doc.PDF",
+        ),
+      ).toBe(".pdf");
+    });
+  });
+
+  describe("getFileTypeInfo", () => {
+    test("should identify image files", () => {
+      const info = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/test.png",
+      );
+      expect(info.category).toBe("image");
+      expect(info.extension).toBe(".png");
+      expect(info.sizeLimit).toBe(FILE_SIZE_LIMITS.images);
+    });
+
+    test("should identify document files", () => {
+      const pdfInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/doc.pdf",
+      );
+      expect(pdfInfo.category).toBe("document");
+      expect(pdfInfo.extension).toBe(".pdf");
+      expect(pdfInfo.sizeLimit).toBe(FILE_SIZE_LIMITS.documents);
+
+      const docxInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/doc.docx",
+      );
+      expect(docxInfo.category).toBe("document");
+      expect(docxInfo.extension).toBe(".docx");
+    });
+
+    test("should identify text files", () => {
+      const txtInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/readme.txt",
+      );
+      expect(txtInfo.category).toBe("text");
+      expect(txtInfo.extension).toBe(".txt");
+      expect(txtInfo.sizeLimit).toBe(FILE_SIZE_LIMITS.text);
+
+      const jsonInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/config.json",
+      );
+      expect(jsonInfo.category).toBe("text");
+      expect(jsonInfo.extension).toBe(".json");
+    });
+
+    test("should identify video files", () => {
+      const mp4Info = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/video.mp4",
+      );
+      expect(mp4Info.category).toBe("video");
+      expect(mp4Info.extension).toBe(".mp4");
+      expect(mp4Info.sizeLimit).toBe(FILE_SIZE_LIMITS.videos);
+    });
+
+    test("should identify archive files", () => {
+      const zipInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/archive.zip",
+      );
+      expect(zipInfo.category).toBe("archive");
+      expect(zipInfo.extension).toBe(".zip");
+      expect(zipInfo.sizeLimit).toBe(FILE_SIZE_LIMITS.archives);
+    });
+
+    test("should identify development files", () => {
+      const patchInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/fix.patch",
+      );
+      expect(patchInfo.category).toBe("development");
+      expect(patchInfo.extension).toBe(".patch");
+      expect(patchInfo.sizeLimit).toBe(FILE_SIZE_LIMITS.development);
+    });
+
+    test("should handle unknown file types", () => {
+      const unknownInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/file.xyz",
+      );
+      expect(unknownInfo.category).toBe("unknown");
+      expect(unknownInfo.extension).toBe(".xyz");
+      expect(unknownInfo.sizeLimit).toBe(FILE_SIZE_LIMITS.default);
+    });
+  });
+
+  describe("detectAllAttachments", () => {
+    test("should detect markdown image links", () => {
+      const body =
+        "Here's an image: ![test](https://github.com/user-attachments/assets/test.png)";
+      const attachments = detectAllAttachments(body);
+
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0]?.url).toBe(
+        "https://github.com/user-attachments/assets/test.png",
+      );
+      expect(attachments[0]?.type.category).toBe("image");
+    });
+
+    test("should detect img tag links", () => {
+      const body =
+        'Here is an image: <img src="https://github.com/user-attachments/assets/test.jpg" alt="test">';
+      const attachments = detectAllAttachments(body);
+
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0]?.url).toBe(
+        "https://github.com/user-attachments/assets/test.jpg",
+      );
+      expect(attachments[0]?.type.category).toBe("image");
+    });
+
+    test("should detect file attachments", () => {
+      const body =
+        "Document: [report.pdf](https://github.com/user-attachments/files/report.pdf)";
+      const attachments = detectAllAttachments(body);
+
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0]?.url).toBe(
+        "https://github.com/user-attachments/files/report.pdf",
+      );
+      expect(attachments[0]?.type.category).toBe("document");
+    });
+
+    test("should detect multiple attachments", () => {
+      const body = `
+        Image: ![img](https://github.com/user-attachments/assets/image.png)
+        Document: [doc.pdf](https://github.com/user-attachments/files/document.pdf)
+        Text: [data.csv](https://github.com/user-attachments/files/data.csv)
+      `;
+      const attachments = detectAllAttachments(body);
+
+      expect(attachments).toHaveLength(3);
+      expect(attachments.map((a) => a.type.category)).toEqual([
+        "image",
+        "document",
+        "text",
+      ]);
+    });
+
+    test("should deduplicate URLs", () => {
+      const body = `
+        ![img1](https://github.com/user-attachments/assets/test.png)
+        ![img2](https://github.com/user-attachments/assets/test.png)
+      `;
+      const attachments = detectAllAttachments(body);
+
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0]?.url).toBe(
+        "https://github.com/user-attachments/assets/test.png",
+      );
+    });
+
+    test("should handle mixed patterns", () => {
+      const body = `
+        Markdown: ![img](https://github.com/user-attachments/assets/image.png)
+        HTML: <img src="https://github.com/user-attachments/assets/photo.jpg">
+        File: [document.pdf](https://github.com/user-attachments/files/doc.pdf)
+      `;
+      const attachments = detectAllAttachments(body);
+
+      expect(attachments).toHaveLength(3);
+      expect(attachments.map((a) => a.type.category)).toEqual([
+        "image",
+        "image",
+        "document",
+      ]);
+    });
+  });
+
+  describe("validateFileSize", () => {
+    test("should validate file size within limits", () => {
+      const imageInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/test.png",
+      );
+      expect(validateFileSize(5 * 1024 * 1024, imageInfo)).toBe(true); // 5MB < 10MB limit
+      expect(validateFileSize(15 * 1024 * 1024, imageInfo)).toBe(false); // 15MB > 10MB limit
+    });
+
+    test("should validate document file size", () => {
+      const docInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/doc.pdf",
+      );
+      expect(validateFileSize(20 * 1024 * 1024, docInfo)).toBe(true); // 20MB < 25MB limit
+      expect(validateFileSize(30 * 1024 * 1024, docInfo)).toBe(false); // 30MB > 25MB limit
+    });
+  });
+
+  describe("isSupportedFileType", () => {
+    test("should identify supported file types", () => {
+      const imageInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/test.png",
+      );
+      expect(isSupportedFileType(imageInfo)).toBe(true);
+
+      const docInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/doc.pdf",
+      );
+      expect(isSupportedFileType(docInfo)).toBe(true);
+
+      const textInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/data.csv",
+      );
+      expect(isSupportedFileType(textInfo)).toBe(true);
+    });
+
+    test("should identify unsupported file types", () => {
+      const unknownInfo = getFileTypeInfo(
+        "https://github.com/user-attachments/assets/file.xyz",
+      );
+      expect(isSupportedFileType(unknownInfo)).toBe(false);
+    });
+  });
+
+  describe("constants", () => {
+    test("should have correct supported file types", () => {
+      expect(SUPPORTED_FILE_TYPES.images).toContain(".png");
+      expect(SUPPORTED_FILE_TYPES.images).toContain(".jpg");
+      expect(SUPPORTED_FILE_TYPES.images).toContain(".svg");
+
+      expect(SUPPORTED_FILE_TYPES.documents).toContain(".pdf");
+      expect(SUPPORTED_FILE_TYPES.documents).toContain(".docx");
+
+      expect(SUPPORTED_FILE_TYPES.text).toContain(".txt");
+      expect(SUPPORTED_FILE_TYPES.text).toContain(".json");
+      expect(SUPPORTED_FILE_TYPES.text).toContain(".csv");
+
+      expect(SUPPORTED_FILE_TYPES.videos).toContain(".mp4");
+      expect(SUPPORTED_FILE_TYPES.videos).toContain(".mov");
+
+      expect(SUPPORTED_FILE_TYPES.archives).toContain(".zip");
+      expect(SUPPORTED_FILE_TYPES.development).toContain(".patch");
+    });
+
+    test("should have correct file size limits", () => {
+      expect(FILE_SIZE_LIMITS.images).toBe(10 * 1024 * 1024); // 10MB
+      expect(FILE_SIZE_LIMITS.videos).toBe(10 * 1024 * 1024); // 10MB
+      expect(FILE_SIZE_LIMITS.documents).toBe(25 * 1024 * 1024); // 25MB
+      expect(FILE_SIZE_LIMITS.text).toBe(25 * 1024 * 1024); // 25MB
+      expect(FILE_SIZE_LIMITS.archives).toBe(25 * 1024 * 1024); // 25MB
+      expect(FILE_SIZE_LIMITS.development).toBe(25 * 1024 * 1024); // 25MB
+      expect(FILE_SIZE_LIMITS.default).toBe(25 * 1024 * 1024); // 25MB
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Expands GitHub attachment support from images-only to all supported file types while maintaining full backward compatibility. Adds support for documents, text files, videos, archives, and development files.

## Changes

### Core Implementation
- **New attachment system**: `attachment-downloader.ts` orchestrates all file types
- **File type detection**: `file-type-detector.ts` with comprehensive pattern matching  
- **Processor pattern**: Modular processors in `attachment-processors/` directory
  - `image-processor.ts` - Enhanced image handling
  - `document-processor.ts` - PDF, MS Office, OpenDocument support
  - `text-processor.ts` - CSV, JSON, MD, TXT, LOG files
  - `media-processor.ts` - Videos, archives, development files

### Supported File Types
- **Images** (10MB): PNG, JPG, GIF, WebP, SVG
- **Documents** (25MB): PDF, MS Office, OpenDocument formats
- **Text Files** (25MB): TXT, MD, CSV, JSON, LOG
- **Videos** (metadata only): MP4, MOV, WebM  
- **Archives** (25MB): ZIP, GZ, TGZ
- **Development** (25MB): PATCH, CPU profiles, DMP files

### Integration
- **Backward compatibility**: Existing `image-downloader.ts` functionality preserved
- **Migration**: `fetcher.ts` uses new system while maintaining old interface
- **Error handling**: File size validation, binary detection, graceful degradation
