### PR TITLE
fix: remove git config user.name and user.email from allowed tools

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -60,8 +60,6 @@ export function buildAllowedToolsString(
       "Bash(git diff:*)",
       "Bash(git log:*)",
       "Bash(git rm:*)",
-      "Bash(git config user.name:*)",
-      "Bash(git config user.email:*)",
     );
   }
 

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -1041,8 +1041,6 @@ describe("buildAllowedToolsString", () => {
     expect(result).toContain("Bash(git diff:*)");
     expect(result).toContain("Bash(git log:*)");
     expect(result).toContain("Bash(git rm:*)");
-    expect(result).toContain("Bash(git config user.name:*)");
-    expect(result).toContain("Bash(git config user.email:*)");
 
     // Comment tool from minimal server should be included
     expect(result).toContain("mcp__github_comment__update_claude_comment");


### PR DESCRIPTION
These git config commands are no longer needed as allowed tools since Claude should not be modifying git configuration settings. Updated the corresponding test to reflect this intentional change.

🤖 Generated with [Claude Code](https://claude.ai/code)