### PR TITLE
fix: review mode not triggering on draft to ready transitions

### DIFF
--- a/src/modes/review/index.ts
+++ b/src/modes/review/index.ts
@@ -39,7 +39,12 @@ export const reviewMode: Mode = {
 
     // For pull_request events, only trigger on specific actions
     if (isPullRequestEvent(context)) {
-      const allowedActions = ["opened", "synchronize", "reopened"];
+      const allowedActions = [
+        "opened",
+        "synchronize",
+        "reopened",
+        "ready_for_review",
+      ];
       const action = context.payload.action;
       return allowedActions.includes(action);
     }


### PR DESCRIPTION
When a PR transitions from draft to ready for review, GitHub triggers a `ready_for_review` event. However, this event wasn't included in the review mode's `shouldTrigger` method, causing the action to exit early with "No trigger found, skipping remaining steps".

### What changed
- Added `ready_for_review` to the list of allowed actions in review mode
- This enables automatic code reviews when draft PRs are marked as ready

### Why
This ensures that PRs receive automated reviews regardless of whether they were created as ready for review or transitioned from draft status, providing a more consistent review experience.