### PR TITLE
fix: resolve Claude Code Action failure with non-ASCII branch names in PR comments

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -6,7 +6,7 @@
  * - For Issues: Create a new branch
  */
 
-import { $ } from "bun";
+import { $, spawn } from "bun";
 import * as core from "@actions/core";
 import type { ParsedGitHubContext } from "../context";
 import type { GitHubPullRequest } from "../types";
@@ -54,7 +54,13 @@ export async function setupBranch(
       );
 
       // Execute git commands to checkout PR branch (dynamic depth based on PR size)
-      await $`git fetch origin --depth=${fetchDepth} ${branchName}`;
+      await spawn([
+        "git",
+        "fetch",
+        "origin",
+        `--depth=${fetchDepth}`,
+        branchName,
+      ]).exited;
       await $`git checkout ${branchName} --`;
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);


### PR DESCRIPTION
Replace `$` template literal with Bun.spawn() array format in git commands handling PR branch names to avoid Bun shell template bug with non-ASCII characters.

Claude Code Action fails when the source branch name of a triggering PR contains "/{non-ASCII characters}". This is caused by a Bun template literal ($) bug (https://github.com/oven-sh/bun/issues/15929), where variables are converted to "__bunstr_0" format when commands contain "/{non-ASCII characters}".

This issue causes the command:
```
await $`git fetch origin --depth=${fetchDepth} ${branchName}` 
```
to fail when {branchName} contains "/{non-ASCII characters}", as {fetchDepth} gets converted to "__bunstr_0".

While this change affects code consistency, we use Bun.spawn() because avoiding the bug while maintaining template literals proved difficult. The spawn() array format bypasses shell parsing and safely handles all non-ASCII characters including Japanese.

fix: #616