### PR TITLE
feat: make MCP servers conditional in agent mode

### DIFF
--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -161,9 +161,11 @@ describe("Agent Mode", () => {
 
     // Note: We can't easily test file creation in this unit test,
     // but we can verify the method completes without errors
-    // Agent mode now includes MCP config even with empty user args
+    // With our conditional MCP logic, agent mode with no allowed tools
+    // should not include any MCP config
     const callArgs = setOutputSpy.mock.calls[0];
     expect(callArgs[0]).toBe("claude_args");
-    expect(callArgs[1]).toContain("--mcp-config");
+    // Should be empty or just whitespace when no MCP servers are included
+    expect(callArgs[1]).not.toContain("--mcp-config");
   });
 });


### PR DESCRIPTION
## Summary
- MCP servers (github_comment, github_ci) are now conditional in agent mode
- They are only included when explicitly requested via allowedTools
- Tag mode behavior remains unchanged (auto-inclusion)

## Motivation
Currently, MCP servers are automatically included in both tag and agent modes. This causes issues for agent mode workflows that don't need these servers, as they are auto-provisioned even when not wanted.

This change gives agent mode workflows complete control over which MCP servers are included.

## Changes
- Added agent mode detection in `prepareMcpConfig` by checking `context.inputs?.prompt`
- Added tool detection helpers for `mcp__github_comment__*` and `mcp__github_ci__*` tools
- Modified github_comment server inclusion logic:
  - Tag mode: Always included (preserves existing behavior)
  - Agent mode: Only included if `mcp__github_comment__*` tools in allowedTools
- Modified github_ci server inclusion logic:
  - Tag mode: Included for PRs with proper permissions (preserves existing behavior)
  - Agent mode: Only included if `mcp__github_ci__*` tools in allowedTools AND PR/permission requirements met

## Test plan
- [ ] Verify agent mode with no MCP tools in allowedTools → no servers added
- [ ] Verify agent mode with github_comment tools → github_comment server added
- [ ] Verify agent mode with github_ci tools → github_ci server added
- [ ] Verify tag mode still works as before (auto-inclusion)
- [x] All formatting and typechecking passes

🤖 Generated with [Claude Code](https://claude.ai/code)