### PR TITLE
fix: Error comparing non-existent remote branch

### DIFF
--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -110,7 +110,7 @@ async function run() {
     // Check if we need to add PR URL when we have a new branch
     let prLink = "";
     // If claudeBranch is set, it means we created a new branch (for issues or closed/merged PRs)
-    if (claudeBranch && !shouldDeleteBranch) {
+    if (branchLink && claudeBranch && !shouldDeleteBranch) {
       // Check if comment already contains a PR URL
       const serverUrlPattern = serverUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const prUrlPattern = new RegExp(


### PR DESCRIPTION
fix: #271 

## Description

When updating a comment, a PR link is added. This step compares the branch name created by Claude with the remote repository. However, the problem is that the locally created branch has not been pushed to the remote repository, which causes the comparison to fail. A suspected cause is that in this PR https://github.com/anthropics/claude-code-action/pull/244, the branch update operation was delayed, while the action to add the PR link occurs before it.

Additionally, the naming of the `checkAndCommitOrDeleteBranch` function seems problematic. The name is misleading because it implies that the function will automatically commit a new local branch. However, in reality, the function only processes its logic when the remote branch already exists, which is a clear contradiction.

## Solution

Assume the PR link is already included in Claude's response, then just skip the manual PR creation step in the action. This is a minimal change and can be easily rolled back even if it doesn't take effect.