### PR TITLE
fix: handle missing slash-commands directory gracefully

### DIFF
--- a/base-action/src/setup-claude-code-settings.ts
+++ b/base-action/src/setup-claude-code-settings.ts
@@ -72,7 +72,7 @@ export async function setupClaudeCodeSettings(
       `Copying slash commands from ${slashCommandsDir} to ${home}/.claude/`,
     );
     try {
-      await $`test -d ${slashCommandsDir}`.quiet();
+      await $`mkdir -p ${slashCommandsDir}`.quiet();
       await $`cp ${slashCommandsDir}/*.md ${home}/.claude/ 2>/dev/null || true`.quiet();
       console.log(`Slash commands copied successfully`);
     } catch (e) {


### PR DESCRIPTION
## Summary

This PR fixes the "Slash commands directory not found" error that appears in GitHub Actions logs when the slash-commands directory doesn't exist.

## Root Cause

In the current implementation, `setup-claude-code-settings.ts` uses `test -d` to check if the slash-commands directory exists before attempting to copy files. When the directory doesn't exist (which is common since it was removed in recent changes), this causes a non-fatal but noisy error:

```
Slash commands directory not found or error copying: ShellError: Failed with exit code 1
```

## Solution

Change from `test -d ${slashCommandsDir}` to `mkdir -p ${slashCommandsDir}` to:
- Create the directory if it doesn't exist (no-op if it already exists)
- Prevent the shell error from occurring
- Maintain backwards compatibility

## Error Context

This error appears in the same logs as Issue #403, though it's a separate cosmetic issue:
```
Copying slash commands from /home/runner/work/_actions/anthropics/claude-code-action/beta/slash-commands to /home/runner/.claude/
Slash commands directory not found or error copying: ShellError: Failed with exit code 1
```

## Testing

- ✅ When directory exists: `mkdir -p` is a no-op, copy proceeds normally
- ✅ When directory doesn't exist: `mkdir -p` creates it, copy proceeds (though with no files to copy)
- ✅ Maintains all existing functionality while eliminating the error message

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: yoshikouki <yoshikouki@users.noreply.github.com>