### PR TITLE
fix(#626): resolve [View job] links pointing to previous workflow runs after comment updates

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -684,7 +684,7 @@ ${
 - Display the todo list as a checklist in the GitHub comment and mark things off as you go.
 - REPOSITORY SETUP INSTRUCTIONS: The repository's CLAUDE.md file(s) contain critical repo-specific setup instructions, development guidelines, and preferences. Always read and follow these files, particularly the root CLAUDE.md, as they provide essential context for working with the codebase effectively.
 - Use h3 headers (###) for section titles in your comments, not h1 headers (#).
-- Your comment must always include the job run link (and branch link if there is one) at the bottom.
+- Your comment must always include the job run link in the format "[View job run](${GITHUB_SERVER_URL}/${context.repository}/actions/runs/${process.env.GITHUB_RUN_ID})" at the bottom of your response (branch link if there is one should also be included there).
 
 CAPABILITIES AND LIMITATIONS:
 When users ask you to do something, be aware of what you can and cannot do. This section helps you understand how to respond when users request actions outside your scope.


### PR DESCRIPTION
## Summary

Fixes issue #626 where `[View job]` links in comment updates were pointing to previous workflow runs instead of the current one.

## AS-IS (Problem)

- `[View job]` links continue to point to previous workflow runs after comment updates
- `[View job run]` links update correctly, but `[View job]` links do not
- Users may be directed to incorrect workflow runs
- System prompt does not explicitly specify job link format

## TO-BE (Solution)

- System prompt now explicitly specifies job link format
- Claude generates links in the correct format with current workflow information
- Comment updates always display links pointing to the current workflow run

<img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/591b820a-a654-4a33-8e51-28f8718a14e5" />


## UX Improvement

By ensuring the job link always points to the current workflow run, users no longer need to navigate to the Actions tab to search for the correct workflow. This reduces friction and improves the user experience when monitoring Claude's task execution.

Closes #626 