### PR TITLE
refactor: remove redundant step comments

### DIFF
--- a/src/entrypoints/prepare.ts
+++ b/src/entrypoints/prepare.ts
@@ -28,7 +28,7 @@ async function run() {
     const githubToken = await setupGitHubToken();
     const octokit = createOctokit(githubToken);
 
-    // Step 3: Check write permissions (only for entity contexts)
+    // Check write permissions (only for entity contexts)
     if (isEntityContext(context)) {
       const hasWritePermissions = await checkWritePermissions(
         octokit.rest,
@@ -59,7 +59,7 @@ async function run() {
       return;
     }
 
-    // Step 5: Use the new modular prepare function
+    // Use the new modular prepare function
     const result = await prepare({
       context,
       octokit,
@@ -72,7 +72,7 @@ async function run() {
     // Expose the GitHub token (Claude App token) as an output
     core.setOutput("github_token", githubToken);
 
-    // Step 6: Get system prompt from mode if available
+    // Get system prompt from mode if available
     if (mode.getSystemPrompt) {
       const modeContext = mode.prepareContext(context, {
         commentId: result.commentId,


### PR DESCRIPTION
There were multiple STEP 2 comments in the prepare script.
Since the `STEP X` comments are unnecessary, they have been removed entirely.

https://github.com/anthropics/claude-code-action/blob/main/src/entrypoints/prepare.ts#L28

https://github.com/anthropics/claude-code-action/blob/main/src/entrypoints/prepare.ts#L46

No functional changes.
