### PR TITLE
fix: add missing id-token: write permissions to issue triage workflow

### DIFF
--- a/examples/issue-triage.yml
+++ b/examples/issue-triage.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Fixes the OIDC authentication issue by adding the required id-token: write permission to the GitHub Actions workflow for issue triage.

🤖 Generated with [Claude Code](https://claude.ai/code)