### PR TITLE
docs: add prominent notice about upcoming v1.0 breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ A general-purpose [Claude Code](https://claude.ai/code) action for GitHub PRs an
 - 📋 **Progress Tracking**: Visual progress indicators with checkboxes that dynamically update as Claude completes tasks
 - 🏃 **Runs on Your Infrastructure**: The action executes entirely on your own GitHub runner (Anthropic API calls go to your chosen provider)
 
+## ⚠️ **BREAKING CHANGES COMING IN v1.0** ⚠️
+
+**We're planning a major update that will significantly change how this action works.** The new version will:
+
+- ✨ Automatically select the appropriate mode (no more `mode` input)
+- 🔧 Simplify configuration with unified `prompt` and `claude_args`
+- 🚀 Align more closely with the Claude Code SDK capabilities
+- 💥 Remove multiple inputs like `direct_prompt`, `custom_instructions`, and others
+
+**[→ Read the full v1.0 roadmap and provide feedback](https://github.com/anthropics/claude-code-action/discussions/428)**
+
+---
+
 ## Quickstart
 
 The easiest way to set up this action is through [Claude Code](https://claude.ai/code) in the terminal. Just open `claude` and run `/install-github-app`.


### PR DESCRIPTION
- Add GitHub alert box highlighting the v1.0 roadmap
- Link to discussion #428 for community feedback
- Briefly summarize key changes (automatic mode selection, unified prompt interface)
- Position prominently at top of README for maximum visibility