### PR TITLE
fix: update action reference to claude-code-action in issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -97,7 +97,7 @@ jobs:
           EOF
 
       - name: Run Claude Code for Issue Triage
-        uses: anthropics/claude-code-base-action@v1
+        uses: anthropics/claude-code-action@v1
         with:
           prompt: $(cat /tmp/claude-prompts/triage-prompt.txt)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION


Changed from @anthropics/claude-code-base-action to @anthropics/claude-code-action to use the correct action name in the issue triage workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)