### PR TITLE
fix: prevent test pollution by ensuring inputs are cloned

### DIFF
--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -72,7 +72,7 @@ export const createMockAutomationContext = (
 
   const mergedInputs = overrides.inputs
     ? { ...defaultInputs, ...overrides.inputs }
-    : defaultInputs;
+    : { ...defaultInputs };
 
   return { ...baseContext, ...overrides, inputs: mergedInputs };
 };


### PR DESCRIPTION
## Summary
- Always create a new object copy of defaultInputs to prevent mutations from affecting other tests
- Ensures test isolation by avoiding shared object references

## Test plan
- [ ] Existing tests pass
- [ ] No test pollution occurs when tests modify inputs

🤖 Generated with [Claude Code](https://claude.ai/code)