### PR TITLE
fix - allowed and disallowed tools ignored in agent mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -207,15 +207,8 @@ Claude does **not** have access to execute arbitrary Bash commands by default. I
 ```yaml
 - uses: anthropics/claude-code-action@beta
   with:
-    allowed_tools: |
-      Bash(npm install)
-      Bash(npm run test)
-      Edit
-      Replace
-      NotebookEditCell
-    disallowed_tools: |
-      TaskOutput
-      KillTask
+    allowed_tools: "Bash(npm install),Bash(npm run test),Edit,Replace,NotebookEditCell"
+    disallowed_tools: "TaskOutput,KillTask"
     # ... other inputs
 ```
 

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -80,9 +80,8 @@ export const agentMode: Mode = {
       ...context.inputs.disallowedTools,
     ];
 
-    // Export as INPUT_ prefixed variables for the base action
-    core.exportVariable("INPUT_ALLOWED_TOOLS", allowedTools.join(","));
-    core.exportVariable("INPUT_DISALLOWED_TOOLS", disallowedTools.join(","));
+    core.exportVariable("ALLOWED_TOOLS", allowedTools.join(","));
+    core.exportVariable("DISALLOWED_TOOLS", disallowedTools.join(","));
 
     // Agent mode uses a minimal MCP configuration
     // We don't need comment servers or PR-specific tools for automation

--- a/src/modes/review/index.ts
+++ b/src/modes/review/index.ts
@@ -297,9 +297,8 @@ This ensures users get value from the review even before checking individual inl
       ...context.inputs.disallowedTools,
     ];
 
-    // Export as INPUT_ prefixed variables for the base action
-    core.exportVariable("INPUT_ALLOWED_TOOLS", allowedTools.join(","));
-    core.exportVariable("INPUT_DISALLOWED_TOOLS", disallowedTools.join(","));
+    core.exportVariable("ALLOWED_TOOLS", allowedTools.join(","));
+    core.exportVariable("DISALLOWED_TOOLS", disallowedTools.join(","));
 
     const additionalMcpConfig = process.env.MCP_CONFIG || "";
     const mcpConfig = await prepareMcpConfig({


### PR DESCRIPTION
## Problem

When using agent mode, allowed_tools and disallowed_tools are ignored.  I believe this also affects review mode. 

The `Prepare action` step of the action takes `inputs.allowed_tools` and sets the env var `ALLOWED_TOOLS`.  Further down in the workflows, the action takes the preset values of the allowed tools and joins with the supplied allowed tools.  For agent (and review) mode, we then set the `INPUT_ALLOWED_TOOLS` environment variable.  However, in the `Run Claude Code` step of the action, we're setting `INPUT_ALLOWED_TOOLS` to the value of `env.ALLOWED_TOOLS`, which is empty at this point.

## Solution

- Export to the variables of `ALLOW_TOOLS` and `DISALLOWED_TOOLS` so that action.yml picks up the correct data.
- Update documentation so that allowed_tools and disallowed_tools examples are always comma-separated list, per the requirements of the input fields.

## References

This should address https://github.com/anthropics/claude-code-action/issues/423.