### PR TITLE
feat: add exec_user input for customizable action execution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -110,6 +110,10 @@ inputs:
     description: "Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands"
     required: false
     default: "false"
+  exec_user:
+    description: "The user to execute claude-code as. If not set, the action will run as the default user."
+    required: false
+    default: ""
   experimental_allowed_domains:
     description: "Restrict network access to these domains only (newline-separated). If not set, no restrictions are applied. Provider domains are auto-detected."
     required: false
@@ -188,9 +192,12 @@ runs:
       if: steps.prepare.outputs.contains_trigger == 'true'
       shell: bash
       run: |
-
-        # Run the base-action
-        bun run ${GITHUB_ACTION_PATH}/base-action/src/index.ts
+        EXEC_USER=${{ inputs.exec_user }}
+        if [ -n "$EXEC_USER" ]; then
+          sudo -E -u $EXEC_USER bun run ${GITHUB_ACTION_PATH}/base-action/src/index.ts
+        else
+          bun run ${GITHUB_ACTION_PATH}/base-action/src/index.ts
+        fi
       env:
         # Base-action inputs
         CLAUDE_CODE_ACTION: "1"


### PR DESCRIPTION
- Introduced `exec_user` input to allow specifying a user for executing the action.
- Updated the action's run command to conditionally use the specified user if provided, enhancing flexibility in execution context.