### PR TITLE
feat: add MCP servers to agent mode

### DIFF
--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 import { GITHUB_API_URL, GITHUB_SERVER_URL } from "../github/api/config";
 import type { GitHubContext } from "../github/context";
+import { isEntityContext } from "../github/context";
 import { Octokit } from "@octokit/rest";
 
 type PrepareConfigParams = {
@@ -115,7 +116,7 @@ export async function prepareMcpConfig(
     const hasActionsReadPermission =
       context.inputs.additionalPermissions.get("actions") === "read";
 
-    if ("isPR" in context && context.isPR && hasActionsReadPermission) {
+    if (isEntityContext(context) && context.isPR && hasActionsReadPermission) {
       // Verify the token actually has actions:read permission
       const actuallyHasPermission = await checkActionsReadPermission(
         process.env.ACTIONS_TOKEN || "",
@@ -141,10 +142,9 @@ export async function prepareMcpConfig(
           GITHUB_TOKEN: process.env.ACTIONS_TOKEN,
           REPO_OWNER: owner,
           REPO_NAME: repo,
-          PR_NUMBER:
-            "entityNumber" in context
-              ? context.entityNumber?.toString() || ""
-              : "",
+          PR_NUMBER: isEntityContext(context)
+            ? context.entityNumber?.toString() || ""
+            : "",
           RUNNER_TEMP: process.env.RUNNER_TEMP || "/tmp",
         },
       };

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -1,6 +1,6 @@
 import * as core from "@actions/core";
 import { GITHUB_API_URL, GITHUB_SERVER_URL } from "../github/api/config";
-import type { ParsedGitHubContext } from "../github/context";
+import type { GitHubContext } from "../github/context";
 import { Octokit } from "@octokit/rest";
 
 type PrepareConfigParams = {
@@ -12,7 +12,7 @@ type PrepareConfigParams = {
   additionalMcpConfig?: string;
   claudeCommentId?: string;
   allowedTools: string[];
-  context: ParsedGitHubContext;
+  context: GitHubContext;
 };
 
 async function checkActionsReadPermission(
@@ -115,7 +115,7 @@ export async function prepareMcpConfig(
     const hasActionsReadPermission =
       context.inputs.additionalPermissions.get("actions") === "read";
 
-    if (context.isPR && hasActionsReadPermission) {
+    if ('isPR' in context && context.isPR && hasActionsReadPermission) {
       // Verify the token actually has actions:read permission
       const actuallyHasPermission = await checkActionsReadPermission(
         process.env.ACTIONS_TOKEN || "",
@@ -141,7 +141,7 @@ export async function prepareMcpConfig(
           GITHUB_TOKEN: process.env.ACTIONS_TOKEN,
           REPO_OWNER: owner,
           REPO_NAME: repo,
-          PR_NUMBER: context.entityNumber?.toString() || "",
+          PR_NUMBER: 'entityNumber' in context ? context.entityNumber?.toString() || "" : "",
           RUNNER_TEMP: process.env.RUNNER_TEMP || "/tmp",
         },
       };

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -115,7 +115,7 @@ export async function prepareMcpConfig(
     const hasActionsReadPermission =
       context.inputs.additionalPermissions.get("actions") === "read";
 
-    if ('isPR' in context && context.isPR && hasActionsReadPermission) {
+    if ("isPR" in context && context.isPR && hasActionsReadPermission) {
       // Verify the token actually has actions:read permission
       const actuallyHasPermission = await checkActionsReadPermission(
         process.env.ACTIONS_TOKEN || "",
@@ -141,7 +141,10 @@ export async function prepareMcpConfig(
           GITHUB_TOKEN: process.env.ACTIONS_TOKEN,
           REPO_OWNER: owner,
           REPO_NAME: repo,
-          PR_NUMBER: 'entityNumber' in context ? context.entityNumber?.toString() || "" : "",
+          PR_NUMBER:
+            "entityNumber" in context
+              ? context.entityNumber?.toString() || ""
+              : "",
           RUNNER_TEMP: process.env.RUNNER_TEMP || "/tmp",
         },
       };

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -1,7 +1,6 @@
 import * as core from "@actions/core";
 import type { Mode, ModeOptions, ModeResult } from "../types";
 import { isAutomationContext } from "../../github/context";
-import type { PreparedContext } from "../../create-prompt/types";
 import { prepareMcpConfig } from "../../mcp/install-mcp-server";
 
 /**
@@ -93,19 +92,5 @@ export const agentMode: Mode = {
       },
       mcpConfig: mcpConfig,
     };
-  },
-
-  generatePrompt(context: PreparedContext): string {
-    // Agent mode uses override or direct prompt, no GitHub data needed
-    if (context.overridePrompt) {
-      return context.overridePrompt;
-    }
-
-    if (context.directPrompt) {
-      return context.directPrompt;
-    }
-
-    // Minimal fallback - repository is a string in PreparedContext
-    return `Repository: ${context.repository}`;
   },
 };


### PR DESCRIPTION
## Summary

- Enables full MCP server capabilities in agent mode (previously had empty MCP config)
- Updates `prepareMcpConfig` to handle both entity contexts (PRs/issues) and automation contexts (workflow_dispatch/schedule)
- Allows bot actors to access Claude's full tool capabilities via agent mode

## Context

Agent mode was designed for automation events but had minimal MCP configuration. This limited its usefulness for scenarios where automated workflows need access to GitHub tools (comments, file operations, CI tools, etc).

## Changes

1. Updated agent mode to call `prepareMcpConfig` instead of using an empty MCP configuration
2. Modified `prepareMcpConfig` to accept both `ParsedGitHubContext` and `AutomationContext` types
3. Added type guards (`'isPR' in context`) to safely handle context-specific properties

## Benefits

- Bot actors can now use workflow_dispatch to trigger Claude with full MCP capabilities
- Users can control which tools are available via the `allowed_tools` parameter
- Consistent MCP configuration across all modes
- Enables more powerful automation workflows

## Testing

- All existing tests pass
- Type checking passes with the updated context types