### PR TITLE
docs: update action version from @beta to @v1 in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,7 +130,7 @@ To allow Claude to view workflow run results, job logs, and CI status:
 2. **Configure the action with additional permissions**:
 
    ```yaml
-   - uses: anthropics/claude-code-action@beta
+   - uses: anthropics/claude-code-action@v1
      with:
        anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
        additional_permissions: |
@@ -162,7 +162,7 @@ jobs:
   claude-ci-helper:
     runs-on: ubuntu-latest
     steps:
-      - uses: anthropics/claude-code-action@beta
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           additional_permissions: |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -117,7 +117,7 @@ If you prefer to configure the app manually or need custom permissions:
              private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
          # Use Claude with your custom app's token
-         - uses: anthropics/claude-code-action@beta
+         - uses: anthropics/claude-code-action@v1
            with:
              anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
              github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Updates documentation examples to use @v1 instead of @beta in:
- docs/setup.md: custom GitHub app example
- docs/configuration.md: additional permissions examples

Migration guide and usage comparison examples intentionally kept with @beta to show old syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)