### PR TITLE
Fix/remove unneeded tool in review mode

### DIFF
--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -72,22 +72,24 @@ export async function prepareMcpConfig(
       mcpServers: {},
     };
 
-    // Always include comment server for updating Claude comments
-    baseMcpConfig.mcpServers.github_comment = {
-      command: "bun",
-      args: [
-        "run",
-        `${process.env.GITHUB_ACTION_PATH}/src/mcp/github-comment-server.ts`,
-      ],
-      env: {
-        GITHUB_TOKEN: githubToken,
-        REPO_OWNER: owner,
-        REPO_NAME: repo,
-        ...(claudeCommentId && { CLAUDE_COMMENT_ID: claudeCommentId }),
-        GITHUB_EVENT_NAME: process.env.GITHUB_EVENT_NAME || "",
-        GITHUB_API_URL: GITHUB_API_URL,
-      },
-    };
+    // Include comment server for updating Claude comments
+    if (claudeCommentId) {
+      baseMcpConfig.mcpServers.github_comment = {
+        command: "bun",
+        args: [
+          "run",
+          `${process.env.GITHUB_ACTION_PATH}/src/mcp/github-comment-server.ts`,
+        ],
+        env: {
+          GITHUB_TOKEN: githubToken,
+          REPO_OWNER: owner,
+          REPO_NAME: repo,
+          CLAUDE_COMMENT_ID: claudeCommentId,
+          GITHUB_EVENT_NAME: process.env.GITHUB_EVENT_NAME || "",
+          GITHUB_API_URL: GITHUB_API_URL,
+        },
+      };
+    }
 
     // Include file ops server when commit signing is enabled
     if (context.inputs.useCommitSigning) {

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -92,6 +92,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContext,
     });
@@ -106,6 +107,24 @@ describe("prepareMcpConfig", () => {
     );
     expect(parsed.mcpServers.github_comment.env.REPO_OWNER).toBe("test-owner");
     expect(parsed.mcpServers.github_comment.env.REPO_NAME).toBe("test-repo");
+  });
+
+  test("should not include comment server when claudeCommentId is not set", async () => {
+    const result = await prepareMcpConfig({
+      githubToken: "test-token",
+      owner: "test-owner",
+      repo: "test-repo",
+      branch: "test-branch",
+      baseBranch: "main",
+      allowedTools: [],
+      context: mockContext,
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.mcpServers.github).not.toBeDefined();
+    expect(parsed.mcpServers.github_file_ops).not.toBeDefined();
+    expect(parsed.mcpServers.github_comment).not.toBeDefined();
   });
 
   test("should return file ops server when commit signing is enabled", async () => {
@@ -123,6 +142,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: [],
       context: contextWithSigning,
     });
@@ -149,6 +169,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: [
         "mcp__github__create_issue",
         "mcp__github_file_ops__commit_files",
@@ -181,6 +202,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: [
         "mcp__github_file_ops__commit_files",
         "mcp__github_file_ops__update_claude_comment",
@@ -201,6 +223,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: ["Edit", "Read", "Write"],
       context: mockContext,
     });
@@ -220,6 +243,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: "",
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContext,
     });
@@ -239,6 +263,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: "   \n\t  ",
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContext,
     });
@@ -270,6 +295,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: additionalConfig,
+      claudeCommentId: "1",
       allowedTools: [
         "mcp__github__create_issue",
         "mcp__github_file_ops__commit_files",
@@ -309,6 +335,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: additionalConfig,
+      claudeCommentId: "1",
       allowedTools: [
         "mcp__github__create_issue",
         "mcp__github_file_ops__commit_files",
@@ -351,6 +378,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: additionalConfig,
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContextWithSigning,
     });
@@ -372,6 +400,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: invalidJson,
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContextWithSigning,
     });
@@ -394,6 +423,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: nonObjectJson,
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContextWithSigning,
     });
@@ -419,6 +449,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: nullJson,
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContextWithSigning,
     });
@@ -444,6 +475,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: arrayJson,
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContextWithSigning,
     });
@@ -492,6 +524,7 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       additionalMcpConfig: additionalConfig,
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContextWithSigning,
     });
@@ -515,6 +548,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContextWithSigning,
     });
@@ -537,6 +571,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContextWithSigning,
     });
@@ -566,6 +601,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: [],
       context: contextWithPermissions,
     });
@@ -586,6 +622,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockContextWithSigning,
     });
@@ -605,6 +642,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: [],
       context: mockPRContextWithSigning,
     });
@@ -637,6 +675,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: [],
       context: contextWithPermissions,
     });
@@ -666,6 +705,7 @@ describe("prepareMcpConfig", () => {
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
+      claudeCommentId: "1",
       allowedTools: [],
       context: contextWithPermissions,
     });


### PR DESCRIPTION
In review mode, the expected way to post comments is via `Bash(gh issue comment:*)` or `mcp__github_inline_comment__create_inline_comment`. 
However, `mcp__github_comment__update_claude_comment` is included in the available tools even when no Claude comment existed. 
https://github.com/anthropics/claude-code-action/blob/main/src/mcp/install-mcp-server.ts#L75

Updated `prepareMcpConfig` to include this tool only if `claudeCommentId` is set.

When `claudeCommentId` is not set, it causes an error on the MCP side, so this change has no impact.
https://github.com/anthropics/claude-code-action/blob/main/src/mcp/github-comment-server.ts#L41
