### PR TITLE
fix: Increase maxBuffer for jq processing to handle large Claude outputs

### DIFF
--- a/base-action/src/run-claude.ts
+++ b/base-action/src/run-claude.ts
@@ -307,7 +307,10 @@ export async function runClaude(promptPath: string, options: ClaudeOptions) {
       await writeFile("output.txt", output);
 
       // Process output.txt into JSON and save to execution file
-      const { stdout: jsonOutput } = await execAsync("jq -s '.' output.txt");
+      // Increase maxBuffer from Node.js default of 1MB to 10MB to handle large Claude outputs
+      const { stdout: jsonOutput } = await execAsync("jq -s '.' output.txt", {
+        maxBuffer: 10 * 1024 * 1024,
+      });
       await writeFile(EXECUTION_FILE, jsonOutput);
 
       console.log(`Log saved to ${EXECUTION_FILE}`);
@@ -324,7 +327,10 @@ export async function runClaude(promptPath: string, options: ClaudeOptions) {
     if (output) {
       try {
         await writeFile("output.txt", output);
-        const { stdout: jsonOutput } = await execAsync("jq -s '.' output.txt");
+        // Increase maxBuffer from Node.js default of 1MB to 10MB to handle large Claude outputs
+        const { stdout: jsonOutput } = await execAsync("jq -s '.' output.txt", {
+          maxBuffer: 10 * 1024 * 1024,
+        });
         await writeFile(EXECUTION_FILE, jsonOutput);
         core.setOutput("execution_file", EXECUTION_FILE);
       } catch (e) {


### PR DESCRIPTION
## Summary
- Fixes "stdout maxBuffer length exceeded" error when processing large Claude outputs
- Increases buffer from Node.js default of 1MB to 10MB for jq operations

## Problem
When Claude produces large output that gets processed by jq, it exceeds Node.js's default maxBuffer limit of 1MB, causing the error:
```
Warning: Failed to process output for execution metrics: RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stdout maxBuffer length exceeded
```

## Solution
Added explicit `maxBuffer: 10 * 1024 * 1024` option to both `execAsync` calls that run jq, increasing the buffer to 10MB to handle larger outputs.

## Test plan
- [ ] Run Claude with large output to verify no buffer errors
- [ ] Confirm execution metrics are properly saved for both success and failure cases

🤖 Generated with [Claude Code](https://claude.ai/code)