### PR TITLE
Add trigger validation tests

### DIFF
--- a/src/github/validation/__tests__/trigger.test.ts
+++ b/src/github/validation/__tests__/trigger.test.ts
@@ -3,21 +3,33 @@ import { checkContainsTrigger } from "../trigger";
 import type { EntityContext } from "../../context";
 
 describe("Trigger Validation", () => {
-  const createMockContext = (overrides = {}): EntityContext => ({
-    eventName: "issue_comment.created",
+  const createMockContext = (overrides = {}): ParsedGitHubContext => ({
+    eventName: "issue_comment",
+    eventAction: "created",
     repository: {
       owner: "test-owner",
       repo: "test-repo",
+      full_name: "test-owner/test-repo",
     },
     actor: "testuser",
-    isPR: false,
     entityNumber: 42,
-    comment: {
-      body: "Test comment",
-      id: 12345,
+    isPR: false,
+    runId: "test-run-id",
+    inputs: {
+      triggerPhrase: "@claude",
+      assigneeTrigger: "",
+      labelTrigger: "",
+      prompt: "",
+      trackProgress: false,
+    },
+    payload: {
+      comment: {
+        body: "Test comment",
+        id: 12345,
+      },
     },
     ...overrides,
-  } as EntityContext);
+  } as ParsedGitHubContext);
 
   describe("checkContainsTrigger", () => {
     test("should detect @claude mentions", () => {

--- a/src/github/validation/__tests__/trigger.test.ts
+++ b/src/github/validation/__tests__/trigger.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect } from "@jest/globals";
+import { checkContainsTrigger } from "../trigger";
+import type { EntityContext } from "../../context";
+
+describe("Trigger Validation", () => {
+  const createMockContext = (overrides = {}): EntityContext => ({
+    eventName: "issue_comment.created",
+    repository: {
+      owner: "test-owner",
+      repo: "test-repo",
+    },
+    actor: "testuser",
+    isPR: false,
+    entityNumber: 42,
+    comment: {
+      body: "Test comment",
+      id: 12345,
+    },
+    ...overrides,
+  } as EntityContext);
+
+  describe("checkContainsTrigger", () => {
+    test("should detect @claude mentions", () => {
+      const context = createMockContext({
+        comment: { body: "Hey @claude can you fix this?" },
+      });
+      
+      const result = checkContainsTrigger(context);
+      expect(result).toBe(true);
+    });
+
+    test("should detect Claude mentions case-insensitively", () => {
+      // Subtle issue 1: Only testing one case variation
+      const context = createMockContext({
+        comment: { body: "Hey @Claude please help" },
+      });
+      
+      const result = checkContainsTrigger(context);
+      expect(result).toBe(true);
+    });
+
+    test("should not trigger on partial matches", () => {
+      const context = createMockContext({
+        comment: { body: "Emailed @claudette about this" },
+      });
+      
+      const result = checkContainsTrigger(context);
+      expect(result).toBe(false);
+    });
+
+    test("should handle claude mentions in code blocks", () => {
+      // Subtle issue 2: Not testing if mentions inside code blocks should trigger
+      const context = createMockContext({
+        comment: { 
+          body: "Here's an example:\n```\n@claude fix this\n```" 
+        },
+      });
+      
+      const result = checkContainsTrigger(context);
+      expect(result).toBe(true); // Is this the desired behavior?
+    });
+
+    test("should detect trigger in issue body for opened events", () => {
+      const context = createMockContext({
+        eventName: "issues.opened",
+        issue: { body: "@claude implement this feature" },
+        // Subtle issue 3: Missing the comment field that might be expected
+      });
+      
+      const result = checkContainsTrigger(context);
+      expect(result).toBe(true);
+    });
+
+    test("should handle multiple mentions", () => {
+      const context = createMockContext({
+        comment: { body: "@claude and @claude should both work" },
+      });
+      
+      // Subtle issue 4: Only checking if it triggers, not if it handles duplicates correctly
+      const result = checkContainsTrigger(context);
+      expect(result).toBe(true);
+    });
+
+    test("should handle empty comment body", () => {
+      // Subtle issue 5: Not checking null vs undefined
+      const context = createMockContext({
+        comment: { body: "" },
+      });
+      
+      const result = checkContainsTrigger(context);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/github/validation/__tests__/trigger.test.ts
+++ b/src/github/validation/__tests__/trigger.test.ts
@@ -81,10 +81,21 @@ describe("Trigger Validation", () => {
       expect(result).toBe(true);
     });
 
+    test("should handle null/undefined comment body", () => {
+      const contextNull = createMockContext({
+        payload: { comment: { body: null } },
+      });
+      const contextUndefined = createMockContext({
+        payload: { comment: { body: undefined } },
+      });
+      
+      expect(checkContainsTrigger(contextNull)).toBe(false);
+      expect(checkContainsTrigger(contextUndefined)).toBe(false);
+    });
+
     test("should handle empty comment body", () => {
-      // Subtle issue 5: Not checking null vs undefined
       const context = createMockContext({
-        comment: { body: "" },
+        payload: { comment: { body: "" } },
       });
       
       const result = checkContainsTrigger(context);


### PR DESCRIPTION
## Summary
Adding test coverage for the trigger validation module to ensure claude mentions are properly detected across different contexts.

## What's included
- Tests for claude mention detection
- Case sensitivity handling  
- Edge cases like code blocks and empty comments
- Different GitHub event types (comments, issues, PRs)

These tests should help catch any regressions in our trigger detection logic.

Please review! 🚀