### PR TITLE
Add PostToolUse hook for automatic formatting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun run format"
+          }
+        ],
+        "matcher": "Edit|Write|MultiEdit"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Added PostToolUse hook that runs `bun run format` after Edit/Write/MultiEdit operations
- Similar to Python SDK's ruff formatting hook
- Ensures code is automatically formatted when changes are made

🤖 Generated with [Claude Code](https://claude.ai/code)