### PR TITLE
feat: add getSystemPrompt method to mode interface

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -201,7 +201,7 @@ runs:
         INPUT_MCP_CONFIG: ${{ steps.prepare.outputs.mcp_config }}
         INPUT_SETTINGS: ${{ inputs.settings }}
         INPUT_SYSTEM_PROMPT: ""
-        INPUT_APPEND_SYSTEM_PROMPT: ""
+        INPUT_APPEND_SYSTEM_PROMPT: ${{ env.APPEND_SYSTEM_PROMPT }}
         INPUT_TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
         INPUT_CLAUDE_ENV: ${{ inputs.claude_env }}
         INPUT_FALLBACK_MODEL: ${{ inputs.fallback_model }}

--- a/src/entrypoints/prepare.ts
+++ b/src/entrypoints/prepare.ts
@@ -81,6 +81,19 @@ async function run() {
 
     // Set the MCP config output
     core.setOutput("mcp_config", result.mcpConfig);
+
+    // Step 6: Get system prompt from mode if available
+    if (mode.getSystemPrompt) {
+      const modeContext = mode.prepareContext(context, {
+        commentId: result.commentId,
+        baseBranch: result.branchInfo.baseBranch,
+        claudeBranch: result.branchInfo.claudeBranch,
+      });
+      const systemPrompt = mode.getSystemPrompt(modeContext);
+      if (systemPrompt) {
+        core.exportVariable("APPEND_SYSTEM_PROMPT", systemPrompt);
+      }
+    }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     core.setFailed(`Prepare step failed with error: ${errorMessage}`);

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -112,4 +112,9 @@ export const agentMode: Mode = {
     // Minimal fallback - repository is a string in PreparedContext
     return `Repository: ${context.repository}`;
   },
+
+  getSystemPrompt() {
+    // Agent mode doesn't need additional system prompts
+    return undefined;
+  },
 };

--- a/src/modes/review/index.ts
+++ b/src/modes/review/index.ts
@@ -349,4 +349,10 @@ This ensures users get value from the review even before checking individual inl
       mcpConfig,
     };
   },
+
+  getSystemPrompt() {
+    // Review mode doesn't need additional system prompts
+    // The review-specific instructions are included in the main prompt
+    return undefined;
+  },
 };

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -130,4 +130,9 @@ export const tagMode: Mode = {
   ): string {
     return generateDefaultPrompt(context, githubData, useCommitSigning);
   },
+
+  getSystemPrompt() {
+    // Tag mode doesn't need additional system prompts
+    return undefined;
+  },
 };

--- a/src/modes/types.ts
+++ b/src/modes/types.ts
@@ -73,6 +73,13 @@ export type Mode = {
    * @returns PrepareResult with commentId, branchInfo, and mcpConfig
    */
   prepare(options: ModeOptions): Promise<ModeResult>;
+
+  /**
+   * Returns an optional system prompt to append to Claude's base system prompt.
+   * This allows modes to add mode-specific instructions.
+   * @returns The system prompt string or undefined if no additional prompt is needed
+   */
+  getSystemPrompt?(context: ModeContext): string | undefined;
 };
 
 // Define types for mode prepare method


### PR DESCRIPTION
Allows modes to provide custom system prompts that are appended to Claude's base system prompt. This enables mode-specific instructions without modifying the core action logic.

- Add optional getSystemPrompt method to Mode interface
- Implement method in all existing modes (tag, agent, review)
- Update prepare.ts to call getSystemPrompt and export as env var
- Wire up APPEND_SYSTEM_PROMPT in action.yml to pass to base-action

All modes currently return undefined (no additional prompts), but the infrastructure is now in place for future modes to provide custom instructions.