### PR TITLE
feat: skip action gracefully for workflow validation errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -286,7 +286,7 @@ runs:
         fi
 
     - name: Revoke app token
-      if: always() && inputs.github_token == ''
+      if: always() && inputs.github_token == '' && steps.prepare.outputs.skipped_due_to_workflow_validation_mismatch != 'true'
       shell: bash
       run: |
         curl -L \

--- a/src/github/token.ts
+++ b/src/github/token.ts
@@ -68,7 +68,6 @@ async function exchangeForAppToken(oidcToken: string): Promise<string> {
     token?: string;
     app_token?: string;
   };
-  console.log("Full OIDC exchange response:", appTokenData);
   const appToken = appTokenData.token || appTokenData.app_token;
 
   if (!appToken) {


### PR DESCRIPTION
Handle workflow_not_found_on_default_branch and workflow_content_mismatch errors by skipping the action with a warning instead of failing. This improves user experience when adding Claude Code workflows to new repositories or making workflow changes in PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)