### PR TITLE
Update github-mcp-server to v0.17.1

### DIFF
--- a/base-action/examples/issue-triage.yml
+++ b/base-action/examples/issue-triage.yml
@@ -32,7 +32,7 @@ jobs:
                   "--rm",
                   "-e",
                   "GITHUB_PERSONAL_ACCESS_TOKEN",
-                  "ghcr.io/github/github-mcp-server:sha-7aced2b"
+                  "ghcr.io/github/github-mcp-server:sha-23fa0dd"
                 ],
                 "env": {
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_TOKEN }}"

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -209,7 +209,7 @@ export async function prepareMcpConfig(
           "GITHUB_PERSONAL_ACCESS_TOKEN",
           "-e",
           "GITHUB_HOST",
-          "ghcr.io/github/github-mcp-server:sha-efef8ae", // https://github.com/github/github-mcp-server/releases/tag/v0.9.0
+          "ghcr.io/github/github-mcp-server:sha-23fa0dd", // https://github.com/github/github-mcp-server/releases/tag/v0.17.1
         ],
         env: {
           GITHUB_PERSONAL_ACCESS_TOKEN: githubToken,


### PR DESCRIPTION
Updates the GitHub MCP server from v0.9.0 (sha-efef8ae) to v0.17.1 (sha-23fa0dd).

- https://github.com/github/github-mcp-server/releases/tag/v0.17.1