### PR TITLE
Remove mcp_config input in favor of --mcp-config in claude_args

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -101,7 +101,8 @@ jobs:
         with:
           prompt_file: /tmp/claude-prompts/triage-prompt.txt
           allowed_tools: "Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues"
-          mcp_config: /tmp/mcp-config/mcp-servers.json
+          claude_args: |
+            --mcp-config /tmp/mcp-config/mcp-servers.json
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -162,11 +162,6 @@ jobs:
   # Test the outer action with inline MCP config
   test-outer-action-inline-mcp:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
@@ -184,6 +179,7 @@ jobs:
         with:
           prompt: "List all available MCP tools that start with 'mcp__test-server'"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --mcp-config '{"mcpServers":{"test-server":{"type":"stdio","command":"bun","args":["base-action/test/mcp-test/simple-mcp-server.ts"],"env":{}}}}'
 
@@ -210,11 +206,6 @@ jobs:
   # Test the outer action with file-based MCP config
   test-outer-action-file-mcp:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
@@ -247,6 +238,7 @@ jobs:
         with:
           prompt: "Use the mcp__test-server__test_tool to test the MCP integration"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --mcp-config /tmp/test-mcp-config.json
             --allowedTools mcp__test-server__test_tool

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -255,6 +255,8 @@ jobs:
             exit 1
           fi
 
+          cat $OUTPUT_FILE
+
           # Check if the tool was actually called
           if jq -e '.[] | select(.type == "tool" and .name == "mcp__test-server__test_tool")' "$OUTPUT_FILE" > /dev/null; then
             echo "✓ MCP test tool was called"

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -162,6 +162,11 @@ jobs:
   # Test the outer action with inline MCP config
   test-outer-action-inline-mcp:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
@@ -205,6 +210,11 @@ jobs:
   # Test the outer action with file-based MCP config
   test-outer-action-file-mcp:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -166,6 +166,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 #v2
+
       - name: Install test MCP server dependencies
         run: |
           cd base-action/test/mcp-test
@@ -205,6 +208,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 #v2
 
       - name: Install test MCP server dependencies
         run: |

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -178,15 +178,16 @@ jobs:
         uses: ./
         id: claude-inline-test
         with:
-          prompt: "List all available MCP tools that start with 'mcp__test-server'"
+          prompt: "Use the mcp__test-server__test_tool to test the MCP integration"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --mcp-config '{"mcpServers":{"test-server":{"type":"stdio","command":"bun","args":["base-action/test/mcp-test/simple-mcp-server.ts"],"env":{}}}}'
+            --allowedTools mcp__test-server__test_tool
 
       - name: Check execution output
         run: |
-          echo "Checking execution output for MCP test tool..."
+          echo "Checking if MCP test tool was used..."
           OUTPUT_FILE="${{ steps.claude-inline-test.outputs.execution_file }}"
 
           if [ ! -f "$OUTPUT_FILE" ]; then
@@ -194,13 +195,25 @@ jobs:
             exit 1
           fi
 
-          # Check if the MCP test tool was mentioned in the response
-          if jq -e '.[] | select(.type == "assistant" and .content != null) | .content | contains("mcp__test-server__test_tool")' "$OUTPUT_FILE" > /dev/null; then
-            echo "✓ MCP test tool was mentioned in response"
+          cat $OUTPUT_FILE
+
+          # Check if the tool was actually called - looking in assistant messages
+          if jq -e '.[] | select(.type == "assistant" and .message.content) | .message.content[] | select(.type == "tool_use" and .name == "mcp__test-server__test_tool")' "$OUTPUT_FILE" > /dev/null; then
+            echo "✓ MCP test tool was called"
+            
+            # Check the tool result - looking for the user message with tool_result
+            if jq -e '.[] | select(.type == "user" and .message.content[0].type == "tool_result") | .message.content[0].content[0].text | contains("Test tool response")' "$OUTPUT_FILE" > /dev/null; then
+              echo "✓ MCP test tool returned expected result"
+            else
+              echo "✗ MCP test tool result not as expected"
+              echo "Tool results in output:"
+              jq '.[] | select(.type == "user") | .message.content[]? | select(.type == "tool_result")' "$OUTPUT_FILE"
+              exit 1
+            fi
           else
-            echo "✗ MCP test tool not mentioned in response"
-            echo "Assistant responses:"
-            jq '.[] | select(.type == "assistant" and .content != null) | .content' "$OUTPUT_FILE"
+            echo "✗ MCP test tool was not called"
+            echo "Tools used:"
+            jq '.[] | select(.type == "assistant" and .message.content) | .message.content[] | select(.type == "tool_use") | .name' "$OUTPUT_FILE"
             exit 1
           fi
 

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Check execution output
         run: |
           echo "Checking execution output for MCP test tool..."
-          OUTPUT_FILE="${{ runner.temp }}/claude-execution-output.json"
+          OUTPUT_FILE="${RUNNER_TEMP}/claude-execution-output.json"
 
           if [ ! -f "$OUTPUT_FILE" ]; then
             echo "Error: Output file not found!"
@@ -246,7 +246,7 @@ jobs:
       - name: Check tool usage
         run: |
           echo "Checking if MCP test tool was used..."
-          OUTPUT_FILE="${{ runner.temp }}/claude-execution-output.json"
+          OUTPUT_FILE="${RUNNER_TEMP}/claude-execution-output.json"
 
           if [ ! -f "$OUTPUT_FILE" ]; then
             echo "Error: Output file not found!"

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -176,6 +176,7 @@ jobs:
 
       - name: Test outer action with inline MCP config
         uses: ./
+        id: claude-inline-test
         with:
           prompt: "List all available MCP tools that start with 'mcp__test-server'"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -186,7 +187,7 @@ jobs:
       - name: Check execution output
         run: |
           echo "Checking execution output for MCP test tool..."
-          OUTPUT_FILE="${RUNNER_TEMP}/claude-execution-output.json"
+          OUTPUT_FILE="${{ steps.claude-inline-test.outputs.execution_file }}"
 
           if [ ! -f "$OUTPUT_FILE" ]; then
             echo "Error: Output file not found!"
@@ -235,6 +236,7 @@ jobs:
 
       - name: Test outer action with file-based MCP config
         uses: ./
+        id: claude-file-test
         with:
           prompt: "Use the mcp__test-server__test_tool to test the MCP integration"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -246,7 +248,7 @@ jobs:
       - name: Check tool usage
         run: |
           echo "Checking if MCP test tool was used..."
-          OUTPUT_FILE="${RUNNER_TEMP}/claude-execution-output.json"
+          OUTPUT_FILE="${{ steps.claude-file-test.outputs.execution_file }}"
 
           if [ ! -f "$OUTPUT_FILE" ]; then
             echo "Error: Output file not found!"

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -158,3 +158,108 @@ jobs:
           fi
 
           echo "✓ All MCP server checks passed with --mcp-config flag!"
+
+  # Test the outer action with inline MCP config
+  test-outer-action-inline-mcp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
+
+      - name: Install test MCP server dependencies
+        run: |
+          cd base-action/test/mcp-test
+          bun install
+
+      - name: Test outer action with inline MCP config
+        uses: ./
+        with:
+          prompt: "List all available MCP tools that start with 'mcp__test-server'"
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --mcp-config '{"mcpServers":{"test-server":{"type":"stdio","command":"bun","args":["base-action/test/mcp-test/simple-mcp-server.ts"],"env":{}}}}'
+
+      - name: Check execution output
+        run: |
+          echo "Checking execution output for MCP test tool..."
+          OUTPUT_FILE="${{ runner.temp }}/claude-execution-output.json"
+
+          if [ ! -f "$OUTPUT_FILE" ]; then
+            echo "Error: Output file not found!"
+            exit 1
+          fi
+
+          # Check if the MCP test tool was mentioned in the response
+          if jq -e '.[] | select(.type == "assistant" and .content != null) | .content | contains("mcp__test-server__test_tool")' "$OUTPUT_FILE" > /dev/null; then
+            echo "✓ MCP test tool was mentioned in response"
+          else
+            echo "✗ MCP test tool not mentioned in response"
+            echo "Assistant responses:"
+            jq '.[] | select(.type == "assistant" and .content != null) | .content' "$OUTPUT_FILE"
+            exit 1
+          fi
+
+  # Test the outer action with file-based MCP config
+  test-outer-action-file-mcp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
+
+      - name: Install test MCP server dependencies
+        run: |
+          cd base-action/test/mcp-test
+          bun install
+
+      - name: Create MCP config file
+        run: |
+          cat > /tmp/test-mcp-config.json << 'EOF'
+          {
+            "mcpServers": {
+              "test-server": {
+                "type": "stdio",
+                "command": "bun",
+                "args": ["base-action/test/mcp-test/simple-mcp-server.ts"],
+                "env": {}
+              }
+            }
+          }
+          EOF
+
+      - name: Test outer action with file-based MCP config
+        uses: ./
+        with:
+          prompt: "Use the mcp__test-server__test_tool to test the MCP integration"
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: |
+            --mcp-config /tmp/test-mcp-config.json
+            --allowedTools mcp__test-server__test_tool
+
+      - name: Check tool usage
+        run: |
+          echo "Checking if MCP test tool was used..."
+          OUTPUT_FILE="${{ runner.temp }}/claude-execution-output.json"
+
+          if [ ! -f "$OUTPUT_FILE" ]; then
+            echo "Error: Output file not found!"
+            exit 1
+          fi
+
+          # Check if the tool was actually called
+          if jq -e '.[] | select(.type == "tool" and .name == "mcp__test-server__test_tool")' "$OUTPUT_FILE" > /dev/null; then
+            echo "✓ MCP test tool was called"
+            
+            # Check the tool result
+            if jq -e '.[] | select(.type == "tool-result" and .tool_name == "mcp__test-server__test_tool") | .result | contains("Hello from test tool")' "$OUTPUT_FILE" > /dev/null; then
+              echo "✓ MCP test tool returned expected result"
+            else
+              echo "✗ MCP test tool result not as expected"
+              jq '.[] | select(.type == "tool-result" and .tool_name == "mcp__test-server__test_tool")' "$OUTPUT_FILE"
+              exit 1
+            fi
+          else
+            echo "✗ MCP test tool was not called"
+            echo "Tools used:"
+            jq '.[] | select(.type == "tool") | .name' "$OUTPUT_FILE"
+            exit 1
+          fi

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -257,16 +257,17 @@ jobs:
 
           cat $OUTPUT_FILE
 
-          # Check if the tool was actually called
-          if jq -e '.[] | select(.type == "tool" and .name == "mcp__test-server__test_tool")' "$OUTPUT_FILE" > /dev/null; then
+          # Check if the tool was actually called - looking in assistant messages
+          if jq -e '.[] | select(.type == "assistant" and .message.content) | .message.content[] | select(.type == "tool_use" and .name == "mcp__test-server__test_tool")' "$OUTPUT_FILE" > /dev/null; then
             echo "✓ MCP test tool was called"
             
-            # Check the tool result
-            if jq -e '.[] | select(.type == "tool-result" and .tool_name == "mcp__test-server__test_tool") | .result | contains("Hello from test tool")' "$OUTPUT_FILE" > /dev/null; then
+            # Check the tool result - looking for the user message with tool_result
+            if jq -e '.[] | select(.type == "user" and .message.content[0].type == "tool_result") | .message.content[0].content[0].text | contains("Test tool response")' "$OUTPUT_FILE" > /dev/null; then
               echo "✓ MCP test tool returned expected result"
             else
               echo "✗ MCP test tool result not as expected"
-              jq '.[] | select(.type == "tool-result" and .tool_name == "mcp__test-server__test_tool")' "$OUTPUT_FILE"
+              echo "Tool results in output:"
+              jq '.[] | select(.type == "user") | .message.content[]? | select(.type == "tool_result")' "$OUTPUT_FILE"
               exit 1
             fi
           else

--- a/action.yml
+++ b/action.yml
@@ -61,10 +61,6 @@ inputs:
     description: "Additional arguments to pass directly to Claude CLI"
     required: false
     default: ""
-  mcp_config:
-    description: "Additional MCP configuration (JSON string) that merges with built-in GitHub MCP servers"
-    required: false
-    default: ""
   additional_permissions:
     description: "Additional GitHub permissions to request (e.g., 'actions: read')"
     required: false
@@ -146,7 +142,6 @@ runs:
         USE_COMMIT_SIGNING: ${{ inputs.use_commit_signing }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         CLAUDE_ARGS: ${{ inputs.claude_args }}
-        MCP_CONFIG: ${{ inputs.mcp_config }}
         ALL_INPUTS: ${{ toJson(inputs) }}
 
     - name: Install Base Action Dependencies

--- a/base-action/examples/issue-triage.yml
+++ b/base-action/examples/issue-triage.yml
@@ -103,5 +103,6 @@ jobs:
         with:
           prompt_file: /tmp/claude-prompts/triage-prompt.txt
           allowed_tools: "Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues"
-          mcp_config: /tmp/mcp-config/mcp-servers.json
+          claude_args: |
+            --mcp-config /tmp/mcp-config/mcp-servers.json
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -25,6 +25,7 @@ The following inputs have been deprecated and replaced:
 | `allowed_tools`       | `claude_args: --allowedTools`    | Use CLI format                                |
 | `disallowed_tools`    | `claude_args: --disallowedTools` | Use CLI format                                |
 | `claude_env`          | `settings` with env object       | Use settings JSON                             |
+| `mcp_config`          | `claude_args: --mcp-config`      | Pass MCP config via CLI arguments             |
 
 ## Migration Examples
 
@@ -156,17 +157,19 @@ claude_args: |
   --allowedTools Edit,Read,Write,Bash
   --disallowedTools WebSearch
   --system-prompt "You are a senior engineer focused on code quality"
+  --mcp-config '{"mcpServers": {"custom": {"command": "npx", "args": ["-y", "@example/server"]}}}'
 ```
 
 ### Common claude_args Options
 
-| Option              | Description              | Example                               |
-| ------------------- | ------------------------ | ------------------------------------- |
-| `--max-turns`       | Limit conversation turns | `--max-turns 10`                      |
-| `--model`           | Specify Claude model     | `--model claude-4-0-sonnet-20250805`  |
-| `--allowedTools`    | Enable specific tools    | `--allowedTools Edit,Read,Write`      |
-| `--disallowedTools` | Disable specific tools   | `--disallowedTools WebSearch`         |
-| `--system-prompt`   | Add system instructions  | `--system-prompt "Focus on security"` |
+| Option              | Description              | Example                                |
+| ------------------- | ------------------------ | -------------------------------------- |
+| `--max-turns`       | Limit conversation turns | `--max-turns 10`                       |
+| `--model`           | Specify Claude model     | `--model claude-4-0-sonnet-20250805`   |
+| `--allowedTools`    | Enable specific tools    | `--allowedTools Edit,Read,Write`       |
+| `--disallowedTools` | Disable specific tools   | `--disallowedTools WebSearch`          |
+| `--system-prompt`   | Add system instructions  | `--system-prompt "Focus on security"`  |
+| `--mcp-config`      | Add MCP server config    | `--mcp-config '{"mcpServers": {...}}'` |
 
 ## Provider-Specific Updates
 
@@ -190,6 +193,44 @@ claude_args: |
       --model claude-4-0-sonnet@20250805
 ```
 
+## MCP Configuration Migration
+
+### Adding Custom MCP Servers
+
+**Before (v0.x):**
+
+```yaml
+- uses: anthropics/claude-code-action@beta
+  with:
+    mcp_config: |
+      {
+        "mcpServers": {
+          "custom-server": {
+            "command": "npx",
+            "args": ["-y", "@example/server"]
+          }
+        }
+      }
+```
+
+**After (v1.0):**
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    claude_args: |
+      --mcp-config '{"mcpServers": {"custom-server": {"command": "npx", "args": ["-y", "@example/server"]}}}'
+```
+
+You can also pass MCP configuration from a file:
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    claude_args: |
+      --mcp-config /path/to/mcp-config.json
+```
+
 ## Step-by-Step Migration Checklist
 
 - [ ] Update action version from `@beta` to `@v1`
@@ -202,6 +243,7 @@ claude_args: |
 - [ ] Convert `allowed_tools` to `claude_args` with `--allowedTools`
 - [ ] Convert `disallowed_tools` to `claude_args` with `--disallowedTools`
 - [ ] Move `claude_env` to `settings` JSON format
+- [ ] Move `mcp_config` to `claude_args` with `--mcp-config`
 - [ ] Test workflow in a non-production environment
 
 ## Getting Help

--- a/src/entrypoints/collect-inputs.ts
+++ b/src/entrypoints/collect-inputs.ts
@@ -17,7 +17,6 @@ export function collectActionInputsPresence(): void {
     custom_instructions: "",
     direct_prompt: "",
     override_prompt: "",
-    mcp_config: "",
     additional_permissions: "",
     claude_env: "",
     settings: "",

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -119,13 +119,6 @@ export const agentMode: Mode = {
       claudeArgs = `--mcp-config '${escapedOurConfig}'`;
     }
 
-    // Add user's MCP_CONFIG env var as separate --mcp-config
-    const userMcpConfig = process.env.MCP_CONFIG;
-    if (userMcpConfig?.trim()) {
-      const escapedUserConfig = userMcpConfig.replace(/'/g, "'\\''");
-      claudeArgs = `${claudeArgs} --mcp-config '${escapedUserConfig}'`.trim();
-    }
-
     // Append user's claude_args (which may have more --mcp-config flags)
     claudeArgs = `${claudeArgs} ${userClaudeArgs}`.trim();
 

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -155,13 +155,6 @@ export const tagMode: Mode = {
     const escapedOurConfig = ourMcpConfig.replace(/'/g, "'\\''");
     claudeArgs = `--mcp-config '${escapedOurConfig}'`;
 
-    // Add user's MCP_CONFIG env var as separate --mcp-config
-    const userMcpConfig = process.env.MCP_CONFIG;
-    if (userMcpConfig?.trim()) {
-      const escapedUserConfig = userMcpConfig.replace(/'/g, "'\\''");
-      claudeArgs = `${claudeArgs} --mcp-config '${escapedUserConfig}'`;
-    }
-
     // Add required tools for tag mode
     claudeArgs += ` --allowedTools "${tagModeTools.join(",")}"`;
 


### PR DESCRIPTION
## Summary

This PR removes the deprecated `mcp_config` input and consolidates MCP configuration through the `claude_args` input using the `--mcp-config` flag. This simplifies the action's input surface area and aligns better with the Claude Code CLI interface.

## Breaking Change

**Before:**
```yaml
- uses: anthropics/claude-code-action@v1
  with:
    mcp_config: |
      {
        "mcpServers": {
          "custom-server": {
            "command": "npx",
            "args": ["-y", "@example/server"]
          }
        }
      }
```

**After:**
```yaml
- uses: anthropics/claude-code-action@v1
  with:
    claude_args: |
      --mcp-config '{"mcpServers": {"custom-server": {"command": "npx", "args": ["-y", "@example/server"]}}}'
```

## Changes

- Removed `mcp_config` input from `action.yml`
- Removed `MCP_CONFIG` environment variable handling from tag and agent modes
- Updated documentation to guide users to use `--mcp-config` in `claude_args`
- Updated all examples to use the new approach
- Added migration instructions in the migration guide

## Benefits

- Simplifies the action's input interface
- Aligns with Claude Code CLI conventions
- Users can still specify multiple MCP configurations using multiple `--mcp-config` flags
- Reduces code complexity by removing duplicate configuration paths

## Test Results

All tests pass ✅

🤖 Generated with [Claude Code](https://claude.ai/code)