### PR TITLE
feat: Added debug option to the claude code command execution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,10 @@ inputs:
     description: "Custom environment variables to pass to Claude Code execution (YAML format)"
     required: false
     default: ""
+  debug:
+    description: "Enable debug mode for Claude Code execution"
+    required: false
+    default: "false"
   settings:
     description: "Claude Code settings as JSON string or path to settings JSON file"
     required: false
@@ -212,6 +216,7 @@ runs:
         INPUT_TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
         INPUT_CLAUDE_ENV: ${{ inputs.claude_env }}
         INPUT_FALLBACK_MODEL: ${{ inputs.fallback_model }}
+        INPUT_DEBUG: ${{ inputs.debug }}
         INPUT_EXPERIMENTAL_SLASH_COMMANDS_DIR: ${{ github.action_path }}/slash-commands
         INPUT_ACTION_INPUTS_PRESENT: ${{ steps.prepare.outputs.action_inputs_present }}
 

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: "Custom environment variables to pass to Claude Code execution (YAML multiline format)"
     required: false
     default: ""
+  debug:
+    description: "Enable debug mode for Claude Code execution"
+    required: false
+    default: "false"
 
   # Action settings
   timeout_minutes:
@@ -146,6 +150,7 @@ runs:
         INPUT_TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
         INPUT_CLAUDE_ENV: ${{ inputs.claude_env }}
         INPUT_FALLBACK_MODEL: ${{ inputs.fallback_model }}
+        INPUT_DEBUG: ${{ inputs.debug }}
         INPUT_EXPERIMENTAL_SLASH_COMMANDS_DIR: ${{ inputs.experimental_slash_commands_dir }}
 
         # Provider configuration

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -31,6 +31,7 @@ async function run() {
       claudeEnv: process.env.INPUT_CLAUDE_ENV,
       fallbackModel: process.env.INPUT_FALLBACK_MODEL,
       model: process.env.ANTHROPIC_MODEL,
+      debug: process.env.INPUT_DEBUG,
     });
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`);

--- a/base-action/src/run-claude.ts
+++ b/base-action/src/run-claude.ts
@@ -22,6 +22,7 @@ export type ClaudeOptions = {
   fallbackModel?: string;
   timeoutMinutes?: string;
   model?: string;
+  debug?: string;
 };
 
 type PreparedConfig = {
@@ -97,6 +98,9 @@ export function prepareRunConfig(
   }
   if (options.model) {
     claudeArgs.push("--model", options.model);
+  }
+  if (options.debug) {
+    claudeArgs.push("--debug");
   }
   if (options.timeoutMinutes) {
     const timeoutMinutesNum = parseInt(options.timeoutMinutes, 10);


### PR DESCRIPTION
This `--debug` flag will be populated to claude code to enable debug mode. 

Signed-off-by: Jiaxiao Zhou <duibao55328@gmail.com>
