### PR TITLE
feat(review): make it possible to use sticky comment in review mode

### DIFF
--- a/src/modes/types.ts
+++ b/src/modes/types.ts
@@ -55,7 +55,7 @@ export type Mode = {
   /**
    * Determines if this mode should create a tracking comment
    */
-  shouldCreateTrackingComment(): boolean;
+  shouldCreateTrackingComment(context?: GitHubContext): boolean;
 
   /**
    * Generates the prompt for this mode.


### PR DESCRIPTION
## summary

adds support for sticky comments in review mode when both `use_sticky_comment` and `override_prompt` are provided. this allows users to have a single persistent comment for custom review workflows instead of creating new reviews on every rebase/force push.

## problem

we do atomic prs/commits and so we often push many times to a given set of prs. we love the sticky comment, and wanted to bring it back for the review mode!

review mode currently creates github reviews which:
- create multiple review instances on rebased prs
- don't provide a single persistent comment for tracking
- can clutter pr history with repeated reviews <-- biggest issue

## solution

enable sticky comments in review mode with these conditions:
- both `use_sticky_comment: true` and `override_prompt` must be provided
- warns users if sticky comment is enabled without override prompt
- adds comment update tool when conditions are met

## changes

### code changes
- modified `shouldCreateTrackingComment()` to check for both sticky comment and override prompt
- added conditional comment creation in `prepare()` method
- added warning when misconfigured
- conditionally includes `mcp__github_comment__update_claude_comment` tool
- returns `commentId` in mode result for consistency

## benefits

- single persistent comment across rebases (overview, update each push)
- custom review behavior with override prompts
- backward compatible - default review behavior unchanged
- opt-in feature for advanced users