### PR TITLE
fix: update test workflow reference in test-local.sh

### DIFF
--- a/base-action/CLAUDE.md
+++ b/base-action/CLAUDE.md
@@ -50,7 +50,7 @@ This is a GitHub Action that allows running Claude Code within GitHub workflows.
 
 - Unit tests for configuration logic
 - Integration tests for prompt preparation
-- Full workflow tests in `.github/workflows/test-action.yml`
+- Full workflow tests in `.github/workflows/test-base-action.yml`
 
 ## Important Technical Details
 

--- a/base-action/test-local.sh
+++ b/base-action/test-local.sh
@@ -9,4 +9,4 @@ fi
 # Run the test workflow locally
 # You'll need to provide your ANTHROPIC_API_KEY
 echo "Running action locally with act..."
-act push --secret ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" -W .github/workflows/test-action.yml --container-architecture linux/amd64
+act push --secret ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" -W .github/workflows/test-base-action.yml --container-architecture linux/amd64


### PR DESCRIPTION
## Summary

- Update test workflow references from `test-action.yml` to `test-base-action.yml` in documentation and test scripts

## Changes

- **base-action/CLAUDE.md**: Updated workflow reference in testing section
- **base-action/test-local.sh**: Updated act command to use correct workflow file path

This ensures consistency between the actual workflow filename and references in documentation/tooling.

🤖 Generated with [Claude Code](https://claude.ai/code)
