### PR TITLE
feat: change plugins input from comma-separated to newline-separated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ inputs:
     required: false
     default: ""
   plugins:
-    description: "Comma-separated list of Claude Code plugin names to install (e.g., 'plugin1,plugin2,plugin3')"
+    description: "Newline-separated list of Claude Code plugin names to install (e.g., 'code-review@claude-code-plugins\nfeature-dev@claude-code-plugins')"
     required: false
     default: ""
   plugin_marketplaces:

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -56,7 +56,7 @@ inputs:
     required: false
     default: ""
   plugins:
-    description: "Comma-separated list of Claude Code plugin names to install (e.g., 'plugin1,plugin2,plugin3')"
+    description: "Newline-separated list of Claude Code plugin names to install (e.g., 'code-review@claude-code-plugins\nfeature-dev@claude-code-plugins')"
     required: false
     default: ""
   plugin_marketplaces:

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -18,9 +18,9 @@ async function run() {
 
     // Install Claude Code plugins if specified
     await installPlugins(
+      process.env.INPUT_PLUGIN_MARKETPLACES,
       process.env.INPUT_PLUGINS,
       process.env.INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE,
-      process.env.INPUT_PLUGIN_MARKETPLACES,
     );
 
     const promptConfig = await preparePrompt({

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,8 +32,10 @@ jobs:
           #   --max-turns 10
           #   --model claude-4-0-sonnet-20250805
 
+          # Optional: add custom plugin marketplaces
+          # plugin_marketplaces: "https://github.com/user/marketplace1.git\nhttps://github.com/user/marketplace2.git"
           # Optional: install Claude Code plugins
-          # plugins: "plugin1,plugin2,plugin3"
+          # plugins: "code-review@claude-code-plugins\nfeature-dev@claude-code-plugins"
 
           # Optional: add custom trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
@@ -76,7 +78,8 @@ jobs:
 | `allowed_non_write_users`        | **⚠️ RISKY**: Comma-separated list of usernames to allow without write permissions, or '\*' for all users. Only works with `github_token` input. See [Security](./security.md)         | No       | ""            |
 | `path_to_claude_code_executable` | Optional path to a custom Claude Code executable. Skips automatic installation. Useful for Nix, custom containers, or specialized environments                                         | No       | ""            |
 | `path_to_bun_executable`         | Optional path to a custom Bun executable. Skips automatic Bun installation. Useful for Nix, custom containers, or specialized environments                                             | No       | ""            |
-| `plugins`                        | Comma-separated list of Claude Code plugin names to install (e.g., `plugin1,plugin2,plugin3`). Plugins are installed before Claude Code execution                                      | No       | ""            |
+| `plugin_marketplaces`            | Newline-separated list of Claude Code plugin marketplace Git URLs to install from (e.g., see example in workflow above). Marketplaces are added before plugin installation             | No       | ""            |
+| `plugins`                        | Newline-separated list of Claude Code plugin names to install (e.g., see example in workflow above). Plugins are installed before Claude Code execution                                | No       | ""            |
 
 ### Deprecated Inputs
 


### PR DESCRIPTION
## Summary
1. Changes the `plugins` input format from comma-separated to newline-separated to match the `plugin_marketplaces` input format, providing consistency across the action.
2. Update usage.md for marketplaces.

## Changes
- Updated `parsePlugins()` function to split by newline (`\n`) instead of comma (`,`)
- Updated action configuration files with realistic plugin examples (`code-review@claude-code-plugins`, `feature-dev@claude-code-plugins`)
- Added `plugin_marketplaces` documentation to `docs/usage.md`
- Updated all 25 unit tests to match the new `installPlugins()` signature
- Improved JSDoc comments for `parsePlugins()` and `installPlugin()` functions
- Fixed TypeScript diagnostic by removing redundant URL validation

## Breaking Change
⚠️ Users must update their workflows to use newline-separated format:

**Before:**
```yaml
plugins: "plugin1,plugin2,plugin3"
```

**After:**
```yaml
plugins: "plugin1\nplugin2\nplugin3"
```

## Test Results
✅ All 25 install-plugins tests passing

## Files Changed
- `action.yml`
- `base-action/action.yml`
- `base-action/src/install-plugins.ts`
- `base-action/test/install-plugins.test.ts`
- `docs/usage.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)