### PR TITLE
docs: clarify agent mode only works with workflow_dispatch and schedule events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Execution steps:
 #### Mode System (`src/modes/`)
 
 - **Tag Mode** (`tag/`): Responds to `@claude` mentions and issue assignments
-- **Agent Mode** (`agent/`): Automated execution without trigger checking
+- **Agent Mode** (`agent/`): Automated execution for workflow_dispatch and schedule events only
 - Extensible registry pattern in `modes/registry.ts`
 
 #### GitHub Integration (`src/github/`)
@@ -118,7 +118,7 @@ src/
 
 - Modes implement `Mode` interface with `shouldTrigger()` and `prepare()` methods
 - Registry validates mode compatibility with GitHub event types
-- Agent mode bypasses all trigger checking for automation scenarios
+- Agent mode only works with workflow_dispatch and schedule events
 
 ### Comment Threading
 

--- a/README.md
+++ b/README.md
@@ -167,36 +167,36 @@ jobs:
 
 ## Inputs
 
-| Input                          | Description                                                                                                            | Required | Default   |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
-| `mode`                         | Execution mode: 'tag' (default - triggered by mentions/assignments), 'agent' (for automation with no trigger checking) | No       | `tag`     |
-| `anthropic_api_key`            | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                             | No\*     | -         |
-| `claude_code_oauth_token`      | Claude Code OAuth token (alternative to anthropic_api_key)                                                             | No\*     | -         |
-| `direct_prompt`                | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)                  | No       | -         |
-| `override_prompt`              | Complete replacement of Claude's prompt with custom template (supports variable substitution)                          | No       | -         |
-| `base_branch`                  | The base branch to use for creating new branches (e.g., 'main', 'develop')                                             | No       | -         |
-| `max_turns`                    | Maximum number of conversation turns Claude can take (limits back-and-forth exchanges)                                 | No       | -         |
-| `timeout_minutes`              | Timeout in minutes for execution                                                                                       | No       | `30`      |
-| `use_sticky_comment`           | Use just one comment to deliver PR comments (only applies for pull_request event workflows)                            | No       | `false`   |
-| `github_token`                 | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!**   | No       | -         |
-| `model`                        | Model to use (provider-specific format required for Bedrock/Vertex)                                                    | No       | -         |
-| `fallback_model`               | Enable automatic fallback to specified model when primary model is unavailable                                         | No       | -         |
-| `anthropic_model`              | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                  | No       | -         |
-| `use_bedrock`                  | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                            | No       | `false`   |
-| `use_vertex`                   | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                          | No       | `false`   |
-| `allowed_tools`                | Additional tools for Claude to use (the base GitHub tools will always be included)                                     | No       | ""        |
-| `disallowed_tools`             | Tools that Claude should never use                                                                                     | No       | ""        |
-| `custom_instructions`          | Additional custom instructions to include in the prompt for Claude                                                     | No       | ""        |
-| `mcp_config`                   | Additional MCP configuration (JSON string) that merges with the built-in GitHub MCP servers                            | No       | ""        |
-| `assignee_trigger`             | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                          | No       | -         |
-| `label_trigger`                | The label name that triggers the action when applied to an issue (e.g. "claude")                                       | No       | -         |
-| `trigger_phrase`               | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                          | No       | `@claude` |
-| `branch_prefix`                | The prefix to use for Claude branches (defaults to 'claude/', use 'claude-' for dash format)                           | No       | `claude/` |
-| `claude_env`                   | Custom environment variables to pass to Claude Code execution (YAML format)                                            | No       | ""        |
-| `settings`                     | Claude Code settings as JSON string or path to settings JSON file                                                      | No       | ""        |
-| `additional_permissions`       | Additional permissions to enable. Currently supports 'actions: read' for viewing workflow results                      | No       | ""        |
-| `experimental_allowed_domains` | Restrict network access to these domains only (newline-separated).                                                     | No       | ""        |
-| `use_commit_signing`           | Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands      | No       | `false`   |
+| Input                          | Description                                                                                                               | Required | Default   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
+| `mode`                         | Execution mode: 'tag' (default - triggered by mentions/assignments), 'agent' (for workflow_dispatch/schedule events only) | No       | `tag`     |
+| `anthropic_api_key`            | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                                | No\*     | -         |
+| `claude_code_oauth_token`      | Claude Code OAuth token (alternative to anthropic_api_key)                                                                | No\*     | -         |
+| `direct_prompt`                | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)                     | No       | -         |
+| `override_prompt`              | Complete replacement of Claude's prompt with custom template (supports variable substitution)                             | No       | -         |
+| `base_branch`                  | The base branch to use for creating new branches (e.g., 'main', 'develop')                                                | No       | -         |
+| `max_turns`                    | Maximum number of conversation turns Claude can take (limits back-and-forth exchanges)                                    | No       | -         |
+| `timeout_minutes`              | Timeout in minutes for execution                                                                                          | No       | `30`      |
+| `use_sticky_comment`           | Use just one comment to deliver PR comments (only applies for pull_request event workflows)                               | No       | `false`   |
+| `github_token`                 | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!**      | No       | -         |
+| `model`                        | Model to use (provider-specific format required for Bedrock/Vertex)                                                       | No       | -         |
+| `fallback_model`               | Enable automatic fallback to specified model when primary model is unavailable                                            | No       | -         |
+| `anthropic_model`              | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                     | No       | -         |
+| `use_bedrock`                  | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                               | No       | `false`   |
+| `use_vertex`                   | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                             | No       | `false`   |
+| `allowed_tools`                | Additional tools for Claude to use (the base GitHub tools will always be included)                                        | No       | ""        |
+| `disallowed_tools`             | Tools that Claude should never use                                                                                        | No       | ""        |
+| `custom_instructions`          | Additional custom instructions to include in the prompt for Claude                                                        | No       | ""        |
+| `mcp_config`                   | Additional MCP configuration (JSON string) that merges with the built-in GitHub MCP servers                               | No       | ""        |
+| `assignee_trigger`             | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                             | No       | -         |
+| `label_trigger`                | The label name that triggers the action when applied to an issue (e.g. "claude")                                          | No       | -         |
+| `trigger_phrase`               | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                             | No       | `@claude` |
+| `branch_prefix`                | The prefix to use for Claude branches (defaults to 'claude/', use 'claude-' for dash format)                              | No       | `claude/` |
+| `claude_env`                   | Custom environment variables to pass to Claude Code execution (YAML format)                                               | No       | ""        |
+| `settings`                     | Claude Code settings as JSON string or path to settings JSON file                                                         | No       | ""        |
+| `additional_permissions`       | Additional permissions to enable. Currently supports 'actions: read' for viewing workflow results                         | No       | ""        |
+| `experimental_allowed_domains` | Restrict network access to these domains only (newline-separated).                                                        | No       | ""        |
+| `use_commit_signing`           | Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands         | No       | `false`   |
 
 \*Required when using direct Anthropic API (default and when not using Bedrock or Vertex)
 
@@ -223,19 +223,30 @@ The traditional implementation mode that responds to @claude mentions, issue ass
 
 ### Agent Mode
 
-For automation and scheduled tasks without trigger checking.
+For automation with workflow_dispatch and scheduled events only.
 
-- **Triggers**: Always runs (no trigger checking)
-- **Features**: Perfect for scheduled tasks, works with `override_prompt`
-- **Use case**: Maintenance tasks, automated reporting, scheduled checks
+- **Triggers**: Only runs on `workflow_dispatch` and `schedule` events
+- **Features**: Bypasses mention/assignment checking for automation scenarios
+- **Use case**: Manual workflow runs, scheduled maintenance tasks, cron jobs
+- **Note**: Does NOT work with `pull_request`, `issues`, or `issue_comment` events
 
 ```yaml
-- uses: anthropics/claude-code-action@beta
-  with:
-    mode: agent
-    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-    override_prompt: |
-      Check for outdated dependencies and create an issue if any are found.
+# Example with workflow_dispatch
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # Weekly on Sunday
+
+jobs:
+  automated-task:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@beta
+        with:
+          mode: agent
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          override_prompt: |
+            Check for outdated dependencies and create an issue if any are found.
 ```
 
 See [`examples/claude-modes.yml`](./examples/claude-modes.yml) for complete examples of each mode.

--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ The traditional implementation mode that responds to @claude mentions, issue ass
 
 ### Agent Mode
 
-For automation with workflow_dispatch and scheduled events only.
+**Note: Agent mode is currently in active development and may undergo breaking changes.**
+
+For automation with workflow_dis`patch and scheduled events only.
 
 - **Triggers**: Only runs on `workflow_dispatch` and `schedule` events
 - **Features**: Bypasses mention/assignment checking for automation scenarios

--- a/examples/claude-modes.yml
+++ b/examples/claude-modes.yml
@@ -1,13 +1,17 @@
 name: Claude Mode Examples
 
 on:
-  # Common events for both modes
+  # Events for tag mode
   issue_comment:
     types: [created]
   issues:
     types: [opened, labeled]
   pull_request:
     types: [opened]
+  # Events for agent mode (only these work with agent mode)
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday
 
 jobs:
   # Tag Mode (Default) - Traditional implementation
@@ -28,13 +32,12 @@ jobs:
           # - Creates tracking comments with progress checkboxes
           # - Perfect for: Interactive Q&A, on-demand code changes
 
-  # Agent Mode - Automation without triggers
-  agent-mode-auto-review:
-    # Automatically review every new PR
-    if: github.event_name == 'pull_request' && github.event.action == 'opened'
+  # Agent Mode - Automation for workflow_dispatch and schedule events
+  agent-mode-scheduled-task:
+    # Only works with workflow_dispatch or schedule events
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write
@@ -44,13 +47,10 @@ jobs:
           mode: agent
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           override_prompt: |
-            Review this PR for code quality. Focus on:
-            - Potential bugs or logic errors
-            - Security concerns
-            - Performance issues
-
-            Provide specific, actionable feedback.
+            Check for outdated dependencies and security vulnerabilities.
+            Create an issue if any critical problems are found.
           # Agent mode behavior:
-          # - NO @claude mention needed - runs immediately
-          # - Enables true automation (impossible with tag mode)
-          # - Perfect for: CI/CD integration, automatic reviews, label-based workflows
+          # - ONLY works with workflow_dispatch and schedule events
+          # - Does NOT work with pull_request, issues, or issue_comment events
+          # - No @claude mention needed for supported events
+          # - Perfect for: scheduled maintenance, manual automation runs

--- a/examples/claude-modes.yml
+++ b/examples/claude-modes.yml
@@ -11,7 +11,7 @@ on:
   # Events for agent mode (only these work with agent mode)
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0'  # Weekly on Sunday
+    - cron: "0 0 * * 0" # Weekly on Sunday
 
 jobs:
   # Tag Mode (Default) - Traditional implementation


### PR DESCRIPTION
## Summary
- Updates documentation to accurately reflect that agent mode only works with `workflow_dispatch` and `schedule` events
- Addresses confusion reported in issues #364 and #376

## Changes
- Updated README.md to clearly state agent mode limitations
- Added explicit note that agent mode does NOT work with `pull_request`, `issues`, or `issue_comment` events
- Updated example workflows to only show supported event types
- Updated CLAUDE.md internal documentation to match implementation

## Related Issues
Fixes #364 
Fixes #376

## Test Plan
Documentation-only change. The updated documentation now accurately reflects the current implementation behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)