### PR TITLE
docs: add prompt injection security note

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -13,6 +13,10 @@
 - **No Cross-Repository Access**: Each action invocation is limited to the repository where it was triggered
 - **Limited Scope**: The token cannot access other repositories or perform actions beyond the configured permissions
 
+## ⚠️ Prompt Injection Risks
+
+**Beware of potential hidden markdown when tagging Claude on untrusted content.** External contributors may include hidden instructions through HTML comments, invisible characters, hidden attributes, or other techniques. The action sanitizes content by stripping HTML comments, invisible characters, markdown image alt text, hidden HTML attributes, and HTML entities, but new bypass techniques may emerge.
+
 ## GitHub App Permissions
 
 The [Claude Code GitHub app](https://github.com/apps/claude) requires these permissions:

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,7 +15,7 @@
 
 ## ⚠️ Prompt Injection Risks
 
-**Beware of potential hidden markdown when tagging Claude on untrusted content.** External contributors may include hidden instructions through HTML comments, invisible characters, hidden attributes, or other techniques. The action sanitizes content by stripping HTML comments, invisible characters, markdown image alt text, hidden HTML attributes, and HTML entities, but new bypass techniques may emerge. We recommend reviewing the raw content of all input coming from external contributors before allowing Claude to process it.  
+**Beware of potential hidden markdown when tagging Claude on untrusted content.** External contributors may include hidden instructions through HTML comments, invisible characters, hidden attributes, or other techniques. The action sanitizes content by stripping HTML comments, invisible characters, markdown image alt text, hidden HTML attributes, and HTML entities, but new bypass techniques may emerge. We recommend reviewing the raw content of all input coming from external contributors before allowing Claude to process it.
 
 ## GitHub App Permissions
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -15,7 +15,7 @@
 
 ## ⚠️ Prompt Injection Risks
 
-**Beware of potential hidden markdown when tagging Claude on untrusted content.** External contributors may include hidden instructions through HTML comments, invisible characters, hidden attributes, or other techniques. The action sanitizes content by stripping HTML comments, invisible characters, markdown image alt text, hidden HTML attributes, and HTML entities, but new bypass techniques may emerge.
+**Beware of potential hidden markdown when tagging Claude on untrusted content.** External contributors may include hidden instructions through HTML comments, invisible characters, hidden attributes, or other techniques. The action sanitizes content by stripping HTML comments, invisible characters, markdown image alt text, hidden HTML attributes, and HTML entities, but new bypass techniques may emerge. We recommend reviewing the raw content of all input coming from external contributors before allowing Claude to process it.  
 
 ## GitHub App Permissions
 


### PR DESCRIPTION
## Summary
- Adds concise security warning about potential hidden markdown in untrusted content
- Documents existing sanitization measures (HTML comments, invisible characters, hidden attributes, etc.)
- Acknowledges new bypass techniques may emerge

## Context
Addresses HackerOne report about hidden content bypassing sanitization. Rather than attempting exhaustive technical mitigation (which is impractical), this documents the risk and empowers users to make informed decisions when tagging Claude on external contributor content.

## Test plan
- [x] Tests pass (415/415)
- [x] Typecheck passes
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)