### PR TITLE
fix: The `use_sticky_comment`option does not reference the input `bot_id`.

### DIFF
--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -39,7 +39,7 @@ export async function createInitialComment(
         issue_number: context.entityNumber,
       });
       const existingComment = comments.data.find((comment) => {
-        const idMatch = comment.user?.id === CLAUDE_APP_BOT_ID;
+        const idMatch = comment.user?.id === CLAUDE_APP_BOT_ID || comment.user?.id === parseInt(context.inputs.botId);
         const botNameMatch =
           comment.user?.type === "Bot" &&
           comment.user?.login.toLowerCase().includes("claude");

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -14,8 +14,6 @@ import {
 } from "../../context";
 import type { Octokit } from "@octokit/rest";
 
-const CLAUDE_APP_BOT_ID = 209825114;
-
 export async function createInitialComment(
   octokit: Octokit,
   context: ParsedGitHubContext,
@@ -39,7 +37,7 @@ export async function createInitialComment(
         issue_number: context.entityNumber,
       });
       const existingComment = comments.data.find((comment) => {
-        const idMatch = comment.user?.id === CLAUDE_APP_BOT_ID || comment.user?.id === parseInt(context.inputs.botId);
+        const idMatch = comment.user?.id === parseInt(context.inputs.botId);
         const botNameMatch =
           comment.user?.type === "Bot" &&
           comment.user?.login.toLowerCase().includes("claude");


### PR DESCRIPTION
Hello, thank you for developing such an excellent library.
I am currently using this action in my project.
I'm utilizing the `use_sticky_comment` option, but
a new comment is created with every commit.

Upon investigating the cause, I found that the bot user commenting in my project was not Claude.
Therefore, the `use_sticky_comment` option is not functioning properly.
When Claude runs, it first comments “Claude Code is working…”, right?
It reflects the execution results by updating this comment.
However, when a new commit is added, it cannot find an `existingComment` , so it creates a new comment again.

In my project, the GitHub Actions official user comments,
but the current code only considers comments made by the official Claude App user.
Therefore, I modified it so that if the botId in the actions input matches, it is also recognized as an `existingComment` .
This allows `existingComments` to be found even when users other than the official Claude App comment.

Once this change is reflected, my project will specify `botId` as `41898282` .
Below is the information for the GitHub Actions bot.
https://api.github.com/users/github-actions[bot]