### PR TITLE
Switch to curl-based Claude Code installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -177,7 +177,7 @@ runs:
         echo "Base-action dependencies installed"
         cd -
         # Install Claude Code globally
-        bun install -g @anthropic-ai/claude-code@1.0.81
+        curl -fsSL https://claude.ai/install.sh | bash -s 1.0.81
 
     - name: Setup Network Restrictions
       if: steps.prepare.outputs.contains_trigger == 'true' && inputs.experimental_allowed_domains != ''

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -118,7 +118,7 @@ runs:
 
     - name: Install Claude Code
       shell: bash
-      run: bun install -g @anthropic-ai/claude-code@1.0.81
+      run: curl -fsSL https://claude.ai/install.sh | bash -s 1.0.81
 
     - name: Run Claude Code Action
       shell: bash


### PR DESCRIPTION
Replace bun install with official install script for more reliable installation across different environments.

Relates to #443 

🤖 Generated with [Claude Code](https://claude.ai/code)