### PR TITLE
Fix detectMode to handle pull_request_review event

### DIFF
--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -2,6 +2,7 @@ import type { GitHubContext } from "../github/context";
 import {
   isEntityContext,
   isIssueCommentEvent,
+  isPullRequestReviewEvent,
   isPullRequestReviewCommentEvent,
 } from "../github/context";
 import { checkContainsTrigger } from "../github/validation/trigger";
@@ -18,6 +19,7 @@ export function detectMode(context: GitHubContext): AutoDetectedMode {
   if (isEntityContext(context)) {
     if (
       isIssueCommentEvent(context) ||
+      isPullRequestReviewEvent(context) ||
       isPullRequestReviewCommentEvent(context)
     ) {
       if (checkContainsTrigger(context)) {


### PR DESCRIPTION
Fixes https://github.com/anthropics/claude-code-action/issues/483

## Test
I have tested this change in my repository.

Here is the log:

```console
Run bun run ${GITHUB_ACTION_PATH}/src/entrypoints/prepare.ts

Pull request review contains exact trigger phrase '@claude'
Auto-detected mode: tag for event: pull_request_review
Using provided GITHUB_TOKEN for authentication
Checking permissions for actor: int128
Permission level retrieved: admin
Actor has write access: admin
Pull request review contains exact trigger phrase '@claude'
Mode: tag
Context prompt: NO PROMPT
Trigger result: true
Preparing with mode: tag for event: pull_request_review
Actor type: User
Verified human actor: int128
✅ Created initial comment with ID: 3223624782
```
