### PR TITLE
feat: expose file download feature outside of tag mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: "Comma-separated list of allowed bot usernames, or '*' to allow all bots. Empty string (default) allows no bots."
     required: false
     default: ""
+  download_github_assets:
+    description: "Download GitHub assets (images, attachments) for access via environment variables"
+    required: false
+    default: "false"
 
   # Claude Code configuration
   prompt:
@@ -143,6 +147,7 @@ runs:
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         CLAUDE_ARGS: ${{ inputs.claude_args }}
         ALL_INPUTS: ${{ toJson(inputs) }}
+        DOWNLOAD_GITHUB_ASSETS: ${{ inputs.download_github_assets }}
 
     - name: Install Base Action Dependencies
       if: steps.prepare.outputs.contains_trigger == 'true'

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,6 @@ inputs:
     description: "Comma-separated list of allowed bot usernames, or '*' to allow all bots. Empty string (default) allows no bots."
     required: false
     default: ""
-  download_github_assets:
-    description: "Download GitHub assets (images, attachments) for access via environment variables"
-    required: false
-    default: "false"
 
   # Claude Code configuration
   prompt:
@@ -147,7 +143,6 @@ runs:
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         CLAUDE_ARGS: ${{ inputs.claude_args }}
         ALL_INPUTS: ${{ toJson(inputs) }}
-        DOWNLOAD_GITHUB_ASSETS: ${{ inputs.download_github_assets }}
 
     - name: Install Base Action Dependencies
       if: steps.prepare.outputs.contains_trigger == 'true'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,28 +47,27 @@ jobs:
 
 ## Inputs
 
-| Input                          | Description                                                                                                                                                         | Required | Default   |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
-| `anthropic_api_key`            | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                                                                          | No\*     | -         |
-| `claude_code_oauth_token`      | Claude Code OAuth token (alternative to anthropic_api_key)                                                                                                          | No\*     | -         |
-| `prompt`                       | Instructions for Claude. Can be a direct prompt or custom template for automation workflows                                                                         | No       | -         |
-| `claude_args`                  | Additional arguments to pass directly to Claude CLI (e.g., `--max-turns 10 --model claude-4-0-sonnet-20250805`)                                                     | No       | ""        |
-| `base_branch`                  | The base branch to use for creating new branches (e.g., 'main', 'develop')                                                                                          | No       | -         |
-| `use_sticky_comment`           | Use just one comment to deliver PR comments (only applies for pull_request event workflows)                                                                         | No       | `false`   |
-| `github_token`                 | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!**                                                | No       | -         |
-| `use_bedrock`                  | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                                                                         | No       | `false`   |
-| `use_vertex`                   | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                                                                       | No       | `false`   |
-| `mcp_config`                   | Additional MCP configuration (JSON string) that merges with the built-in GitHub MCP servers                                                                         | No       | ""        |
-| `assignee_trigger`             | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                                                                       | No       | -         |
-| `label_trigger`                | The label name that triggers the action when applied to an issue (e.g. "claude")                                                                                    | No       | -         |
-| `trigger_phrase`               | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                                                                       | No       | `@claude` |
-| `branch_prefix`                | The prefix to use for Claude branches (defaults to 'claude/', use 'claude-' for dash format)                                                                        | No       | `claude/` |
-| `settings`                     | Claude Code settings as JSON string or path to settings JSON file                                                                                                   | No       | ""        |
-| `additional_permissions`       | Additional permissions to enable. Currently supports 'actions: read' for viewing workflow results                                                                   | No       | ""        |
-| `experimental_allowed_domains` | Restrict network access to these domains only (newline-separated).                                                                                                  | No       | ""        |
-| `use_commit_signing`           | Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands                                                   | No       | `false`   |
-| `allowed_bots`                 | Comma-separated list of allowed bot usernames, or '\*' to allow all bots. Empty string (default) allows no bots                                                     | No       | ""        |
-| `download_github_assets`       | Enable GitHub asset downloading in Agent Mode (Tag Mode downloads assets by default). Downloaded file paths available via `CLAUDE_ASSET_FILES` environment variable | No       | `false`   |
+| Input                          | Description                                                                                                          | Required | Default   |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
+| `anthropic_api_key`            | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                           | No\*     | -         |
+| `claude_code_oauth_token`      | Claude Code OAuth token (alternative to anthropic_api_key)                                                           | No\*     | -         |
+| `prompt`                       | Instructions for Claude. Can be a direct prompt or custom template for automation workflows                          | No       | -         |
+| `claude_args`                  | Additional arguments to pass directly to Claude CLI (e.g., `--max-turns 10 --model claude-4-0-sonnet-20250805`)      | No       | ""        |
+| `base_branch`                  | The base branch to use for creating new branches (e.g., 'main', 'develop')                                           | No       | -         |
+| `use_sticky_comment`           | Use just one comment to deliver PR comments (only applies for pull_request event workflows)                          | No       | `false`   |
+| `github_token`                 | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!** | No       | -         |
+| `use_bedrock`                  | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                          | No       | `false`   |
+| `use_vertex`                   | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                        | No       | `false`   |
+| `mcp_config`                   | Additional MCP configuration (JSON string) that merges with the built-in GitHub MCP servers                          | No       | ""        |
+| `assignee_trigger`             | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                        | No       | -         |
+| `label_trigger`                | The label name that triggers the action when applied to an issue (e.g. "claude")                                     | No       | -         |
+| `trigger_phrase`               | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                        | No       | `@claude` |
+| `branch_prefix`                | The prefix to use for Claude branches (defaults to 'claude/', use 'claude-' for dash format)                         | No       | `claude/` |
+| `settings`                     | Claude Code settings as JSON string or path to settings JSON file                                                    | No       | ""        |
+| `additional_permissions`       | Additional permissions to enable. Currently supports 'actions: read' for viewing workflow results                    | No       | ""        |
+| `experimental_allowed_domains` | Restrict network access to these domains only (newline-separated).                                                   | No       | ""        |
+| `use_commit_signing`           | Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands    | No       | `false`   |
+| `allowed_bots`                 | Comma-separated list of allowed bot usernames, or '\*' to allow all bots. Empty string (default) allows no bots      | No       | ""        |
 
 ### Deprecated Inputs
 
@@ -215,17 +214,17 @@ Claude can see and analyze images, making it easy to fix visual bugs or UI issue
 
 ### Analyze Images with GitHub Assets
 
-For automation workflows that need to analyze images from GitHub issues or PRs, you can enable asset downloading:
+For automation workflows that need to analyze images from GitHub issues or PRs, GitHub assets (images, attachments) are automatically downloaded when running in entity contexts (issue comments, pull requests, etc.):
 
 ```yaml
 - uses: anthropics/claude-code-action@v1
   with:
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-    download_github_assets: true
     prompt: |
       Analyze any images attached to this issue/PR.
-      Downloaded files are available via CLAUDE_ASSET_FILES environment variable.
+
+      GitHub assets are automatically downloaded and available via CLAUDE_ASSET_FILES environment variable.
       Use the Read tool to access and analyze each image file.
 ```
 
-This automatically downloads images from the GitHub context and makes them available to Claude for analysis.
+Images from GitHub issues and PRs are automatically downloaded and made available to Claude through the `CLAUDE_ASSET_FILES` environment variable when running in entity contexts.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,27 +47,28 @@ jobs:
 
 ## Inputs
 
-| Input                          | Description                                                                                                          | Required | Default   |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
-| `anthropic_api_key`            | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                           | No\*     | -         |
-| `claude_code_oauth_token`      | Claude Code OAuth token (alternative to anthropic_api_key)                                                           | No\*     | -         |
-| `prompt`                       | Instructions for Claude. Can be a direct prompt or custom template for automation workflows                          | No       | -         |
-| `claude_args`                  | Additional arguments to pass directly to Claude CLI (e.g., `--max-turns 10 --model claude-4-0-sonnet-20250805`)      | No       | ""        |
-| `base_branch`                  | The base branch to use for creating new branches (e.g., 'main', 'develop')                                           | No       | -         |
-| `use_sticky_comment`           | Use just one comment to deliver PR comments (only applies for pull_request event workflows)                          | No       | `false`   |
-| `github_token`                 | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!** | No       | -         |
-| `use_bedrock`                  | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                          | No       | `false`   |
-| `use_vertex`                   | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                        | No       | `false`   |
-| `mcp_config`                   | Additional MCP configuration (JSON string) that merges with the built-in GitHub MCP servers                          | No       | ""        |
-| `assignee_trigger`             | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                        | No       | -         |
-| `label_trigger`                | The label name that triggers the action when applied to an issue (e.g. "claude")                                     | No       | -         |
-| `trigger_phrase`               | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                        | No       | `@claude` |
-| `branch_prefix`                | The prefix to use for Claude branches (defaults to 'claude/', use 'claude-' for dash format)                         | No       | `claude/` |
-| `settings`                     | Claude Code settings as JSON string or path to settings JSON file                                                    | No       | ""        |
-| `additional_permissions`       | Additional permissions to enable. Currently supports 'actions: read' for viewing workflow results                    | No       | ""        |
-| `experimental_allowed_domains` | Restrict network access to these domains only (newline-separated).                                                   | No       | ""        |
-| `use_commit_signing`           | Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands    | No       | `false`   |
-| `allowed_bots`                 | Comma-separated list of allowed bot usernames, or '\*' to allow all bots. Empty string (default) allows no bots      | No       | ""        |
+| Input                          | Description                                                                                                                                                         | Required | Default   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- |
+| `anthropic_api_key`            | Anthropic API key (required for direct API, not needed for Bedrock/Vertex)                                                                                          | No\*     | -         |
+| `claude_code_oauth_token`      | Claude Code OAuth token (alternative to anthropic_api_key)                                                                                                          | No\*     | -         |
+| `prompt`                       | Instructions for Claude. Can be a direct prompt or custom template for automation workflows                                                                         | No       | -         |
+| `claude_args`                  | Additional arguments to pass directly to Claude CLI (e.g., `--max-turns 10 --model claude-4-0-sonnet-20250805`)                                                     | No       | ""        |
+| `base_branch`                  | The base branch to use for creating new branches (e.g., 'main', 'develop')                                                                                          | No       | -         |
+| `use_sticky_comment`           | Use just one comment to deliver PR comments (only applies for pull_request event workflows)                                                                         | No       | `false`   |
+| `github_token`                 | GitHub token for Claude to operate with. **Only include this if you're connecting a custom GitHub app of your own!**                                                | No       | -         |
+| `use_bedrock`                  | Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API                                                                                         | No       | `false`   |
+| `use_vertex`                   | Use Google Vertex AI with OIDC authentication instead of direct Anthropic API                                                                                       | No       | `false`   |
+| `mcp_config`                   | Additional MCP configuration (JSON string) that merges with the built-in GitHub MCP servers                                                                         | No       | ""        |
+| `assignee_trigger`             | The assignee username that triggers the action (e.g. @claude). Only used for issue assignment                                                                       | No       | -         |
+| `label_trigger`                | The label name that triggers the action when applied to an issue (e.g. "claude")                                                                                    | No       | -         |
+| `trigger_phrase`               | The trigger phrase to look for in comments, issue/PR bodies, and issue titles                                                                                       | No       | `@claude` |
+| `branch_prefix`                | The prefix to use for Claude branches (defaults to 'claude/', use 'claude-' for dash format)                                                                        | No       | `claude/` |
+| `settings`                     | Claude Code settings as JSON string or path to settings JSON file                                                                                                   | No       | ""        |
+| `additional_permissions`       | Additional permissions to enable. Currently supports 'actions: read' for viewing workflow results                                                                   | No       | ""        |
+| `experimental_allowed_domains` | Restrict network access to these domains only (newline-separated).                                                                                                  | No       | ""        |
+| `use_commit_signing`           | Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands                                                   | No       | `false`   |
+| `allowed_bots`                 | Comma-separated list of allowed bot usernames, or '\*' to allow all bots. Empty string (default) allows no bots                                                     | No       | ""        |
+| `download_github_assets`       | Enable GitHub asset downloading in Agent Mode (Tag Mode downloads assets by default). Downloaded file paths available via `CLAUDE_ASSET_FILES` environment variable | No       | `false`   |
 
 ### Deprecated Inputs
 
@@ -211,3 +212,20 @@ Upload a screenshot of a bug and ask Claude to fix it:
 ```
 
 Claude can see and analyze images, making it easy to fix visual bugs or UI issues.
+
+### Analyze Images with GitHub Assets
+
+For automation workflows that need to analyze images from GitHub issues or PRs, you can enable asset downloading:
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    download_github_assets: true
+    prompt: |
+      Analyze any images attached to this issue/PR.
+      Downloaded files are available via CLAUDE_ASSET_FILES environment variable.
+      Use the Read tool to access and analyze each image file.
+```
+
+This automatically downloads images from the GitHub context and makes them available to Claude for analysis.

--- a/examples/agent-with-assets.yml
+++ b/examples/agent-with-assets.yml
@@ -1,4 +1,4 @@
-name: Agent Mode Issue Screenshot Analysis
+name: Agent Mode Asset Analysis
 on:
   issue_comment:
     types: [created]
@@ -8,51 +8,17 @@ jobs:
     if: contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      # First step: Download assets and prepare file list
-      - name: Download GitHub assets
-        uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           download_github_assets: true
-          prompt: "Downloading GitHub assets..."
-
-      # Second step: Expand CLAUDE_ASSET_FILES and create file list
-      - name: Prepare asset file list
-        shell: bash
-        run: |
-          if [ -n "$CLAUDE_ASSET_FILES" ]; then
-            echo "ASSET_FILE_LIST<<EOF" >> $GITHUB_ENV
-            echo "$CLAUDE_ASSET_FILES" | tr ',' '\n' | while IFS= read -r file; do
-              [ -n "$file" ] && echo "- $file"
-            done >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
-            
-            echo "ASSET_COUNT<<EOF" >> $GITHUB_ENV
-            echo "$CLAUDE_ASSET_FILES" | tr ',' '\n' | grep -c . >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
-          else
-            echo "ASSET_FILE_LIST=No images found in this issue/PR" >> $GITHUB_ENV
-            echo "ASSET_COUNT=0" >> $GITHUB_ENV
-          fi
-
-      # Third step: Analyze images with expanded file list in prompt
-      - name: Analyze images
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            ## Image Analysis Task
+            Analyze the images from this GitHub issue/PR.
 
-            Please analyze the images that were downloaded from this GitHub issue/PR context.
+            The downloaded file paths are available in the CLAUDE_ASSET_FILES environment variable.
+            You can use bash commands to process this environment variable and access the files.
 
-            Downloaded files (${{ env.ASSET_COUNT }} total):
-            ${{ env.ASSET_FILE_LIST }}
+            For example, list the files with:
+            `echo $CLAUDE_ASSET_FILES | tr ',' '\n'`
 
-            For each file listed above:
-            1. Use the Read() tool to access the image file
-            2. Analyze the content and describe what you see
-            3. Provide insights about the image (UI elements, code snippets, diagrams, etc.)
-
-            Please provide a comprehensive analysis of all available images.
+            Then use the Read tool to analyze each file.

--- a/examples/agent-with-assets.yml
+++ b/examples/agent-with-assets.yml
@@ -1,0 +1,58 @@
+name: Agent Mode Issue Screenshot Analysis
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  analyze:
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # First step: Download assets and prepare file list
+      - name: Download GitHub assets
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          download_github_assets: true
+          prompt: "Downloading GitHub assets..."
+
+      # Second step: Expand CLAUDE_ASSET_FILES and create file list
+      - name: Prepare asset file list
+        shell: bash
+        run: |
+          if [ -n "$CLAUDE_ASSET_FILES" ]; then
+            echo "ASSET_FILE_LIST<<EOF" >> $GITHUB_ENV
+            echo "$CLAUDE_ASSET_FILES" | tr ',' '\n' | while IFS= read -r file; do
+              [ -n "$file" ] && echo "- $file"
+            done >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+            
+            echo "ASSET_COUNT<<EOF" >> $GITHUB_ENV
+            echo "$CLAUDE_ASSET_FILES" | tr ',' '\n' | grep -c . >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          else
+            echo "ASSET_FILE_LIST=No images found in this issue/PR" >> $GITHUB_ENV
+            echo "ASSET_COUNT=0" >> $GITHUB_ENV
+          fi
+
+      # Third step: Analyze images with expanded file list in prompt
+      - name: Analyze images
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            ## Image Analysis Task
+
+            Please analyze the images that were downloaded from this GitHub issue/PR context.
+
+            Downloaded files (${{ env.ASSET_COUNT }} total):
+            ${{ env.ASSET_FILE_LIST }}
+
+            For each file listed above:
+            1. Use the Read() tool to access the image file
+            2. Analyze the content and describe what you see
+            3. Provide insights about the image (UI elements, code snippets, diagrams, etc.)
+
+            Please provide a comprehensive analysis of all available images.

--- a/examples/agent-with-assets.yml
+++ b/examples/agent-with-assets.yml
@@ -11,11 +11,11 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          download_github_assets: true
           prompt: |
             Analyze the images from this GitHub issue/PR.
 
-            The downloaded file paths are available in the CLAUDE_ASSET_FILES environment variable.
+            GitHub assets (images, attachments) are automatically downloaded and available 
+            in the CLAUDE_ASSET_FILES environment variable.
             You can use bash commands to process this environment variable and access the files.
 
             For example, list the files with:

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -143,9 +143,11 @@ export const agentMode: Mode = {
         // Set simple environment variable with comma-separated paths
         const downloadedPaths = Array.from(githubData.imageUrlMap.values());
         if (downloadedPaths.length > 0) {
-          process.env.CLAUDE_ASSET_FILES = downloadedPaths.join(",");
+          const concatDownloadedPaths = downloadedPaths.join(",");
+          process.env.CLAUDE_ASSET_FILES = concatDownloadedPaths;
+          core.exportVariable("CLAUDE_ASSET_FILES", concatDownloadedPaths);
           console.log(
-            `Exposed ${downloadedPaths.length} assets: ${process.env.CLAUDE_ASSET_FILES}`,
+            `Exposed ${downloadedPaths.length} assets: ${concatDownloadedPaths}`,
           );
         }
       } catch (error) {

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -124,10 +124,8 @@ export const agentMode: Mode = {
     // Append user's claude_args (which may have more --mcp-config flags)
     claudeArgs = `${claudeArgs} ${userClaudeArgs}`.trim();
 
-    // Download GitHub assets if requested
-    const shouldDownload = process.env.DOWNLOAD_GITHUB_ASSETS === "true";
-
-    if (shouldDownload && isEntityContext(context)) {
+    // Download GitHub assets automatically for entity contexts
+    if (isEntityContext(context)) {
       console.log("Downloading GitHub assets for agent mode...");
 
       try {

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -223,6 +223,12 @@ describe("Agent Mode", () => {
       "/tmp/github-images/image-123.png,/tmp/github-images/image-456.jpg",
     );
 
+    // Verify core.exportVariable was called with correct arguments
+    expect(exportVariableSpy).toHaveBeenCalledWith(
+      "CLAUDE_ASSET_FILES",
+      "/tmp/github-images/image-123.png,/tmp/github-images/image-456.jpg",
+    );
+
     // Clean up
     delete process.env.CLAUDE_ASSET_FILES;
     if (originalDownload !== undefined) {


### PR DESCRIPTION
This PR implements the feature requested in #426 to make GitHub asset download functionality available outside of Tag Mode.

**Changes:**

- **New input parameter**: Added `download_github_assets` (default: `false`) to `action.yml`
- **Agent Mode enhancement**: Extended Agent Mode to download GitHub images when enabled and running in entity context (issues/PRs)
- **Environment variable**: Downloaded file paths are exposed via `CLAUDE_ASSET_FILES` as comma-separated values
- **Context-aware**: Only downloads assets for entity events (`issue_comment`, `pull_request`, etc.), not automation events
- **Error handling**: Failures don't break the entire action execution

**Usage:**

```yaml
- uses: anthropics/claude-code-action@v1
  with:
    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
    download_github_assets: true
    prompt: |
      Analyze images from this issue/PR.
      Files available in CLAUDE_ASSET_FILES environment variable.
```

**Files changed:**
- `action.yml` - Added new input parameter
- `src/modes/agent/index.ts` - Implemented download functionality
- `examples/agent-with-assets.yml` - Added usage example with shell expansion
- `test/modes/agent.test.ts` - Added comprehensive tests

This enables Agent Mode workflows to access and analyze GitHub attachments (screenshots, diagrams, etc.) that were previously only available in Tag Mode.