### PR TITLE
fix: add missing githubContext

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -335,6 +335,7 @@ export function prepareContext(
   return {
     ...commonFields,
     eventData,
+    githubContext: context,
   };
 }
 


### PR DESCRIPTION
When `prepareContext` was called, `githubContext` field was not returned, causing the custom prompt to not be passed into `FINAL PROMPT` when `issues` event triggered the action.

See the failed example: https://github.com/CherryHQ/cherry-studio/actions/runs/17512222482/job/49745322109