### PR TITLE
fix: add Claude Code binary to GitHub Actions PATH

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -178,6 +178,7 @@ runs:
         cd -
         # Install Claude Code globally
         curl -fsSL https://claude.ai/install.sh | bash -s 1.0.83
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
     - name: Setup Network Restrictions
       if: steps.prepare.outputs.contains_trigger == 'true' && inputs.experimental_allowed_domains != ''


### PR DESCRIPTION
## What
Adds the ~/.local/bin directory to the GitHub Actions PATH environment variable using $GITHUB_PATH, 
ensuring the Claude Code binary is available in subsequent steps after installation.
## Why
By this [commit](https://github.com/anthropics/claude-code-action/commit/ae66eb6a644f9c34886cd7d4d5a7516e9b472b85), claude code installed by curl, 
but there is no configuration to update PATH.

