### PR TITLE
feat: Add ANTHROPIC_CUSTOM_HEADERS environment variable support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -223,6 +223,7 @@ runs:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
         ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
+        ANTHROPIC_CUSTOM_HEADERS: ${{ env.ANTHROPIC_CUSTOM_HEADERS }}
         CLAUDE_CODE_USE_BEDROCK: ${{ inputs.use_bedrock == 'true' && '1' || '' }}
         CLAUDE_CODE_USE_VERTEX: ${{ inputs.use_vertex == 'true' && '1' || '' }}
 

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -131,6 +131,7 @@ runs:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
         ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
+        ANTHROPIC_CUSTOM_HEADERS: ${{ env.ANTHROPIC_CUSTOM_HEADERS }}
         # Only set provider flags if explicitly true, since any value (including "false") is truthy
         CLAUDE_CODE_USE_BEDROCK: ${{ inputs.use_bedrock == 'true' && '1' || '' }}
         CLAUDE_CODE_USE_VERTEX: ${{ inputs.use_vertex == 'true' && '1' || '' }}


### PR DESCRIPTION
Hi! 
We were happy to find that support for the `ANTHROPIC_BASE_URL` env var was added in these PRs: 
https://github.com/anthropics/claude-code-base-action/pull/20
https://github.com/anthropics/claude-code-action/pull/80

We're running an internal LLM gateway for additional control and hence need to set the base URL, however we are also dependent on the `ANTHROPIC_CUSTOM_HEADERS` env var that Claude Code supports: https://github.com/anthropics/claude-code/issues/321#issuecomment-2730081305

I am suggesting that this env var is also allowed to be passed through the Github Action config. 🙂  

