### PR TITLE
fix: provides github token for claude code action

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -104,3 +104,5 @@ jobs:
           mcp_config: /tmp/mcp-config/mcp-servers.json
           timeout_minutes: "5"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently when running the `gh` command in the action, there is an error in the action logs that suggests that the `GH_TOKEN` isn't being set. We've solved this internally in our company by providing the `GH_TOKEN` in the action.