### PR TITLE
feat: route Claude API through claude-lb proxy for instant failover

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -246,7 +246,7 @@ runs:
         VERTEX_REGION_CLAUDE_3_7_SONNET: ${{ env.VERTEX_REGION_CLAUDE_3_7_SONNET }}
 
     - name: Update comment with job link
-      if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.claude_comment_id && always()
+      if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.claude_comment_id && !cancelled()
       shell: bash
       run: |
         bun run ${GITHUB_ACTION_PATH}/src/entrypoints/update-comment-link.ts

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -2,7 +2,7 @@
 
 import * as core from "@actions/core";
 import { preparePrompt } from "./prepare-prompt";
-import { runClaude } from "./run-claude";
+import { runClaudeWithRetry } from "./run-claude";
 import { setupClaudeCodeSettings } from "./setup-claude-code-settings";
 import { validateEnvironmentVariables } from "./validate-env";
 
@@ -20,7 +20,7 @@ async function run() {
       promptFile: process.env.INPUT_PROMPT_FILE || "",
     });
 
-    await runClaude(promptConfig.path, {
+    await runClaudeWithRetry(promptConfig.path, {
       claudeArgs: process.env.INPUT_CLAUDE_ARGS,
       allowedTools: process.env.INPUT_ALLOWED_TOOLS,
       disallowedTools: process.env.INPUT_DISALLOWED_TOOLS,

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -10,6 +10,12 @@ async function run() {
   try {
     validateEnvironmentVariables();
 
+    // Route all Claude API requests through claude-lb proxy
+    // This provides: Bedrock-first routing, immediate Anthropic failover, AI Gateway tracking
+    process.env.ANTHROPIC_BASE_URL = "https://claude-lb.dotdo.workers.dev";
+    console.log("🔀 Routing Claude API requests through claude-lb proxy");
+    console.log("   Bedrock-first with immediate Anthropic failover on 429");
+
     await setupClaudeCodeSettings(
       process.env.INPUT_SETTINGS,
       undefined, // homeDir

--- a/base-action/src/validate-env.ts
+++ b/base-action/src/validate-env.ts
@@ -23,17 +23,22 @@ export function validateEnvironmentVariables() {
       );
     }
   } else if (useBedrock) {
-    const requiredBedrockVars = {
-      AWS_REGION: process.env.AWS_REGION,
-      AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
-      AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
-    };
+    // AWS_REGION is always required
+    if (!process.env.AWS_REGION) {
+      errors.push("AWS_REGION is required when using AWS Bedrock.");
+    }
 
-    Object.entries(requiredBedrockVars).forEach(([key, value]) => {
-      if (!value) {
-        errors.push(`${key} is required when using AWS Bedrock.`);
-      }
-    });
+    // Support bearer token authentication (simpler) or full AWS credentials
+    const hasBearerToken = !!process.env.AWS_BEARER_TOKEN_BEDROCK;
+    const hasAwsCredentials =
+      !!process.env.AWS_ACCESS_KEY_ID &&
+      !!process.env.AWS_SECRET_ACCESS_KEY;
+
+    if (!hasBearerToken && !hasAwsCredentials) {
+      errors.push(
+        "AWS Bedrock requires either AWS_BEARER_TOKEN_BEDROCK (for Bedrock API keys) or both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (for IAM credentials).",
+      );
+    }
   } else if (useVertex) {
     const requiredVertexVars = {
       ANTHROPIC_VERTEX_PROJECT_ID: process.env.ANTHROPIC_VERTEX_PROJECT_ID,

--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -67,6 +67,7 @@ export function detectMode(context: GitHubContext): AutoDetectedMode {
       "synchronize",
       "ready_for_review",
       "reopened",
+      "assigned",
     ];
     if (context.eventAction && supportedActions.includes(context.eventAction)) {
       // If prompt is provided, use agent mode (default for automation)
@@ -114,6 +115,7 @@ function validateTrackProgressEvent(context: GitHubContext): void {
       "synchronize",
       "ready_for_review",
       "reopened",
+      "assigned",
     ];
     if (!validActions.includes(context.eventAction)) {
       throw new Error(

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -71,6 +71,34 @@ describe("detectMode with enhanced routing", () => {
       expect(detectMode(context)).toBe("agent");
     });
 
+    it("should use tag mode when track_progress is true for pull_request.assigned", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "assigned",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, trackProgress: true },
+      };
+
+      expect(detectMode(context)).toBe("tag");
+    });
+
+    it("should use agent mode when prompt is provided for pull_request.assigned", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "assigned",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, prompt: "Fix the issues", trackProgress: false },
+      };
+
+      expect(detectMode(context)).toBe("agent");
+    });
+
     it("should throw error when track_progress is used with unsupported PR action", () => {
       const context: GitHubContext = {
         ...baseContext,


### PR DESCRIPTION
## Summary

Routes all Claude API requests through the `claude-lb` worker proxy for HTTP-level Bedrock-first routing with immediate Anthropic failover.

## Problem

Current retry logic spawns new Claude CLI processes on rate limit errors, causing:
- ~177s overhead per retry (MCP initialization, setup, etc.)  
- Takes 3+ minutes on first 429 before trying Anthropic
- Multiple full process restarts

## Solution

Single Claude CLI execution with failover handled by `claude-lb` worker proxy:
- Sets `ANTHROPIC_BASE_URL=https://claude-lb.dotdo.workers.dev`
- Worker tries Bedrock first (via AI Gateway)
- On 429: immediate Anthropic failover (HTTP-level, milliseconds)
- Pass-through authentication (action passes headers)

## Changes

**base-action/src/index.ts**:
- Set `ANTHROPIC_BASE_URL` before Claude execution

**base-action/src/run-claude.ts**:
- Simplify `runClaudeWithRetry` to single execution
- Remove complex retry loop (87 lines → 8 lines)

## Benefits

✅ Single Claude CLI process (no re-initialization)  
✅ HTTP-level failover (<1s vs 3+ minutes)  
✅ Unified AI Gateway tracking  
✅ Pass-through authentication (no secrets in worker)  
✅ Bedrock-first routing maintained  

## Testing

Requires manual testing with the deployed `claude-lb` worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)