### PR TITLE
make github server url customizable when using github enterprise

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -166,6 +166,8 @@ runs:
         DEFAULT_WORKFLOW_TOKEN: ${{ github.token }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         USE_COMMIT_SIGNING: ${{ inputs.use_commit_signing }}
+        GITHUB_SERVER_URL: ${{ env.GITHUB_SERVER_URL || 'https://github.com' }}
+        GITHUB_API_URL: ${{ env.GITHUB_SERVER_URL && format('{0}/api/v3', env.GITHUB_SERVER_URL) || 'https://api.github.com' }}
 
     - name: Install Base Action Dependencies
       if: steps.prepare.outputs.contains_trigger == 'true'


### PR DESCRIPTION
- It was impossible to override environment variables `GITHUB_SERVER_API` and `GITHUB_API_URL` inside the prepare step.
- This made it impossible to use claude code with github enterprise.
- Make both environment variables inserted when calling the step, and use the default value when not declared.