### PR TITLE
fix: authenticate gh CLI with GitHub token

### DIFF
--- a/base-action/README.md
+++ b/base-action/README.md
@@ -124,6 +124,8 @@ The following environment variables can be used to configure the action:
 | -------------- | ----------------------------------------------------- | ------- |
 | `NODE_VERSION` | Node.js version to use (e.g., '18.x', '20.x', '22.x') | '18.x'  |
 
+**Note:** The action synchronizes `GITHUB_TOKEN` and `GH_TOKEN` when either is present (`GITHUB_TOKEN` takes precedence). This ensures `gh` CLI and other tools work regardless of which token name is provided. The `GH_TOKEN` environment variable will override any existing `gh` CLI authentication.
+
 Example usage:
 
 ```yaml


### PR DESCRIPTION
**Note: ~~Hypothesis.~~ Nvm, turns out `gh` honors both env vars anyway.**

Local test:
```bash
# Without env vars - uses existing gh auth
$ claude -p "Run: gh auth status"
GitHub CLI is authenticated successfully as user **[username]**.

# With invalid tokens - overrides existing auth
$ GITHUB_TOKEN=test-token GH_TOKEN=test-token claude -p "Run: gh auth status"
The GitHub CLI is not authenticated...
```
This suggests Claude Code passes environment variables to subprocesses and they override existing authentication.

---

Synchronize `GITHUB_TOKEN` and `GH_TOKEN` environment variables to ensure both `gh` CLI and MCP servers can authenticate properly.

- `gh` CLI expects `GH_TOKEN`, MCP servers expect `GITHUB_TOKEN`
- Extract token synchronization into testable function
- Support tokens from `process.env` and `claude_env` input
- Add comprehensive tests and documentation

**Note:** `GH_TOKEN` environment variable overrides any existing `gh` CLI authentication.

Fixes #140