### PR TITLE
fix: remove OIDC id-token permission and add github_token input

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -11,7 +11,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -102,6 +101,7 @@ jobs:
         with:
           prompt: $(cat /tmp/claude-prompts/triage-prompt.txt)
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --allowedTools Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues
             --mcp-config /tmp/mcp-config/mcp-servers.json

--- a/examples/issue-triage.yml
+++ b/examples/issue-triage.yml
@@ -10,7 +10,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -72,5 +71,6 @@ jobs:
             - It's okay to not add any labels if none are clearly applicable
 
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: |
             --allowedTools "Bash(gh label list),mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__search_issues,mcp__github__list_issues"


### PR DESCRIPTION
Removes the OIDC id-token permission requirement and adds explicit github_token input to both workflow files. This simplifies authentication by using the standard GITHUB_TOKEN instead of requiring OIDC token exchange.

🤖 Generated with [Claude Code](https://claude.ai/code)