### PR TITLE
fix(tag): no such tool available mcp__github_*

### DIFF
--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -135,8 +135,8 @@ export const agentMode: Mode = {
       baseBranch: baseBranch,
       claudeCommentId: undefined, // No tracking comment in agent mode
       allowedTools,
-      context,
       mode: "agent",
+      context,
     });
 
     // Build final claude_args with multiple --mcp-config flags

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -106,8 +106,8 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       allowedTools: [],
-      context: mockContextWithSigning,
       mode: "tag",
+      context: mockContextWithSigning,
     });
 
     const parsed = JSON.parse(result);
@@ -130,8 +130,8 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       allowedTools: ["mcp__github__create_issue", "mcp__github__create_pr"],
-      context: mockContext,
       mode: "tag",
+      context: mockContext,
     });
 
     const parsed = JSON.parse(result);
@@ -151,8 +151,8 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       allowedTools: ["mcp__github_inline_comment__create_inline_comment"],
-      context: mockPRContext,
       mode: "tag",
+      context: mockPRContext,
     });
 
     const parsed = JSON.parse(result);
@@ -172,8 +172,8 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       allowedTools: [],
-      context: mockContext,
       mode: "tag",
+      context: mockContext,
     });
 
     const parsed = JSON.parse(result);
@@ -193,8 +193,8 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       allowedTools: [],
-      context: mockContextWithSigning,
       mode: "tag",
+      context: mockContextWithSigning,
     });
 
     const parsed = JSON.parse(result);
@@ -213,8 +213,8 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       allowedTools: [],
-      context: mockContextWithSigning,
       mode: "tag",
+      context: mockContextWithSigning,
     });
 
     const parsed = JSON.parse(result);
@@ -231,8 +231,8 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       allowedTools: [],
-      context: mockPRContext,
       mode: "tag",
+      context: mockPRContext,
     });
 
     const parsed = JSON.parse(result);
@@ -251,8 +251,8 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       allowedTools: [],
-      context: mockContext,
       mode: "tag",
+      context: mockContext,
     });
 
     const parsed = JSON.parse(result);
@@ -269,8 +269,8 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       allowedTools: [],
-      context: mockPRContext,
       mode: "tag",
+      context: mockPRContext,
     });
 
     const parsed = JSON.parse(result);


### PR DESCRIPTION
Ref: https://github.com/anthropics/claude-code-action/issues/548#issuecomment-3269207757

In tag mode, it is necessary to adhere to the user's input of `--allowedTools`. The current PR reverts the changes made in #549 because the allowedTools are now partially controllable by the user.

The judgment of `isAgentMode` has been improved to ensure that there will not be two different detection logics.

----

Fix: #532 #548 #555
Revert #549

Test: `uses: BlackHole1/claude-code-action@main`