### PR TITLE
Add debug logging to checkContainsTrigger for test debugging

### DIFF
--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -12,9 +12,22 @@ import {
 import type { ParsedGitHubContext } from "../context";
 
 export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
+  console.log("checkContainsTrigger called with context:", {
+    eventName: context.eventName,
+    eventAction: context.eventAction,
+    inputs: context.inputs,
+  });
+
   const {
     inputs: { assigneeTrigger, labelTrigger, triggerPhrase, prompt },
   } = context;
+
+  console.log("Extracted inputs:", {
+    assigneeTrigger,
+    labelTrigger,
+    triggerPhrase,
+    prompt,
+  });
 
   // If prompt is provided, always trigger
   if (prompt) {
@@ -46,15 +59,21 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
 
   // Check for issue body and title trigger on issue creation
   if (isIssuesEvent(context) && context.eventAction === "opened") {
+    console.log("Checking issue opened trigger");
     const issueBody = context.payload.issue.body || "";
     const issueTitle = context.payload.issue.title || "";
+    console.log("Issue content:", { issueBody, issueTitle });
+
     // Check for exact match with word boundaries or punctuation
     const regex = new RegExp(
       `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
     );
+    console.log("Regex pattern:", regex.toString());
 
     // Check in body
-    if (regex.test(issueBody)) {
+    const bodyMatch = regex.test(issueBody);
+    console.log("Body match result:", bodyMatch);
+    if (bodyMatch) {
       console.log(
         `Issue body contains exact trigger phrase '${triggerPhrase}'`,
       );
@@ -62,7 +81,9 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     }
 
     // Check in title
-    if (regex.test(issueTitle)) {
+    const titleMatch = regex.test(issueTitle);
+    console.log("Title match result:", titleMatch);
+    if (titleMatch) {
       console.log(
         `Issue title contains exact trigger phrase '${triggerPhrase}'`,
       );
@@ -133,6 +154,7 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
   }
 
   console.log(`No trigger was met for ${triggerPhrase}`);
+  console.log("Returning false from checkContainsTrigger");
 
   return false;
 }

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -24,11 +24,16 @@ export const tagMode: Mode = {
   description: "Traditional implementation mode triggered by @claude mentions",
 
   shouldTrigger(context) {
+    console.log("tagMode.shouldTrigger called");
     // Tag mode only handles entity events
     if (!isEntityContext(context)) {
+      console.log("Not entity context, returning false");
       return false;
     }
-    return checkContainsTrigger(context);
+    console.log("Is entity context, calling checkContainsTrigger");
+    const result = checkContainsTrigger(context);
+    console.log("checkContainsTrigger returned:", result);
+    return result;
   },
 
   prepareContext(context, data) {

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -72,7 +72,7 @@ export const createMockAutomationContext = (
 
   const mergedInputs = overrides.inputs
     ? { ...defaultInputs, ...overrides.inputs }
-    : defaultInputs;
+    : { ...defaultInputs };
 
   return { ...baseContext, ...overrides, inputs: mergedInputs };
 };

--- a/test/modes/tag.test.ts
+++ b/test/modes/tag.test.ts
@@ -22,7 +22,7 @@ describe("Tag Mode", () => {
     expect(tagMode.shouldCreateTrackingComment()).toBe(true);
   });
 
-  test("shouldTrigger delegates to checkContainsTrigger", () => {
+  test.only("shouldTrigger delegates to checkContainsTrigger", () => {
     const contextWithTrigger = createMockContext({
       eventName: "issue_comment",
       isPR: false,

--- a/test/modes/tag.test.ts
+++ b/test/modes/tag.test.ts
@@ -22,7 +22,8 @@ describe("Tag Mode", () => {
     expect(tagMode.shouldCreateTrackingComment()).toBe(true);
   });
 
-  test.only("shouldTrigger delegates to checkContainsTrigger", () => {
+  test("shouldTrigger delegates to checkContainsTrigger", () => {
+    console.log("enter test");
     const contextWithTrigger = createMockContext({
       eventName: "issue_comment",
       isPR: false,


### PR DESCRIPTION
Added console.log statements to trace execution flow in trigger validation:
- Log context and inputs at function entry
- Log issue content and regex pattern matching
- Log final return value
- Add logging to tagMode.shouldTrigger to trace delegation

These logs help debug the 'shouldTrigger delegates to checkContainsTrigger' test.