### PR TITLE
refactor: rename ACTIONS_TOKEN to DEFAULT_WORKFLOW_TOKEN

### DIFF
--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -118,7 +118,7 @@ export async function prepareMcpConfig(
     if (context.isPR && hasActionsReadPermission) {
       // Verify the token actually has actions:read permission
       const actuallyHasPermission = await checkActionsReadPermission(
-        process.env.ACTIONS_TOKEN || "",
+        process.env.DEFAULT_WORKFLOW_TOKEN || "",
         owner,
         repo,
       );
@@ -138,7 +138,7 @@ export async function prepareMcpConfig(
         ],
         env: {
           // Use workflow github token, not app token
-          GITHUB_TOKEN: process.env.ACTIONS_TOKEN,
+          GITHUB_TOKEN: process.env.DEFAULT_WORKFLOW_TOKEN,
           REPO_OWNER: owner,
           REPO_NAME: repo,
           PR_NUMBER: context.entityNumber?.toString() || "",

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -547,8 +547,8 @@ describe("prepareMcpConfig", () => {
   });
 
   test("should include github_ci server when context.isPR is true and actions:read permission is granted", async () => {
-    const oldEnv = process.env.ACTIONS_TOKEN;
-    process.env.ACTIONS_TOKEN = "workflow-token";
+    const oldEnv = process.env.DEFAULT_WORKFLOW_TOKEN;
+    process.env.DEFAULT_WORKFLOW_TOKEN = "workflow-token";
 
     const contextWithPermissions = {
       ...mockPRContext,
@@ -575,7 +575,7 @@ describe("prepareMcpConfig", () => {
     expect(parsed.mcpServers.github_ci.env.PR_NUMBER).toBe("456");
     expect(parsed.mcpServers.github_file_ops).toBeDefined();
 
-    process.env.ACTIONS_TOKEN = oldEnv;
+    process.env.DEFAULT_WORKFLOW_TOKEN = oldEnv;
   });
 
   test("should not include github_ci server when context.isPR is false", async () => {
@@ -595,8 +595,8 @@ describe("prepareMcpConfig", () => {
   });
 
   test("should not include github_ci server when actions:read permission is not granted", async () => {
-    const oldTokenEnv = process.env.ACTIONS_TOKEN;
-    process.env.ACTIONS_TOKEN = "workflow-token";
+    const oldTokenEnv = process.env.DEFAULT_WORKFLOW_TOKEN;
+    process.env.DEFAULT_WORKFLOW_TOKEN = "workflow-token";
 
     const result = await prepareMcpConfig({
       githubToken: "test-token",
@@ -612,12 +612,12 @@ describe("prepareMcpConfig", () => {
     expect(parsed.mcpServers.github_ci).not.toBeDefined();
     expect(parsed.mcpServers.github_file_ops).toBeDefined();
 
-    process.env.ACTIONS_TOKEN = oldTokenEnv;
+    process.env.DEFAULT_WORKFLOW_TOKEN = oldTokenEnv;
   });
 
   test("should parse additional_permissions with multiple lines correctly", async () => {
-    const oldTokenEnv = process.env.ACTIONS_TOKEN;
-    process.env.ACTIONS_TOKEN = "workflow-token";
+    const oldTokenEnv = process.env.DEFAULT_WORKFLOW_TOKEN;
+    process.env.DEFAULT_WORKFLOW_TOKEN = "workflow-token";
 
     const contextWithPermissions = {
       ...mockPRContext,
@@ -644,12 +644,12 @@ describe("prepareMcpConfig", () => {
     expect(parsed.mcpServers.github_ci).toBeDefined();
     expect(parsed.mcpServers.github_ci.env.GITHUB_TOKEN).toBe("workflow-token");
 
-    process.env.ACTIONS_TOKEN = oldTokenEnv;
+    process.env.DEFAULT_WORKFLOW_TOKEN = oldTokenEnv;
   });
 
   test("should warn when actions:read is requested but token lacks permission", async () => {
-    const oldTokenEnv = process.env.ACTIONS_TOKEN;
-    process.env.ACTIONS_TOKEN = "invalid-token";
+    const oldTokenEnv = process.env.DEFAULT_WORKFLOW_TOKEN;
+    process.env.DEFAULT_WORKFLOW_TOKEN = "invalid-token";
 
     const contextWithPermissions = {
       ...mockPRContext,
@@ -677,6 +677,6 @@ describe("prepareMcpConfig", () => {
       ),
     );
 
-    process.env.ACTIONS_TOKEN = oldTokenEnv;
+    process.env.DEFAULT_WORKFLOW_TOKEN = oldTokenEnv;
   });
 });


### PR DESCRIPTION
Regression from https://github.com/anthropics/claude-code-action/pull/374

Updated all references from ACTIONS_TOKEN to DEFAULT_WORKFLOW_TOKEN to match the naming convention used in action.yml where the GitHub token is passed as DEFAULT_WORKFLOW_TOKEN environment variable.