### PR TITLE
feat: add JSON syntax validation for .claude/settings.json

### DIFF
--- a/base-action/src/schemas/settings-schema.ts
+++ b/base-action/src/schemas/settings-schema.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+
+/**
+ * Schema for Claude Code settings.json file
+ * Based on the structure documented in the README and used in tests
+ */
+export const ClaudeSettingsSchema = z
+  .object({
+    model: z
+      .string()
+      .min(1, "Model name cannot be empty")
+      .optional()
+      .describe("Override the default model"),
+
+    env: z
+      .record(z.string())
+      .optional()
+      .describe("Environment variables for the session"),
+
+    permissions: z
+      .object({
+        allow: z
+          .array(z.string().min(1, "Tool name cannot be empty"))
+          .optional()
+          .describe("List of allowed tools"),
+        deny: z
+          .array(z.string().min(1, "Tool name cannot be empty"))
+          .optional()
+          .describe("List of denied tools"),
+      })
+      .optional()
+      .describe("Tool usage permissions"),
+
+    hooks: z
+      .object({
+        PreToolUse: z
+          .array(
+            z.object({
+              matcher: z
+                .string()
+                .min(1, "Matcher pattern cannot be empty")
+                .describe("Pattern to match tool names"),
+              hooks: z
+                .array(
+                  z.object({
+                    type: z
+                      .string()
+                      .min(1, "Hook type cannot be empty")
+                      .describe("Type of hook (e.g., 'command', 'log')"),
+                    command: z
+                      .string()
+                      .min(1, "Command cannot be empty")
+                      .optional()
+                      .describe("Command to execute"),
+                  }),
+                )
+                .min(1, "At least one hook must be defined")
+                .describe("List of hooks to execute"),
+            }),
+          )
+          .optional()
+          .describe("Pre-tool-use hooks"),
+      })
+      .optional()
+      .describe("Hook configurations"),
+
+    enableAllProjectMcpServers: z
+      .boolean()
+      .optional()
+      .describe("Enable all project MCP servers (automatically set to true)"),
+
+    includeCoAuthoredBy: z
+      .boolean()
+      .optional()
+      .describe("Include co-authored-by in git commits"),
+  })
+  .passthrough() // Allow additional properties for future extensibility
+  .describe("Claude Code settings configuration");
+
+export type ClaudeSettings = z.infer<typeof ClaudeSettingsSchema>;
+
+/**
+ * Validates Claude Code settings and returns typed result
+ * @param data - Raw settings data to validate
+ * @returns Validated settings or throws detailed error
+ */
+export function validateSettings(data: unknown): ClaudeSettings {
+  return ClaudeSettingsSchema.parse(data);
+}
+
+/**
+ * Safely validates Claude Code settings and returns result with error info
+ * @param data - Raw settings data to validate
+ * @returns Validation result with success/error information
+ */
+export function safeValidateSettings(data: unknown) {
+  return ClaudeSettingsSchema.safeParse(data);
+}

--- a/base-action/src/utils/error-formatter.ts
+++ b/base-action/src/utils/error-formatter.ts
@@ -1,0 +1,152 @@
+import { ZodError } from "zod";
+
+/**
+ * Formats JSON syntax errors with helpful hints
+ * @param error - The SyntaxError from JSON.parse()
+ * @param content - The original JSON content
+ * @param source - Source description (e.g., "settings.json", "inline JSON")
+ * @returns Formatted error with hints
+ */
+export function formatJsonSyntaxError(
+  error: SyntaxError,
+  content: string,
+  source: string = "JSON",
+): Error {
+  let errorMessage = `JSON syntax error in ${source}: ${error.message}`;
+
+  // Add helpful hints for common JSON errors based on error message and content
+  const hints = getJsonSyntaxHints(error.message, content);
+  if (hints.length > 0) {
+    errorMessage += `\n\n${hints.join("\n")}`;
+  }
+
+  return new Error(errorMessage);
+}
+
+/**
+ * Formats Zod validation errors with helpful path information
+ * @param error - The ZodError from validation
+ * @param source - Source description (e.g., "settings.json")
+ * @returns Formatted error message
+ */
+export function formatZodValidationError(
+  error: ZodError,
+  source: string = "settings",
+): string {
+  const issues = error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join(".") : "root";
+
+    let message = `  • ${path}: ${issue.message}`;
+
+    // Add context for specific error types
+    if (issue.code === "invalid_type") {
+      message += ` (expected ${issue.expected}, got ${issue.received})`;
+    }
+
+    return message;
+  });
+
+  let errorMessage = `Invalid ${source} configuration:\n\n${issues.join("\n")}`;
+
+  // Add helpful examples for common validation errors
+  const examples = getValidationExamples(error);
+  if (examples.length > 0) {
+    errorMessage += `\n\nExamples of correct format:\n${examples.join("\n")}`;
+  }
+
+  errorMessage += `\n\nPlease check the documentation for valid settings options.`;
+
+  return errorMessage;
+}
+
+/**
+ * Provides helpful hints for common JSON syntax errors
+ * @param errorMessage - The original error message
+ * @param content - The JSON content that failed to parse
+ * @returns Array of helpful hints
+ */
+function getJsonSyntaxHints(errorMessage: string, content: string): string[] {
+  const hints: string[] = [];
+
+  // Check for trailing commas in the content
+  if (content.includes(",]") || content.includes(",}")) {
+    hints.push(
+      "Hint: Remove the trailing comma before the closing bracket or brace.",
+    );
+  } else if (errorMessage.includes("comma")) {
+    hints.push(
+      "Hint: Remove the trailing comma before the closing bracket or brace.",
+    );
+  }
+
+  // Check for missing quotes on property names
+  if (
+    errorMessage.includes("Property name must be a string") &&
+    !content.includes(",]") &&
+    !content.includes(",}")
+  ) {
+    hints.push("Hint: Property names must be enclosed in double quotes.");
+  }
+
+  if (errorMessage.includes("Unterminated string")) {
+    hints.push(
+      "Hint: Make sure all strings are properly closed with matching quotes.",
+    );
+  }
+
+  if (
+    errorMessage.includes("Unexpected end") ||
+    errorMessage.includes("Unexpected EOF")
+  ) {
+    hints.push(
+      "Hint: Check that all braces {} and brackets [] are properly closed.",
+    );
+  }
+
+  // Check for single quotes
+  if (errorMessage.includes("Single quotes") || content.includes("'")) {
+    hints.push(
+      "Hint: Use double quotes (\") instead of single quotes (') for strings in JSON.",
+    );
+  }
+
+  return hints;
+}
+
+/**
+ * Provides examples for common Zod validation errors
+ * @param error - The ZodError to analyze
+ * @returns Array of helpful examples
+ */
+function getValidationExamples(error: ZodError): string[] {
+  const examples: string[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const issue of error.issues) {
+    const path = issue.path.join(".");
+
+    if (seenPaths.has(path)) continue;
+    seenPaths.add(path);
+
+    if (path === "permissions.allow" || path === "permissions.deny") {
+      examples.push(`  "permissions": {
+    "allow": ["Bash", "Read", "Write"],
+    "deny": ["WebFetch"]
+  }`);
+    } else if (path.startsWith("hooks")) {
+      examples.push(`  "hooks": {
+    "PreToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{ "type": "command", "command": "echo Starting..." }]
+    }]
+  }`);
+    } else if (path === "env") {
+      examples.push(`  "env": {
+    "DEBUG": "true",
+    "API_URL": "https://example.com"
+  }`);
+    }
+  }
+
+  return examples;
+}

--- a/base-action/src/validation/settings.ts
+++ b/base-action/src/validation/settings.ts
@@ -1,0 +1,161 @@
+import { readFile } from "fs/promises";
+import {
+  safeValidateSettings,
+  type ClaudeSettings,
+} from "../schemas/settings-schema";
+import {
+  formatJsonSyntaxError,
+  formatZodValidationError,
+} from "../utils/error-formatter";
+
+/**
+ * Parses and validates JSON settings from a string
+ * @param settingsJson - JSON string containing settings
+ * @param source - Source description for error messages
+ * @returns Validated settings object
+ * @throws Error with detailed message if JSON is invalid or validation fails
+ */
+export function parseAndValidateSettingsJson(
+  settingsJson: string,
+  source: string = "settings",
+): Partial<ClaudeSettings> {
+  try {
+    const parsed = JSON.parse(settingsJson);
+    const validationResult = safeValidateSettings(parsed);
+
+    if (!validationResult.success) {
+      const errorMessage = formatZodValidationError(
+        validationResult.error,
+        source,
+      );
+      throw new Error(errorMessage);
+    }
+
+    return validationResult.data;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw formatJsonSyntaxError(error, settingsJson, source);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Validates existing settings with optional strict mode
+ * @param settingsJson - JSON string containing existing settings
+ * @param strict - If true, throws on validation errors. If false, logs warnings and returns parsed data
+ * @returns Validated or raw settings object
+ * @throws Error if strict mode and validation fails
+ */
+export function validateExistingSettings(
+  settingsJson: string,
+  strict: boolean = false,
+): Partial<ClaudeSettings> {
+  try {
+    const parsed = JSON.parse(settingsJson);
+    const validationResult = safeValidateSettings(parsed);
+
+    if (!validationResult.success) {
+      const errorMessage = formatZodValidationError(
+        validationResult.error,
+        "existing settings.json",
+      );
+
+      if (strict) {
+        throw new Error(errorMessage);
+      } else {
+        console.warn(`Warning: Existing settings file has validation issues:`);
+        console.warn(errorMessage);
+        console.warn(
+          `Using existing settings as-is for backward compatibility.`,
+        );
+        return parsed;
+      }
+    }
+
+    return validationResult.data;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      console.error(`Error parsing existing settings file:`);
+      console.error(
+        formatJsonSyntaxError(error, settingsJson, "existing settings.json")
+          .message,
+      );
+      throw new Error(
+        `Cannot proceed with invalid existing settings file. Please fix the JSON syntax.`,
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Loads and validates settings from a file path
+ * @param filePath - Path to the settings file
+ * @returns Validated settings object
+ * @throws Error with detailed message if file cannot be read or validation fails
+ */
+export async function loadAndValidateSettingsFile(
+  filePath: string,
+): Promise<Partial<ClaudeSettings>> {
+  const fileContent = await readFile(filePath, "utf-8");
+  return parseAndValidateSettingsJson(fileContent, filePath);
+}
+
+/**
+ * Processes settings input which can be either a JSON string or file path
+ * @param settingsInput - JSON string or path to settings file
+ * @returns Validated settings object
+ * @throws Error with detailed message if validation fails
+ */
+export async function processSettingsInput(
+  settingsInput: string,
+): Promise<Partial<ClaudeSettings>> {
+  const trimmedInput = settingsInput.trim();
+
+  // Try to parse as JSON first
+  try {
+    const settings = parseAndValidateSettingsJson(
+      trimmedInput,
+      "input settings",
+    );
+    console.log(`Parsed and validated settings input as JSON`);
+    return settings;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("JSON syntax error")) {
+      // JSON syntax error - might be a file path
+      console.log(
+        `Settings input is not valid JSON, treating as file path: ${trimmedInput}`,
+      );
+
+      try {
+        const settings = await loadAndValidateSettingsFile(trimmedInput);
+        console.log(`Successfully read and validated settings from file`);
+        return settings;
+      } catch (fileError) {
+        if (
+          fileError instanceof Error &&
+          fileError.message.includes("ENOENT")
+        ) {
+          // File doesn't exist - check if input looks like JSON
+          if (trimmedInput.startsWith("{") || trimmedInput.startsWith("[")) {
+            console.error(
+              `Input appears to be malformed JSON rather than a file path.`,
+            );
+            // Re-throw the original JSON error
+            throw error;
+          } else {
+            console.error(`Failed to read settings file: ${fileError}`);
+            console.error(`Original input was also not valid JSON:`);
+            console.error((error as Error).message);
+            throw new Error(
+              `Settings input is neither valid JSON nor a readable file path.`,
+            );
+          }
+        }
+        throw fileError;
+      }
+    }
+    throw error;
+  }
+}

--- a/base-action/test/setup-claude-code-settings.test.ts
+++ b/base-action/test/setup-claude-code-settings.test.ts
@@ -94,16 +94,118 @@ describe("setupClaudeCodeSettings", () => {
     expect(settings.model).toBe("test-model");
   });
 
-  test("should throw error for invalid JSON string", async () => {
-    expect(() =>
-      setupClaudeCodeSettings("{ invalid json", testHomeDir),
-    ).toThrow();
+  // JSON Syntax Error Tests
+  test("should provide detailed error for JSON syntax error with trailing comma", async () => {
+    const invalidJson = `{
+  "model": "test-model",
+  "permissions": {
+    "allow": ["Bash", "Read",]
+  }
+}`;
+
+    await expect(
+      setupClaudeCodeSettings(invalidJson, testHomeDir),
+    ).rejects.toThrow(/JSON syntax error.*input settings.*comma/);
   });
 
-  test("should throw error for non-existent file path", async () => {
-    expect(() =>
+  test("should provide helpful error for missing quotes on property names", async () => {
+    const invalidJson = `{
+  model: "test-model",
+  "permissions": {}
+}`;
+
+    await expect(
+      setupClaudeCodeSettings(invalidJson, testHomeDir),
+    ).rejects.toThrow(/JSON syntax error.*input settings/);
+  });
+
+  test("should provide helpful error for single quotes instead of double quotes", async () => {
+    const invalidJson = `{
+  'model': 'test-model'
+}`;
+
+    await expect(
+      setupClaudeCodeSettings(invalidJson, testHomeDir),
+    ).rejects.toThrow(/JSON syntax error.*input settings.*Single quotes/);
+  });
+
+  test("should provide detailed error for unclosed braces", async () => {
+    const invalidJson = `{
+  "model": "test-model",
+  "permissions": {
+    "allow": ["Bash"]
+
+}`;
+
+    await expect(
+      setupClaudeCodeSettings(invalidJson, testHomeDir),
+    ).rejects.toThrow(/JSON syntax error/);
+  });
+
+  // Schema Validation Error Tests
+  test("should provide detailed error for invalid permissions type", async () => {
+    const invalidSettings = JSON.stringify({
+      permissions: {
+        allow: "should be array", // wrong type
+      },
+    });
+
+    await expect(
+      setupClaudeCodeSettings(invalidSettings, testHomeDir),
+    ).rejects.toThrow(/permissions\.allow.*Expected array/);
+  });
+
+  test("should provide detailed error for invalid hooks structure", async () => {
+    const invalidSettings = JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            // missing hooks array
+          },
+        ],
+      },
+    });
+
+    await expect(
+      setupClaudeCodeSettings(invalidSettings, testHomeDir),
+    ).rejects.toThrow(/hooks\.PreToolUse\.0\.hooks.*Required/);
+  });
+
+  test("should provide detailed error for empty tool names in permissions", async () => {
+    const invalidSettings = JSON.stringify({
+      permissions: {
+        allow: ["Bash", "", "Read"], // empty string not allowed
+      },
+    });
+
+    await expect(
+      setupClaudeCodeSettings(invalidSettings, testHomeDir),
+    ).rejects.toThrow(/permissions\.allow\.1.*Tool name cannot be empty/);
+  });
+
+  // File Path Error Tests
+  test("should provide helpful error for non-existent file path", async () => {
+    await expect(
       setupClaudeCodeSettings("/non/existent/file.json", testHomeDir),
-    ).toThrow();
+    ).rejects.toThrow(
+      /Settings input is neither valid JSON nor a readable file path/,
+    );
+  });
+
+  test("should provide detailed error for file with JSON syntax error", async () => {
+    const invalidJsonContent = `{
+  "model": "test",
+  "permissions": {
+    "allow": ["Bash",] // trailing comma
+  }
+}`;
+
+    await writeFile(testSettingsPath, invalidJsonContent);
+
+    await expect(
+      setupClaudeCodeSettings(testSettingsPath, testHomeDir),
+    ).rejects.toThrow(/JSON syntax error.*test-settings\.json.*comma/);
   });
 
   test("should handle empty string input", async () => {
@@ -146,5 +248,99 @@ describe("setupClaudeCodeSettings", () => {
     expect(settings.existingKey).toBe("existingValue");
     expect(settings.newKey).toBe("newValue");
     expect(settings.model).toBe("claude-opus-4-1-20250805");
+  });
+
+  // Backward Compatibility Tests
+  test("should handle valid settings with unknown properties (passthrough)", async () => {
+    const settingsWithUnknownProps = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      customProperty: "should be preserved",
+      futureFeature: { nested: "object" },
+    });
+
+    await setupClaudeCodeSettings(settingsWithUnknownProps, testHomeDir);
+
+    const settingsContent = await readFile(settingsPath, "utf-8");
+    const settings = JSON.parse(settingsContent);
+
+    expect(settings.model).toBe("claude-sonnet-4-20250514");
+    expect(settings.customProperty).toBe("should be preserved");
+    expect(settings.futureFeature).toEqual({ nested: "object" });
+    expect(settings.enableAllProjectMcpServers).toBe(true);
+  });
+
+  test("should provide helpful error message with examples for common validation issues", async () => {
+    const invalidSettings = JSON.stringify({
+      permissions: {
+        allow: "Bash", // should be array
+      },
+      env: ["should", "be", "object"], // should be object
+    });
+
+    let errorMessage = "";
+    try {
+      await setupClaudeCodeSettings(invalidSettings, testHomeDir);
+    } catch (error) {
+      errorMessage = (error as Error).message;
+    }
+
+    expect(errorMessage).toContain("permissions.allow");
+    expect(errorMessage).toContain("Expected array");
+    expect(errorMessage).toContain("env");
+    expect(errorMessage).toContain("Examples of correct format");
+  });
+
+  // Complex Valid Settings Test
+  test("should accept complex valid settings with all supported features", async () => {
+    const complexValidSettings = JSON.stringify({
+      model: "claude-opus-4-1-20250805",
+      env: {
+        DEBUG: "true",
+        API_URL: "https://api.example.com",
+        CUSTOM_VAR: "value",
+      },
+      permissions: {
+        allow: ["Bash(git:*)", "Read", "Write", "Edit"],
+        deny: ["WebFetch", "Bash(rm:*)", "Bash(sudo:*)"],
+      },
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              { type: "command", command: "echo Starting bash command..." },
+              { type: "log", command: "console.log('Pre-bash hook')" },
+            ],
+          },
+          {
+            matcher: "Write",
+            hooks: [{ type: "command", command: "echo Writing file..." }],
+          },
+        ],
+      },
+      includeCoAuthoredBy: true,
+      customExtension: {
+        experimental: true,
+        features: ["feature1", "feature2"],
+      },
+    });
+
+    await setupClaudeCodeSettings(complexValidSettings, testHomeDir);
+
+    const settingsContent = await readFile(settingsPath, "utf-8");
+    const settings = JSON.parse(settingsContent);
+
+    expect(settings.model).toBe("claude-opus-4-1-20250805");
+    expect(settings.env.DEBUG).toBe("true");
+    expect(settings.permissions.allow).toHaveLength(4);
+    expect(settings.permissions.deny).toHaveLength(3);
+    expect(settings.hooks.PreToolUse).toHaveLength(2);
+    expect(settings.hooks.PreToolUse[0].hooks).toHaveLength(2);
+    expect(settings.includeCoAuthoredBy).toBe(true);
+    expect(settings.customExtension).toEqual({
+      experimental: true,
+      features: ["feature1", "feature2"],
+    });
+    expect(settings.enableAllProjectMcpServers).toBe(true);
   });
 });

--- a/base-action/test/validate-settings.test.ts
+++ b/base-action/test/validate-settings.test.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env bun
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  parseAndValidateSettingsJson,
+  validateExistingSettings,
+  loadAndValidateSettingsFile,
+  processSettingsInput,
+} from "../src/validation/settings";
+import { tmpdir } from "os";
+import { mkdir, writeFile, rm } from "fs/promises";
+import { join } from "path";
+
+const testDir = join(tmpdir(), "validate-settings-test", Date.now().toString());
+const testFilePath = join(testDir, "test-settings.json");
+
+describe("validate-settings", () => {
+  beforeEach(async () => {
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe("parseAndValidateSettingsJson", () => {
+    test("should parse and validate valid JSON settings", () => {
+      const validJson = JSON.stringify({
+        model: "claude-opus",
+        env: { DEBUG: "true" },
+      });
+
+      const result = parseAndValidateSettingsJson(validJson);
+      expect(result.model).toBe("claude-opus");
+      expect(result.env).toEqual({ DEBUG: "true" });
+    });
+
+    test("should throw on invalid JSON syntax", () => {
+      const invalidJson = '{"model": "test",}';
+
+      expect(() => parseAndValidateSettingsJson(invalidJson)).toThrow(
+        /JSON syntax error.*Hint:/s,
+      );
+    });
+
+    test("should throw on schema validation failure", () => {
+      const invalidSchema = JSON.stringify({
+        permissions: { allow: "should be array" },
+      });
+
+      expect(() => parseAndValidateSettingsJson(invalidSchema)).toThrow(
+        /Invalid.*permissions\.allow.*Expected array/s,
+      );
+    });
+  });
+
+  describe("validateExistingSettings", () => {
+    test("should validate and return valid settings in non-strict mode", () => {
+      const validJson = JSON.stringify({
+        model: "claude-opus",
+        permissions: { allow: ["Bash"] },
+      });
+
+      const result = validateExistingSettings(validJson);
+      expect(result.model).toBe("claude-opus");
+    });
+
+    test("should warn but return invalid settings in non-strict mode", () => {
+      const invalidSchema = JSON.stringify({
+        permissions: { allow: "should be array" },
+      });
+
+      // Capture console output
+      const originalWarn = console.warn;
+      const warnings: string[] = [];
+      console.warn = (...args) => warnings.push(args.join(" "));
+
+      try {
+        const result = validateExistingSettings(invalidSchema, false);
+        expect(result).toEqual({ permissions: { allow: "should be array" } });
+        expect(warnings.some((w) => w.includes("validation issues"))).toBe(
+          true,
+        );
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+
+    test("should throw on invalid settings in strict mode", () => {
+      const invalidSchema = JSON.stringify({
+        permissions: { allow: "should be array" },
+      });
+
+      expect(() => validateExistingSettings(invalidSchema, true)).toThrow(
+        /Invalid.*permissions\.allow/s,
+      );
+    });
+
+    test("should always throw on JSON syntax errors", () => {
+      const invalidJson = '{"test": "value",}';
+
+      expect(() => validateExistingSettings(invalidJson)).toThrow(
+        /Cannot proceed with invalid existing settings file/,
+      );
+    });
+  });
+
+  describe("loadAndValidateSettingsFile", () => {
+    test("should load and validate a valid settings file", async () => {
+      const validSettings = {
+        model: "claude-sonnet",
+        includeCoAuthoredBy: true,
+      };
+
+      await writeFile(testFilePath, JSON.stringify(validSettings));
+
+      const result = await loadAndValidateSettingsFile(testFilePath);
+      expect(result.model).toBe("claude-sonnet");
+      expect(result.includeCoAuthoredBy).toBe(true);
+    });
+
+    test("should throw on non-existent file", async () => {
+      await expect(
+        loadAndValidateSettingsFile("/non/existent/file.json"),
+      ).rejects.toThrow(/ENOENT/);
+    });
+
+    test("should throw on invalid JSON in file", async () => {
+      await writeFile(testFilePath, '{"invalid": "json",}');
+
+      await expect(loadAndValidateSettingsFile(testFilePath)).rejects.toThrow(
+        /JSON syntax error.*test-settings\.json/,
+      );
+    });
+  });
+
+  describe("processSettingsInput", () => {
+    test("should parse JSON string input", async () => {
+      const jsonInput = JSON.stringify({ model: "claude-opus" });
+      const result = await processSettingsInput(jsonInput);
+      expect(result.model).toBe("claude-opus");
+    });
+
+    test("should load from file path", async () => {
+      const settings = { env: { API_KEY: "test" } };
+      await writeFile(testFilePath, JSON.stringify(settings));
+
+      const result = await processSettingsInput(testFilePath);
+      expect(result.env).toEqual({ API_KEY: "test" });
+    });
+
+    test("should throw error for malformed JSON that looks like JSON", async () => {
+      const malformedJson = '{"test": "value",}';
+
+      await expect(processSettingsInput(malformedJson)).rejects.toThrow(
+        /JSON syntax error.*input settings/,
+      );
+    });
+
+    test("should throw error for non-existent file that doesn't look like JSON", async () => {
+      await expect(
+        processSettingsInput("/path/to/nonexistent.json"),
+      ).rejects.toThrow(
+        /Settings input is neither valid JSON nor a readable file path/,
+      );
+    });
+
+    test("should handle whitespace in input", async () => {
+      const jsonWithWhitespace =
+        "   " + JSON.stringify({ model: "test" }) + "   ";
+      const result = await processSettingsInput(jsonWithWhitespace);
+      expect(result.model).toBe("test");
+    });
+  });
+});


### PR DESCRIPTION
Validates Claude Code settings files with detailed error messages to prevent silent failures and improve debugging experience.

  - Add Zod settings-schema and validation with helpful error messages
  - Detect JSON syntax errors (trailing commas, quotes, etc.) with hints
  - Maintain backward compatibility via .passthrough() and warnings
  - Refactor validation logic into dedicated module
  - Add comprehensive test coverage (34 new tests)

Fixes #242 (partially)
(implements settings.json validation, GitHub Actions workflow validation not yet included)