### PR TITLE
fix: use agent mode for issues events with explicit prompts

### DIFF
--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -44,6 +44,10 @@ export function detectMode(context: GitHubContext): AutoDetectedMode {
 
   // Issue events
   if (isEntityContext(context) && isIssuesEvent(context)) {
+    // If prompt is provided, use agent mode (same as PR events)
+    if (context.inputs.prompt) {
+      return "agent";
+    }
     // Check for @claude mentions or labels/assignees
     if (checkContainsTrigger(context)) {
       return "tag";

--- a/tests/modes/detector.test.ts
+++ b/tests/modes/detector.test.ts
@@ -113,6 +113,33 @@ describe("detectMode with enhanced routing", () => {
 
       expect(detectMode(context)).toBe("agent");
     });
+
+    it("should use agent mode for issues with explicit prompt", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "issues",
+        eventAction: "opened",
+        payload: { issue: { number: 1, body: "Test issue" } } as any,
+        entityNumber: 1,
+        isPR: false,
+        inputs: { ...baseContext.inputs, prompt: "Analyze this issue" },
+      };
+
+      expect(detectMode(context)).toBe("agent");
+    });
+
+    it("should use tag mode for issues with @claude mention and no prompt", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "issues",
+        eventAction: "opened",
+        payload: { issue: { number: 1, body: "@claude help" } } as any,
+        entityNumber: 1,
+        isPR: false,
+      };
+
+      expect(detectMode(context)).toBe("tag");
+    });
   });
 
   describe("Comment Events (unchanged behavior)", () => {


### PR DESCRIPTION
## Summary
Fixes #528 - Issues events now correctly use agent mode when an explicit prompt is provided in the workflow YAML, matching the behavior of PR events.

## Problem
Previously, issues events would always use tag mode (with tracking comments) even when a prompt was provided, creating inconsistent behavior compared to pull request events which correctly used agent mode for automation.

## Solution
Added a check for explicit prompts in the issues event detection logic before checking for triggers. This ensures:
- Issues with explicit prompts → agent mode (silent automation)
- Issues with @claude/labels/assignees → tag mode (tracking comments)
- Consistent behavior across PR and issue events

## Changes
- Updated `src/modes/detector.ts` to check for explicit prompts in issues events
- Added comprehensive tests to verify the new behavior

## Test Plan
- [x] Added test: `should use agent mode for issues with explicit prompt`
- [x] Added test: `should use tag mode for issues with @claude mention and no prompt`
- [x] All existing tests pass
- [x] Verified the fix addresses the exact scenario described in #528

🤖 Generated with [Claude Code](https://claude.ai/code)