### PR TITLE
feat: add repository_dispatch event support

### DIFF
--- a/docs/custom-automations.md
+++ b/docs/custom-automations.md
@@ -21,7 +21,7 @@ This action supports the following GitHub events ([learn more GitHub event trigg
 - `issues` - When issues are opened or assigned
 - `pull_request_review` - When PR reviews are submitted
 - `pull_request_review_comment` - When comments are made on PR reviews
-- `repository_dispatch` - Custom events triggered via API (coming soon)
+- `repository_dispatch` - Custom events triggered via API
 - `workflow_dispatch` - Manual workflow triggers (coming soon)
 
 ## Automated Documentation Updates

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -26,6 +26,20 @@ export type WorkflowDispatchEvent = {
   workflow: string;
 };
 
+export type RepositoryDispatchEvent = {
+  action: string;
+  client_payload?: Record<string, any>;
+  repository: {
+    name: string;
+    owner: {
+      login: string;
+    };
+  };
+  sender: {
+    login: string;
+  };
+};
+
 export type ScheduleEvent = {
   action?: never;
   schedule?: string;
@@ -48,6 +62,7 @@ const ENTITY_EVENT_NAMES = [
 
 const AUTOMATION_EVENT_NAMES = [
   "workflow_dispatch",
+  "repository_dispatch",
   "schedule",
   "workflow_run",
 ] as const;
@@ -95,10 +110,10 @@ export type ParsedGitHubContext = BaseContext & {
   isPR: boolean;
 };
 
-// Context for automation events (workflow_dispatch, schedule, workflow_run)
+// Context for automation events (workflow_dispatch, repository_dispatch, schedule, workflow_run)
 export type AutomationContext = BaseContext & {
   eventName: AutomationEventName;
-  payload: WorkflowDispatchEvent | ScheduleEvent | WorkflowRunEvent;
+  payload: WorkflowDispatchEvent | RepositoryDispatchEvent | ScheduleEvent | WorkflowRunEvent;
 };
 
 // Union type for all contexts
@@ -188,6 +203,13 @@ export function parseGitHubContext(): GitHubContext {
         ...commonFields,
         eventName: "workflow_dispatch",
         payload: context.payload as unknown as WorkflowDispatchEvent,
+      };
+    }
+    case "repository_dispatch": {
+      return {
+        ...commonFields,
+        eventName: "repository_dispatch",
+        payload: context.payload as unknown as RepositoryDispatchEvent,
       };
     }
     case "schedule": {

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -113,7 +113,11 @@ export type ParsedGitHubContext = BaseContext & {
 // Context for automation events (workflow_dispatch, repository_dispatch, schedule, workflow_run)
 export type AutomationContext = BaseContext & {
   eventName: AutomationEventName;
-  payload: WorkflowDispatchEvent | RepositoryDispatchEvent | ScheduleEvent | WorkflowRunEvent;
+  payload:
+    | WorkflowDispatchEvent
+    | RepositoryDispatchEvent
+    | ScheduleEvent
+    | WorkflowRunEvent;
 };
 
 // Union type for all contexts

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -1,6 +1,7 @@
 import type {
   ParsedGitHubContext,
   AutomationContext,
+  RepositoryDispatchEvent,
 } from "../src/github/context";
 import type {
   IssuesEvent,
@@ -79,6 +80,33 @@ export const createMockAutomationContext = (
     : { ...defaultInputs };
 
   return { ...baseContext, ...overrides, inputs: mergedInputs };
+};
+
+export const mockRepositoryDispatchContext: AutomationContext = {
+  runId: "1234567890",
+  eventName: "repository_dispatch",
+  eventAction: undefined,
+  repository: defaultRepository,
+  actor: "automation-user",
+  payload: {
+    action: "trigger-analysis",
+    client_payload: {
+      source: "issue-detective",
+      issue_number: 42,
+      repository_name: "test-owner/test-repo",
+      analysis_type: "bug-report",
+    },
+    repository: {
+      name: "test-repo",
+      owner: {
+        login: "test-owner",
+      },
+    },
+    sender: {
+      login: "automation-user",
+    },
+  } as RepositoryDispatchEvent,
+  inputs: defaultInputs,
 };
 
 export const mockIssueOpenedContext: ParsedGitHubContext = {

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -107,8 +107,8 @@ describe("Agent Mode", () => {
 
     allEvents.forEach((eventName) => {
       const contextWithPrompt =
-        eventName === "workflow_dispatch" || 
-        eventName === "repository_dispatch" || 
+        eventName === "workflow_dispatch" ||
+        eventName === "repository_dispatch" ||
         eventName === "schedule"
           ? createMockAutomationContext({
               eventName,

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -76,6 +76,11 @@ describe("Agent Mode", () => {
     });
     expect(agentMode.shouldTrigger(scheduleContext)).toBe(false);
 
+    const repositoryDispatchContext = createMockAutomationContext({
+      eventName: "repository_dispatch",
+    });
+    expect(agentMode.shouldTrigger(repositoryDispatchContext)).toBe(false);
+
     // Should NOT trigger for entity events without prompt
     const entityEvents = [
       "issue_comment",
@@ -92,6 +97,7 @@ describe("Agent Mode", () => {
     // Should trigger for ANY event when prompt is provided
     const allEvents = [
       "workflow_dispatch",
+      "repository_dispatch",
       "schedule",
       "issue_comment",
       "pull_request",
@@ -101,7 +107,9 @@ describe("Agent Mode", () => {
 
     allEvents.forEach((eventName) => {
       const contextWithPrompt =
-        eventName === "workflow_dispatch" || eventName === "schedule"
+        eventName === "workflow_dispatch" || 
+        eventName === "repository_dispatch" || 
+        eventName === "schedule"
           ? createMockAutomationContext({
               eventName,
               inputs: { prompt: "Do something" },

--- a/test/modes/registry.test.ts
+++ b/test/modes/registry.test.ts
@@ -76,7 +76,7 @@ describe("Mode Registry", () => {
         sender: { login: "automation-user" },
       },
     });
-    
+
     const mode = getMode(contextWithPayload);
     expect(mode).toBe(agentMode);
     expect(mode.name).toBe("agent");

--- a/test/modes/registry.test.ts
+++ b/test/modes/registry.test.ts
@@ -2,7 +2,11 @@ import { describe, test, expect } from "bun:test";
 import { getMode, isValidMode } from "../../src/modes/registry";
 import { agentMode } from "../../src/modes/agent";
 import { tagMode } from "../../src/modes/tag";
-import { createMockContext, createMockAutomationContext } from "../mockContext";
+import {
+  createMockContext,
+  createMockAutomationContext,
+  mockRepositoryDispatchContext,
+} from "../mockContext";
 
 describe("Mode Registry", () => {
   const mockContext = createMockContext({
@@ -46,6 +50,34 @@ describe("Mode Registry", () => {
 
   test("getMode auto-detects agent for schedule event", () => {
     const mode = getMode(mockScheduleContext);
+    expect(mode).toBe(agentMode);
+    expect(mode.name).toBe("agent");
+  });
+
+  test("getMode auto-detects agent for repository_dispatch event", () => {
+    const mode = getMode(mockRepositoryDispatchContext);
+    expect(mode).toBe(agentMode);
+    expect(mode.name).toBe("agent");
+  });
+
+  test("getMode auto-detects agent for repository_dispatch with client_payload", () => {
+    const contextWithPayload = createMockAutomationContext({
+      eventName: "repository_dispatch",
+      payload: {
+        action: "trigger-analysis",
+        client_payload: {
+          source: "external-system",
+          metadata: { priority: "high" },
+        },
+        repository: {
+          name: "test-repo",
+          owner: { login: "test-owner" },
+        },
+        sender: { login: "automation-user" },
+      },
+    });
+    
+    const mode = getMode(contextWithPayload);
     expect(mode).toBe(agentMode);
     expect(mode.name).toBe("agent");
   });


### PR DESCRIPTION
## Summary
- Add support for repository_dispatch events in GitHub context parsing system
- Enable the action to handle custom API-triggered events properly
- Add comprehensive test coverage for repository_dispatch functionality

## Changes
- Add `RepositoryDispatchEvent` type definition in context.ts:29-41  
- Include `repository_dispatch` in `AUTOMATION_EVENT_NAMES` array
- Update `AutomationContext` payload union type to include `RepositoryDispatchEvent`
- Add case handler for `repository_dispatch` in `parseGitHubContext()` function
- Update documentation to reflect `repository_dispatch` availability (remove "coming soon")

## Test Coverage Added
- Add `mockRepositoryDispatchContext` with realistic payload structure in test/mockContext.ts
- Add repository_dispatch mode detection tests in test/modes/registry.test.ts
- Add repository_dispatch trigger tests in test/modes/agent.test.ts  
- Verify repository_dispatch events are properly handled as automation events
- Ensure agent mode trigger behavior works correctly with and without prompts
- All 394 tests passing with new repository_dispatch coverage

## Integration Testing
Tested the implementation using a live workflow in [bogini/claude-code-action-testing](https://github.com/bogini/claude-code-action-testing):

- **Test Workflow**: [test-repository-dispatch.yml](https://github.com/bogini/claude-code-action-testing/blob/main/.github/workflows/test-repository-dispatch.yml)
- **Successful Run**: [Actions Run #17505331407](https://github.com/bogini/claude-code-action-testing/actions/runs/17505331407)
- **Trigger Method**: Used `gh api` to send repository_dispatch events with `test-claude-action` event type
- **Branch Tested**: `anthropics/claude-code-action@inigo/add-repository-dispatch-support`

The integration test confirms that:
✅ repository_dispatch events properly trigger the action
✅ Claude responds correctly to repository_dispatch-triggered workflows  
✅ All authentication and permissions work as expected

## Test plan
- [x] Verify TypeScript compilation passes
- [x] Test that repository_dispatch events are properly parsed and handled
- [x] Confirm automation workflows can be triggered via repository_dispatch
- [x] Verify comprehensive test coverage (394 tests passing)
- [x] Integration testing with live repository_dispatch events

🤖 Generated with [Claude Code](https://claude.ai/code)