### PR TITLE
Add preserve_checkout_credentials option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,10 @@ inputs:
     description: "Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands"
     required: false
     default: "false"
+  preserve_checkout_credentials:
+    description: "Preserve git credentials from actions/checkout for subsequent git operations. When true, Claude Code will not modify the git config extraheader set by actions/checkout. This is useful for workflows that need to perform git push operations after Claude Code execution."
+    required: false
+    default: "false"
   bot_id:
     description: "GitHub user ID to use for git operations (defaults to Claude's bot ID)"
     required: false
@@ -169,6 +173,7 @@ runs:
         USE_STICKY_COMMENT: ${{ inputs.use_sticky_comment }}
         DEFAULT_WORKFLOW_TOKEN: ${{ github.token }}
         USE_COMMIT_SIGNING: ${{ inputs.use_commit_signing }}
+        PRESERVE_CHECKOUT_CREDENTIALS: ${{ inputs.preserve_checkout_credentials }}
         BOT_ID: ${{ inputs.bot_id }}
         BOT_NAME: ${{ inputs.bot_name }}
         TRACK_PROGRESS: ${{ inputs.track_progress }}

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -146,8 +146,7 @@ export function parseGitHubContext(): GitHubContext {
       branchPrefix: process.env.BRANCH_PREFIX ?? "claude/",
       useStickyComment: process.env.USE_STICKY_COMMENT === "true",
       useCommitSigning: process.env.USE_COMMIT_SIGNING === "true",
-      preserveCheckoutCredentials:
-        process.env.PRESERVE_CHECKOUT_CREDENTIALS === "true",
+      preserveCheckoutCredentials: process.env.PRESERVE_CHECKOUT_CREDENTIALS === "true",
       botId: process.env.BOT_ID ?? String(CLAUDE_APP_BOT_ID),
       botName: process.env.BOT_NAME ?? CLAUDE_BOT_LOGIN,
       allowedBots: process.env.ALLOWED_BOTS ?? "",

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -90,6 +90,7 @@ type BaseContext = {
     branchPrefix: string;
     useStickyComment: boolean;
     useCommitSigning: boolean;
+    preserveCheckoutCredentials: boolean;
     botId: string;
     botName: string;
     allowedBots: string;
@@ -145,6 +146,8 @@ export function parseGitHubContext(): GitHubContext {
       branchPrefix: process.env.BRANCH_PREFIX ?? "claude/",
       useStickyComment: process.env.USE_STICKY_COMMENT === "true",
       useCommitSigning: process.env.USE_COMMIT_SIGNING === "true",
+      preserveCheckoutCredentials:
+        process.env.PRESERVE_CHECKOUT_CREDENTIALS === "true",
       botId: process.env.BOT_ID ?? String(CLAUDE_APP_BOT_ID),
       botName: process.env.BOT_NAME ?? CLAUDE_BOT_LOGIN,
       allowedBots: process.env.ALLOWED_BOTS ?? "",

--- a/src/github/operations/git-config.ts
+++ b/src/github/operations/git-config.ts
@@ -38,12 +38,19 @@ export async function configureGitAuth(
   console.log(`✓ Set git user as ${botName}`);
 
   // Remove the authorization header that actions/checkout sets
-  console.log("Removing existing git authentication headers...");
-  try {
-    await $`git config --unset-all http.${GITHUB_SERVER_URL}/.extraheader`;
-    console.log("✓ Removed existing authentication headers");
-  } catch (e) {
-    console.log("No existing authentication headers to remove");
+  // Skip if preserve_checkout_credentials is enabled
+  if (context.inputs.preserveCheckoutCredentials) {
+    console.log(
+      "Preserving checkout credentials (preserve_checkout_credentials is enabled)",
+    );
+  } else {
+    console.log("Removing existing git authentication headers...");
+    try {
+      await $`git config --unset-all http.${GITHUB_SERVER_URL}/.extraheader`;
+      console.log("✓ Removed existing authentication headers");
+    } catch (e) {
+      console.log("No existing authentication headers to remove");
+    }
   }
 
   // Update the remote URL to include the token for authentication

--- a/src/github/operations/git-config.ts
+++ b/src/github/operations/git-config.ts
@@ -40,17 +40,17 @@ export async function configureGitAuth(
   // Remove the authorization header that actions/checkout sets
   // Skip if preserve_checkout_credentials is enabled
   if (context.inputs.preserveCheckoutCredentials) {
-    console.log(
-      "Preserving checkout credentials (preserve_checkout_credentials is enabled)",
-    );
-  } else {
-    console.log("Removing existing git authentication headers...");
-    try {
-      await $`git config --unset-all http.${GITHUB_SERVER_URL}/.extraheader`;
-      console.log("✓ Removed existing authentication headers");
-    } catch (e) {
-      console.log("No existing authentication headers to remove");
-    }
+    console.log("Preserving checkout credentials (preserve_checkout_credentials is enabled)");
+    console.log("Skipping git authentication configuration - using extraheader from actions/checkout");
+    return;
+  }
+
+  console.log("Removing existing git authentication headers...");
+  try {
+    await $`git config --unset-all http.${GITHUB_SERVER_URL}/.extraheader`;
+    console.log("✓ Removed existing authentication headers");
+  } catch (e) {
+    console.log("No existing authentication headers to remove");
   }
 
   // Update the remote URL to include the token for authentication

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -68,6 +68,7 @@ describe("checkWritePermissions", () => {
       branchPrefix: "claude/",
       useStickyComment: false,
       useCommitSigning: false,
+      preserveCheckoutCredentials: false,
       botId: String(CLAUDE_APP_BOT_ID),
       botName: CLAUDE_BOT_LOGIN,
       allowedBots: "",


### PR DESCRIPTION
## Summary

Add `preserve_checkout_credentials` option to allow workflows to preserve git credentials from `actions/checkout` for subsequent git operations after Claude Code Action execution.

## Problem

When workflows need to perform git push operations after Claude Code Action runs, they encounter authentication failures. This is because Claude Code Action removes the `http.https://github.com/.extraheader` configuration set by `actions/checkout` and replaces it with its own authentication token.

Example workflow that fails without this option:
```yaml
- uses: actions/checkout@v4
- uses: anthropics/claude-code-action@v1
  with:
    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
    prompt: "Analyze changes..."
- name: Push changes
  run: git push  # ❌ Fails: authentication error
```

## Solution

Added `preserve_checkout_credentials` input option (default: `false` for backward compatibility):

- When `true`: Preserves the extraheader configuration from `actions/checkout`
- When `false`: Uses Claude Code Action's own authentication (existing behavior)
