### PR TITLE
fix: clear CLAUDE_CODE_OAUTH_TOKEN in env validation tests

### DIFF
--- a/base-action/test/validate-env.test.ts
+++ b/base-action/test/validate-env.test.ts
@@ -11,6 +11,7 @@ describe("validateEnvironmentVariables", () => {
     originalEnv = { ...process.env };
     // Clear relevant environment variables
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
     delete process.env.CLAUDE_CODE_USE_BEDROCK;
     delete process.env.CLAUDE_CODE_USE_VERTEX;
     delete process.env.AWS_REGION;


### PR DESCRIPTION
## Summary
• Fixed test isolation issue in environment variable validation tests
• Added clearing of `CLAUDE_CODE_OAUTH_TOKEN` in `beforeEach()` to match `ANTHROPIC_API_KEY` clearing
• Ensures tests properly validate missing authentication scenarios

## Test plan
- [x] Run `bun test test/validate-env.test.ts` to verify all validation tests pass
- [x] Confirm test correctly fails when both auth tokens are missing
- [x] Verify test environment isolation works regardless of host environment variables

🤖 Generated with [Claude Code](https://claude.ai/code)