### PR TITLE
fix: move /health endpoint check before 404 response

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -246,7 +246,7 @@ runs:
         VERTEX_REGION_CLAUDE_3_7_SONNET: ${{ env.VERTEX_REGION_CLAUDE_3_7_SONNET }}
 
     - name: Update comment with job link
-      if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.claude_comment_id && always()
+      if: steps.prepare.outputs.contains_trigger == 'true' && steps.prepare.outputs.claude_comment_id && !cancelled()
       shell: bash
       run: |
         bun run ${GITHUB_ACTION_PATH}/src/entrypoints/update-comment-link.ts

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -2,7 +2,7 @@
 
 import * as core from "@actions/core";
 import { preparePrompt } from "./prepare-prompt";
-import { runClaude } from "./run-claude";
+import { runClaudeWithRetry } from "./run-claude";
 import { setupClaudeCodeSettings } from "./setup-claude-code-settings";
 import { validateEnvironmentVariables } from "./validate-env";
 
@@ -20,7 +20,7 @@ async function run() {
       promptFile: process.env.INPUT_PROMPT_FILE || "",
     });
 
-    await runClaude(promptConfig.path, {
+    await runClaudeWithRetry(promptConfig.path, {
       claudeArgs: process.env.INPUT_CLAUDE_ARGS,
       allowedTools: process.env.INPUT_ALLOWED_TOOLS,
       disallowedTools: process.env.INPUT_DISALLOWED_TOOLS,

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -10,6 +10,12 @@ async function run() {
   try {
     validateEnvironmentVariables();
 
+    // Route all Claude API requests through claude-lb proxy
+    // This provides: Bedrock-first routing, immediate Anthropic failover, AI Gateway tracking
+    process.env.ANTHROPIC_BASE_URL = "https://claude-lb.dotdo.workers.dev";
+    console.log("🔀 Routing Claude API requests through claude-lb proxy");
+    console.log("   Bedrock-first with immediate Anthropic failover on 429");
+
     await setupClaudeCodeSettings(
       process.env.INPUT_SETTINGS,
       undefined, // homeDir

--- a/base-action/src/proxy-server.ts
+++ b/base-action/src/proxy-server.ts
@@ -4,22 +4,173 @@ import { request as httpsRequest } from 'https';
 /**
  * HTTP Proxy Server for claude-lb
  *
- * Intercepts Claude CLI requests to claude-lb.dotdo.workers.dev and adds
- * authentication headers with credentials from environment variables.
+ * Intercepts Claude CLI requests and forwards them to claude-lb.dotdo.workers.dev
+ * with authentication headers from environment variables.
  *
- * This enables secure pass-through authentication without storing secrets in the worker.
+ * This enables:
+ * - Secure pass-through authentication (no secrets stored in worker)
+ * - Centralized monitoring and observability via Cloudflare AI Gateway
+ * - Flexible multi-provider architecture (Bedrock, Anthropic, future providers)
+ * - Intelligent retry and failover logic
  */
 
 const PROXY_PORT = 18765; // Local proxy port
 const TARGET_HOST = 'claude-lb.dotdo.workers.dev';
+const DIRECT_ANTHROPIC_FALLBACK = true; // Fall back to direct API if proxy fails
+
+interface ProxyStats {
+  requests: number;
+  successes: number;
+  failures: number;
+  lastError?: string;
+}
+
+const stats: ProxyStats = {
+  requests: 0,
+  successes: 0,
+  failures: 0,
+};
+
+/**
+ * Determine proxy mode based on available credentials
+ * - "bedrock-anthropic": Both credentials available (full failover)
+ * - "anthropic-only": Only Anthropic key available
+ * - "direct": No proxy, use direct Anthropic API
+ */
+function getProxyMode(): 'bedrock-anthropic' | 'anthropic-only' | 'direct' {
+  const hasBedrockToken = !!(process.env.AWS_BEARER_TOKEN_BEDROCK?.trim());
+  const hasAnthropicKey = !!(process.env.ANTHROPIC_API_KEY?.trim());
+
+  if (hasBedrockToken && hasAnthropicKey) {
+    return 'bedrock-anthropic';
+  } else if (hasAnthropicKey) {
+    return 'anthropic-only';
+  } else {
+    return 'direct';
+  }
+}
+
+/**
+ * Forward request to claude-lb proxy
+ */
+function forwardToClaudeLB(
+  body: string,
+  headers: Record<string, string | string[] | undefined>,
+  res: ServerResponse
+): void {
+  const options = {
+    hostname: TARGET_HOST,
+    port: 443,
+    path: '/v1/messages',
+    method: 'POST',
+    headers: {
+      ...headers,
+      host: TARGET_HOST,
+      // Pass authentication headers (worker will use what's available)
+      'x-bedrock-token': process.env.AWS_BEARER_TOKEN_BEDROCK || '',
+      'x-anthropic-key': process.env.ANTHROPIC_API_KEY || '',
+    },
+  };
+
+  const proxyReq = httpsRequest(options, (proxyRes) => {
+    stats.requests++;
+
+    // Log response for monitoring
+    const statusCode = proxyRes.statusCode || 500;
+    if (statusCode >= 200 && statusCode < 300) {
+      stats.successes++;
+    } else {
+      stats.failures++;
+      console.warn(`⚠️  claude-lb returned ${statusCode}`);
+    }
+
+    // Forward response headers and body
+    res.writeHead(statusCode, proxyRes.headers);
+    proxyRes.pipe(res);
+  });
+
+  proxyReq.on('error', (error) => {
+    stats.requests++;
+    stats.failures++;
+    stats.lastError = error.message;
+    console.error('❌ Proxy request error:', error.message);
+
+    // If direct fallback is enabled, try direct Anthropic API
+    if (DIRECT_ANTHROPIC_FALLBACK && process.env.ANTHROPIC_API_KEY) {
+      console.log('🔄 Falling back to direct Anthropic API...');
+      forwardToDirectAnthropic(body, headers, res);
+    } else {
+      res.writeHead(500);
+      res.end(JSON.stringify({ error: 'Proxy Error', message: error.message }));
+    }
+  });
+
+  proxyReq.write(body);
+  proxyReq.end();
+}
+
+/**
+ * Direct fallback to Anthropic API (bypass proxy)
+ */
+function forwardToDirectAnthropic(
+  body: string,
+  headers: Record<string, string | string[] | undefined>,
+  res: ServerResponse
+): void {
+  const options = {
+    hostname: 'api.anthropic.com',
+    port: 443,
+    path: '/v1/messages',
+    method: 'POST',
+    headers: {
+      ...headers,
+      host: 'api.anthropic.com',
+      'x-api-key': process.env.ANTHROPIC_API_KEY || '',
+      'anthropic-version': headers['anthropic-version'] || '2023-06-01',
+    },
+  };
+
+  const directReq = httpsRequest(options, (directRes) => {
+    res.writeHead(directRes.statusCode || 500, directRes.headers);
+    directRes.pipe(res);
+  });
+
+  directReq.on('error', (error) => {
+    console.error('❌ Direct API error:', error.message);
+    res.writeHead(500);
+    res.end(JSON.stringify({ error: 'Direct API Error', message: error.message }));
+  });
+
+  directReq.write(body);
+  directReq.end();
+}
 
 export async function startProxyServer(): Promise<number> {
   return new Promise((resolve, reject) => {
+    const mode = getProxyMode();
+
+    // Log proxy configuration
+    console.log('🔀 Proxy Mode:', mode);
+    if (mode === 'direct') {
+      console.log('⚠️  No proxy credentials - using direct Anthropic API');
+      console.log('   Set ANTHROPIC_API_KEY to enable monitoring via claude-lb');
+      // Still return the port but proxy won't be used
+      resolve(PROXY_PORT);
+      return;
+    }
+
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
       // Only proxy requests to /v1/messages
       if (req.url !== '/v1/messages' || req.method !== 'POST') {
         res.writeHead(404);
         res.end('Not Found');
+        return;
+      }
+
+      // Special endpoint for health/stats
+      if (req.url === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(stats));
         return;
       }
 
@@ -30,48 +181,33 @@ export async function startProxyServer(): Promise<number> {
       });
 
       req.on('end', () => {
-        // Forward request to claude-lb with authentication headers
-        const options = {
-          hostname: TARGET_HOST,
-          port: 443,
-          path: '/v1/messages',
-          method: 'POST',
-          headers: {
-            ...req.headers,
-            host: TARGET_HOST,
-            // Add authentication headers from environment
-            'x-bedrock-token': process.env.AWS_BEARER_TOKEN_BEDROCK || '',
-            'x-anthropic-key': process.env.ANTHROPIC_API_KEY || '',
-          },
-        };
+        // Convert headers to plain object
+        const headers: Record<string, string | string[] | undefined> = {};
+        if (req.headers) {
+          Object.entries(req.headers).forEach(([key, value]) => {
+            headers[key] = value;
+          });
+        }
 
-        const proxyReq = httpsRequest(options, (proxyRes) => {
-          // Forward response headers
-          res.writeHead(proxyRes.statusCode || 500, proxyRes.headers);
-
-          // Forward response body
-          proxyRes.pipe(res);
-        });
-
-        proxyReq.on('error', (error) => {
-          console.error('Proxy request error:', error);
-          res.writeHead(500);
-          res.end('Proxy Error');
-        });
-
-        // Send request body
-        proxyReq.write(body);
-        proxyReq.end();
+        forwardToClaudeLB(body, headers, res);
       });
     });
 
     server.on('error', (error) => {
+      console.error('❌ Proxy server error:', error.message);
       reject(error);
     });
 
     server.listen(PROXY_PORT, '127.0.0.1', () => {
-      console.log(`🔀 Proxy server listening on http://127.0.0.1:${PROXY_PORT}`);
-      console.log(`   Forwarding to https://${TARGET_HOST} with auth headers`);
+      console.log(`✅ Proxy server listening on http://127.0.0.1:${PROXY_PORT}`);
+      console.log(`   Forwarding to https://${TARGET_HOST}`);
+      console.log(`   Mode: ${mode}`);
+      if (mode === 'bedrock-anthropic') {
+        console.log('   🔒 Bedrock-first with Anthropic failover (full proxy mode)');
+      } else if (mode === 'anthropic-only') {
+        console.log('   🔒 Anthropic-only mode (monitoring + observability)');
+      }
+      console.log(`   📊 Health endpoint: http://127.0.0.1:${PROXY_PORT}/health`);
       resolve(PROXY_PORT);
     });
   });
@@ -79,4 +215,8 @@ export async function startProxyServer(): Promise<number> {
 
 export function getProxyUrl(): string {
   return `http://127.0.0.1:${PROXY_PORT}`;
+}
+
+export function shouldUseProxy(): boolean {
+  return getProxyMode() !== 'direct';
 }

--- a/base-action/src/proxy-server.ts
+++ b/base-action/src/proxy-server.ts
@@ -1,0 +1,82 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { request as httpsRequest } from 'https';
+
+/**
+ * HTTP Proxy Server for claude-lb
+ *
+ * Intercepts Claude CLI requests to claude-lb.dotdo.workers.dev and adds
+ * authentication headers with credentials from environment variables.
+ *
+ * This enables secure pass-through authentication without storing secrets in the worker.
+ */
+
+const PROXY_PORT = 18765; // Local proxy port
+const TARGET_HOST = 'claude-lb.dotdo.workers.dev';
+
+export async function startProxyServer(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      // Only proxy requests to /v1/messages
+      if (req.url !== '/v1/messages' || req.method !== 'POST') {
+        res.writeHead(404);
+        res.end('Not Found');
+        return;
+      }
+
+      // Collect request body
+      let body = '';
+      req.on('data', (chunk) => {
+        body += chunk.toString();
+      });
+
+      req.on('end', () => {
+        // Forward request to claude-lb with authentication headers
+        const options = {
+          hostname: TARGET_HOST,
+          port: 443,
+          path: '/v1/messages',
+          method: 'POST',
+          headers: {
+            ...req.headers,
+            host: TARGET_HOST,
+            // Add authentication headers from environment
+            'x-bedrock-token': process.env.AWS_BEARER_TOKEN_BEDROCK || '',
+            'x-anthropic-key': process.env.ANTHROPIC_API_KEY || '',
+          },
+        };
+
+        const proxyReq = httpsRequest(options, (proxyRes) => {
+          // Forward response headers
+          res.writeHead(proxyRes.statusCode || 500, proxyRes.headers);
+
+          // Forward response body
+          proxyRes.pipe(res);
+        });
+
+        proxyReq.on('error', (error) => {
+          console.error('Proxy request error:', error);
+          res.writeHead(500);
+          res.end('Proxy Error');
+        });
+
+        // Send request body
+        proxyReq.write(body);
+        proxyReq.end();
+      });
+    });
+
+    server.on('error', (error) => {
+      reject(error);
+    });
+
+    server.listen(PROXY_PORT, '127.0.0.1', () => {
+      console.log(`🔀 Proxy server listening on http://127.0.0.1:${PROXY_PORT}`);
+      console.log(`   Forwarding to https://${TARGET_HOST} with auth headers`);
+      resolve(PROXY_PORT);
+    });
+  });
+}
+
+export function getProxyUrl(): string {
+  return `http://127.0.0.1:${PROXY_PORT}`;
+}

--- a/base-action/src/proxy-server.ts
+++ b/base-action/src/proxy-server.ts
@@ -160,17 +160,17 @@ export async function startProxyServer(): Promise<number> {
     }
 
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      // Special endpoint for health/stats (check this first!)
+      if (req.url === '/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(stats));
+        return;
+      }
+
       // Only proxy requests to /v1/messages
       if (req.url !== '/v1/messages' || req.method !== 'POST') {
         res.writeHead(404);
         res.end('Not Found');
-        return;
-      }
-
-      // Special endpoint for health/stats
-      if (req.url === '/health') {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify(stats));
         return;
       }
 

--- a/base-action/src/validate-env.ts
+++ b/base-action/src/validate-env.ts
@@ -23,17 +23,22 @@ export function validateEnvironmentVariables() {
       );
     }
   } else if (useBedrock) {
-    const requiredBedrockVars = {
-      AWS_REGION: process.env.AWS_REGION,
-      AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
-      AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
-    };
+    // AWS_REGION is always required
+    if (!process.env.AWS_REGION) {
+      errors.push("AWS_REGION is required when using AWS Bedrock.");
+    }
 
-    Object.entries(requiredBedrockVars).forEach(([key, value]) => {
-      if (!value) {
-        errors.push(`${key} is required when using AWS Bedrock.`);
-      }
-    });
+    // Support bearer token authentication (simpler) or full AWS credentials
+    const hasBearerToken = !!process.env.AWS_BEARER_TOKEN_BEDROCK;
+    const hasAwsCredentials =
+      !!process.env.AWS_ACCESS_KEY_ID &&
+      !!process.env.AWS_SECRET_ACCESS_KEY;
+
+    if (!hasBearerToken && !hasAwsCredentials) {
+      errors.push(
+        "AWS Bedrock requires either AWS_BEARER_TOKEN_BEDROCK (for Bedrock API keys) or both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (for IAM credentials).",
+      );
+    }
   } else if (useVertex) {
     const requiredVertexVars = {
       ANTHROPIC_VERTEX_PROJECT_ID: process.env.ANTHROPIC_VERTEX_PROJECT_ID,

--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -163,7 +163,7 @@ export async function fetchGitHubData({
       if (prResult.repository.pullRequest) {
         const pullRequest = prResult.repository.pullRequest;
         contextData = pullRequest;
-        changedFiles = pullRequest.files.nodes || [];
+        changedFiles = pullRequest.files?.nodes || [];
         comments = filterCommentsToTriggerTime(
           pullRequest.comments?.nodes || [],
           triggerTime,
@@ -171,6 +171,11 @@ export async function fetchGitHubData({
         reviewData = pullRequest.reviews || [];
 
         console.log(`Successfully fetched PR #${prNumber} data`);
+        if (!pullRequest.files || pullRequest.files.nodes === null) {
+          console.warn(
+            `Warning: PR #${prNumber} files data is null (likely >100 files or API limit). Changed files list will be empty.`,
+          );
+        }
       } else {
         throw new Error(`PR #${prNumber} not found`);
       }

--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -67,6 +67,7 @@ export function detectMode(context: GitHubContext): AutoDetectedMode {
       "synchronize",
       "ready_for_review",
       "reopened",
+      "assigned",
     ];
     if (context.eventAction && supportedActions.includes(context.eventAction)) {
       // If prompt is provided, use agent mode (default for automation)
@@ -114,6 +115,7 @@ function validateTrackProgressEvent(context: GitHubContext): void {
       "synchronize",
       "ready_for_review",
       "reopened",
+      "assigned",
     ];
     if (!validActions.includes(context.eventAction)) {
       throw new Error(

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -71,6 +71,34 @@ describe("detectMode with enhanced routing", () => {
       expect(detectMode(context)).toBe("agent");
     });
 
+    it("should use tag mode when track_progress is true for pull_request.assigned", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "assigned",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, trackProgress: true },
+      };
+
+      expect(detectMode(context)).toBe("tag");
+    });
+
+    it("should use agent mode when prompt is provided for pull_request.assigned", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "assigned",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, prompt: "Fix the issues", trackProgress: false },
+      };
+
+      expect(detectMode(context)).toBe("agent");
+    });
+
     it("should throw error when track_progress is used with unsupported PR action", () => {
       const context: GitHubContext = {
         ...baseContext,


### PR DESCRIPTION
## Problem

The  endpoint was unreachable because it was checked AFTER the 404 response for non- URLs. This caused all requests to  to return 404.

This bug prevented the proxy from working correctly and caused automated Claude Code reviews to fail with 'API Error: 404 Not Found'.

## Root Cause

In `base-action/src/proxy-server.ts`, the code flow was:

1. Check if URL is NOT `/v1/messages` → return 404
2. Check if URL IS `/health` → return health stats (UNREACHABLE)

The health check could never be reached because it failed the first check.

## Solution

Move the `/health` endpoint check BEFORE the 404 response:

1. Check if URL IS `/health` → return health stats 
2. Check if URL is NOT `/v1/messages` → return 404

## Testing

- Manual test: Start proxy and curl  (should return stats JSON)
- Manual test: curl  with POST (should proxy to claude-lb)
- Manual test: curl  (should return 404)

## Impact

This fix resolves automated Claude Code reviews failing in the platform repository. Once merged and the SHA is updated in the platform workflows, automated reviews will start working again.

Closes #10