### PR TITLE
Fix test environment variable cleanup for CLAUDE_CODE_OAUTH_TOKEN

### DIFF
--- a/base-action/test/validate-env.test.ts
+++ b/base-action/test/validate-env.test.ts
@@ -11,6 +11,7 @@ describe("validateEnvironmentVariables", () => {
     originalEnv = { ...process.env };
     // Clear relevant environment variables
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
     delete process.env.CLAUDE_CODE_USE_BEDROCK;
     delete process.env.CLAUDE_CODE_USE_VERTEX;
     delete process.env.AWS_REGION;
@@ -36,7 +37,13 @@ describe("validateEnvironmentVariables", () => {
       expect(() => validateEnvironmentVariables()).not.toThrow();
     });
 
-    test("should fail when ANTHROPIC_API_KEY is missing", () => {
+    test("should pass when CLAUDE_CODE_OAUTH_TOKEN is provided", () => {
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = "test-oauth-token";
+
+      expect(() => validateEnvironmentVariables()).not.toThrow();
+    });
+
+    test("should fail when both ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN are missing", () => {
       expect(() => validateEnvironmentVariables()).toThrow(
         "Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.",
       );


### PR DESCRIPTION
## Summary

- Fix test failure when `CLAUDE_CODE_OAUTH_TOKEN` is present in environment
- Add `CLAUDE_CODE_OAUTH_TOKEN` to test environment cleanup in `beforeEach()`
- Add test case to verify `CLAUDE_CODE_OAUTH_TOKEN` works as alternative to `ANTHROPIC_API_KEY`
- Update test description to accurately reflect what is being tested

## Problem

The test `should fail when ANTHROPIC_API_KEY is missing` was failing because it expected `validateEnvironmentVariables()` to throw an error when `ANTHROPIC_API_KEY` is missing, but the function only throws when **both** `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` are missing. Since the OAuth token was present in the test environment (from the user's system), the test was not properly isolated.

## Solution

1. Added `delete process.env.CLAUDE_CODE_OAUTH_TOKEN;` to the `beforeEach()` cleanup
2. Added a new test case: `should pass when CLAUDE_CODE_OAUTH_TOKEN is provided`
3. Updated the failing test description to be more accurate: `should fail when both ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN are missing`

## Test Results

All tests now pass (352 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.ai/code)