### PR TITLE
Update documentation incorrectly reverted after refactor

### DIFF
--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -4,7 +4,7 @@
 
 ## Execution Modes
 
-The action supports two execution modes, each optimized for different use cases:
+The action supports three execution modes, each optimized for different use cases:
 
 ### Tag Mode (Default)
 
@@ -23,9 +23,11 @@ The traditional implementation mode that responds to @claude mentions, issue ass
 
 ### Agent Mode
 
-For automation and scheduled tasks without trigger checking.
+**Note: Agent mode is currently in active development and may undergo breaking changes.**
 
-- **Triggers**: Always runs (no trigger checking)
+For automation with workflow_dispatch and scheduled events only.
+
+- **Triggers**: Only works with `workflow_dispatch` and `schedule` events - does NOT work with PR/issue events
 - **Features**: Perfect for scheduled tasks, works with `override_prompt`
 - **Use case**: Maintenance tasks, automated reporting, scheduled checks
 
@@ -38,7 +40,26 @@ For automation and scheduled tasks without trigger checking.
       Check for outdated dependencies and create an issue if any are found.
 ```
 
-See [`examples/claude-modes.yml`](../examples/claude-modes.yml) for complete examples of each mode.
+### Experimental Review Mode
+
+**Warning: This is an experimental feature that may change or be removed at any time.**
+
+For automated code reviews on pull requests.
+
+- **Triggers**: Pull request events (`opened`, `synchronize`) or `@claude review` comments
+- **Features**: Provides detailed code reviews with inline comments and suggestions
+- **Use case**: Automated PR reviews, code quality checks
+
+```yaml
+- uses: anthropics/claude-code-action@beta
+  with:
+    mode: experimental-review
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    custom_instructions: |
+      Focus on code quality, security, and best practices.
+```
+
+See [`examples/claude-modes.yml`](../examples/claude-modes.yml) and [`examples/claude-experimental-review-mode.yml`](../examples/claude-experimental-review-mode.yml) for complete examples of each mode.
 
 ## Network Restrictions
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -135,6 +135,14 @@ allowed_tools: "Bash(npm:*),Bash(git:*)" # Allows only npm and git commands
 
 No, Claude's GitHub app token is sandboxed to the current repository only. It cannot push to any other repositories. It can, however, read public repositories, but to get access to this, you must configure it with tools to do so.
 
+### Why aren't comments posted as claude[bot]?
+
+Comments appear as claude[bot] when the action uses its built-in authentication. However, if you provide a `github_token` in your workflow, the action will use that token's authentication instead, causing comments to appear under a different username.
+
+**Solution**: Remove `github_token` from your workflow file unless you're using a custom GitHub App.
+
+**Note**: The `use_sticky_comment` feature only works with claude[bot] authentication. If you're using a custom `github_token`, sticky comments won't update properly since they expect the claude[bot] username.
+
 ## MCP Servers and Extended Functionality
 
 ### What MCP servers are available by default?

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,36 +46,36 @@ jobs:
 
 ## Inputs
 
-| Input                          | Description                                                                                                            | Required | Default   |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
-| `mode`                         | Execution mode: 'tag' (default - triggered by mentions/assignments), 'agent' (for automation with no trigger checking) | No       | `tag`     |
-| `anthropic_api_key`            | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                             | No\*     | -         |
-| `claude_code_oauth_token`      | Claude Code OAuth token (alternative to anthropic_api_key)                                                             | No\*     | -         |
-| `direct_prompt`                | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)                  | No       | -         |
-| `override_prompt`              | Complete replacement of Claude's prompt with custom template (supports variable substitution)                          | No       | -         |
-| `base_branch`                  | The base branch to use for creating new branches (e.g., 'main', 'develop')                                             | No       | -         |
-| `max_turns`                    | Maximum number of conversation turns Claude can take (limits back-and-forth exchanges)                                 | No       | -         |
-| `timeout_minutes`              | Timeout in minutes for execution                                                                                       | No       | `30`      |
-| `use_sticky_comment`           | Use just one comment to deliver PR comments (only applies for pull_request event workflows)                            | No       | `false`   |
-| `github_token`                 | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!**   | No       | -         |
-| `model`                        | Model to use (provider-specific format required for Bedrock/Vertex)                                                    | No       | -         |
-| `fallback_model`               | Enable automatic fallback to specified model when primary model is unavailable                                         | No       | -         |
-| `anthropic_model`              | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                  | No       | -         |
-| `use_bedrock`                  | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                            | No       | `false`   |
-| `use_vertex`                   | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                          | No       | `false`   |
-| `allowed_tools`                | Additional tools for Claude to use (the base GitHub tools will always be included)                                     | No       | ""        |
-| `disallowed_tools`             | Tools that Claude should never use                                                                                     | No       | ""        |
-| `custom_instructions`          | Additional custom instructions to include in the prompt for Claude                                                     | No       | ""        |
-| `mcp_config`                   | Additional MCP configuration (JSON string) that merges with the built-in GitHub MCP servers                            | No       | ""        |
-| `assignee_trigger`             | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                          | No       | -         |
-| `label_trigger`                | The label name that triggers the action when applied to an issue (e.g. "claude")                                       | No       | -         |
-| `trigger_phrase`               | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                          | No       | `@claude` |
-| `branch_prefix`                | The prefix to use for Claude branches (defaults to 'claude/', use 'claude-' for dash format)                           | No       | `claude/` |
-| `claude_env`                   | Custom environment variables to pass to Claude Code execution (YAML format)                                            | No       | ""        |
-| `settings`                     | Claude Code settings as JSON string or path to settings JSON file                                                      | No       | ""        |
-| `additional_permissions`       | Additional permissions to enable. Currently supports 'actions: read' for viewing workflow results                      | No       | ""        |
-| `experimental_allowed_domains` | Restrict network access to these domains only (newline-separated).                                                     | No       | ""        |
-| `use_commit_signing`           | Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands      | No       | `false`   |
+| Input                          | Description                                                                                                                           | Required | Default   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
+| `mode`                         | Execution mode: 'tag' (default - triggered by mentions/assignments), 'agent' (for automation), 'experimental-review' (for PR reviews) | No       | `tag`     |
+| `anthropic_api_key`            | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                                            | No\*     | -         |
+| `claude_code_oauth_token`      | Claude Code OAuth token (alternative to anthropic_api_key)                                                                            | No\*     | -         |
+| `direct_prompt`                | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)                                 | No       | -         |
+| `override_prompt`              | Complete replacement of Claude's prompt with custom template (supports variable substitution)                                         | No       | -         |
+| `base_branch`                  | The base branch to use for creating new branches (e.g., 'main', 'develop')                                                            | No       | -         |
+| `max_turns`                    | Maximum number of conversation turns Claude can take (limits back-and-forth exchanges)                                                | No       | -         |
+| `timeout_minutes`              | Timeout in minutes for execution                                                                                                      | No       | `30`      |
+| `use_sticky_comment`           | Use just one comment to deliver PR comments (only applies for pull_request event workflows)                                           | No       | `false`   |
+| `github_token`                 | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!**                  | No       | -         |
+| `model`                        | Model to use (provider-specific format required for Bedrock/Vertex)                                                                   | No       | -         |
+| `fallback_model`               | Enable automatic fallback to specified model when primary model is unavailable                                                        | No       | -         |
+| `anthropic_model`              | **DEPRECATED**: Use `model` instead. Kept for backward compatibility.                                                                 | No       | -         |
+| `use_bedrock`                  | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                                           | No       | `false`   |
+| `use_vertex`                   | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                                         | No       | `false`   |
+| `allowed_tools`                | Additional tools for Claude to use (the base GitHub tools will always be included)                                                    | No       | ""        |
+| `disallowed_tools`             | Tools that Claude should never use                                                                                                    | No       | ""        |
+| `custom_instructions`          | Additional custom instructions to include in the prompt for Claude                                                                    | No       | ""        |
+| `mcp_config`                   | Additional MCP configuration (JSON string) that merges with the built-in GitHub MCP servers                                           | No       | ""        |
+| `assignee_trigger`             | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                                         | No       | -         |
+| `label_trigger`                | The label name that triggers the action when applied to an issue (e.g. "claude")                                                      | No       | -         |
+| `trigger_phrase`               | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                                         | No       | `@claude` |
+| `branch_prefix`                | The prefix to use for Claude branches (defaults to 'claude/', use 'claude-' for dash format)                                          | No       | `claude/` |
+| `claude_env`                   | Custom environment variables to pass to Claude Code execution (YAML format)                                                           | No       | ""        |
+| `settings`                     | Claude Code settings as JSON string or path to settings JSON file                                                                     | No       | ""        |
+| `additional_permissions`       | Additional permissions to enable. Currently supports 'actions: read' for viewing workflow results                                     | No       | ""        |
+| `experimental_allowed_domains` | Restrict network access to these domains only (newline-separated).                                                                    | No       | ""        |
+| `use_commit_signing`           | Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands                     | No       | `false`   |
 
 \*Required when using direct Anthropic API (default and when not using Bedrock or Vertex)
 


### PR DESCRIPTION
## Problem

During the improvement to the documentation in #383, we lost some updates to the documentation in #374 and #378.  In addition, I added an update to the FAQ to reflect some confusion I had around the username associated with the actions taken by the workflow

## Solution

- Update docs/experimental.md and docs/usage.md to reflect the new execution modes.
- Add a Q&A to the `Configuration and Tools` section of FAQ about `github_token` and how it affects the author of workflow actions.