### PR TITLE
feat(docs): improve docs around prompt vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A general-purpose [Claude Code](https://claude.ai/code) action for GitHub PRs an
 - 🛠️ **Flexible Tool Access**: Access to GitHub APIs and file operations (additional tools can be enabled via configuration)
 - 📋 **Progress Tracking**: Visual progress indicators with checkboxes that dynamically update as Claude completes tasks
 - 🏃 **Runs on Your Infrastructure**: The action executes entirely on your own GitHub runner (Anthropic API calls go to your chosen provider)
+- 🎯 **Custom Prompts**: Create tailored prompts with variable substitution (`$PR_NUMBER`, `$CHANGED_FILES`, etc.) for automated workflows
 
 ## Quickstart
 
@@ -29,7 +30,7 @@ This command will guide you through setting up the GitHub app and required secre
 
 - [Setup Guide](./docs/setup.md) - Manual setup, custom GitHub apps, and security best practices
 - [Usage Guide](./docs/usage.md) - Basic usage, workflow configuration, and input parameters
-- [Custom Automations](./docs/custom-automations.md) - Examples of automated workflows and custom prompts
+- [Custom Automations](./docs/custom-automations.md) - Automated workflows, custom prompts with variable substitution
 - [Configuration](./docs/configuration.md) - MCP servers, permissions, environment variables, and advanced settings
 - [Experimental Features](./docs/experimental.md) - Execution modes and network restrictions
 - [Cloud Providers](./docs/cloud-providers.md) - AWS Bedrock and Google Vertex AI setup

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,7 +52,7 @@ jobs:
 | `anthropic_api_key`            | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                                            | No\*     | -         |
 | `claude_code_oauth_token`      | Claude Code OAuth token (alternative to anthropic_api_key)                                                                            | No\*     | -         |
 | `direct_prompt`                | Direct prompt for Claude to execute automatically without needing a trigger (for automated workflows)                                 | No       | -         |
-| `override_prompt`              | Complete replacement of Claude's prompt with custom template (supports variable substitution)                                         | No       | -         |
+| `override_prompt`              | Complete replacement of Claude's prompt with custom template. Supports `$VARIABLE` substitution for GitHub context data. See [Custom Automations](./custom-automations.md#custom-prompt-templates) for available variables and examples. | No       | -         |
 | `base_branch`                  | The base branch to use for creating new branches (e.g., 'main', 'develop')                                                            | No       | -         |
 | `max_turns`                    | Maximum number of conversation turns Claude can take (limits back-and-forth exchanges)                                                | No       | -         |
 | `timeout_minutes`              | Timeout in minutes for execution                                                                                                      | No       | `30`      |


### PR DESCRIPTION
## summary

i wanted to use the new experimental review feature, but with my own prompt. was about to implement variable support myself when i realized, wait, it's already there! just... not documented very well. so here are some improvements!

## what i added

- a table showing all 16 variables you can use
  - what they are, examples, where they work
- real output examples so you know what you're getting (let me know if these are wrong)
- notes for each mode since they work slightly different
- updated the README so people know this exists
- better links in the docs