### PR TITLE
fix: update permission test prompts to trigger actual tool usage

### DIFF
--- a/.github/workflows/test-settings.yml
+++ b/.github/workflows/test-settings.yml
@@ -67,7 +67,7 @@ jobs:
         uses: ./base-action
         with:
           prompt: |
-            Use Bash to echo "This should not work"
+            Run the command `echo $HOME` to check the home directory path
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           settings: |
             {
@@ -163,7 +163,7 @@ jobs:
         uses: ./base-action
         with:
           prompt: |
-            Use Bash to echo "This should not work from file"
+            Run the command `echo $HOME` to check the home directory path
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           settings: "test-settings.json"
 


### PR DESCRIPTION
Changed test prompts from communication-style echo commands to legitimate technical operations. This ensures Claude attempts the Bash tool call (which then gets blocked by permissions) instead of refusing based on communication guidelines.

🤖 Generated with [Claude Code](https://claude.ai/code)