### PR TITLE
fix: prevent undefined directory creation when RUNNER_TEMP is not set

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -836,7 +836,7 @@ export async function createPrompt(
       modeContext.claudeBranch,
     );
 
-    await mkdir(`${process.env.RUNNER_TEMP}/claude-prompts`, {
+    await mkdir(`${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts`, {
       recursive: true,
     });
 
@@ -855,7 +855,7 @@ export async function createPrompt(
 
     // Write the prompt file
     await writeFile(
-      `${process.env.RUNNER_TEMP}/claude-prompts/claude-prompt.txt`,
+      `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts/claude-prompt.txt`,
       promptContent,
     );
 

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -45,7 +45,7 @@ export const agentMode: Mode = {
 
     // TODO: handle by createPrompt (similar to tag and review modes)
     // Create prompt directory
-    await mkdir(`${process.env.RUNNER_TEMP}/claude-prompts`, {
+    await mkdir(`${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts`, {
       recursive: true,
     });
     // Write the prompt file - the base action requires a prompt_file parameter,
@@ -57,7 +57,7 @@ export const agentMode: Mode = {
       context.inputs.directPrompt ||
       `Repository: ${context.repository.owner}/${context.repository.repo}`;
     await writeFile(
-      `${process.env.RUNNER_TEMP}/claude-prompts/claude-prompt.txt`,
+      `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts/claude-prompt.txt`,
       promptContent,
     );
 


### PR DESCRIPTION
## Summary
- Fixed issue where `undefined/claude-prompts/claude-prompt.txt` directories were created during local testing
- Added fallback to `/tmp` when `process.env.RUNNER_TEMP` is undefined
- Follows existing pattern from `src/mcp/github-actions-server.ts`

## Test plan
- [x] Run `bun test` to verify no undefined directories are created
- [x] Verify TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.ai/code)