### PR TITLE
fix: github mcp server not installing when allowing all github tools with `mcp__github`

### DIFF
--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -69,21 +69,26 @@ export async function prepareMcpConfig(
     // Detect if we're in agent mode (explicit prompt provided)
     const isAgentMode = mode === "agent";
 
-    const hasGitHubCommentTools = allowedToolsList.some((tool) =>
-      tool.startsWith("mcp__github_comment__"),
-    );
+    // Check if general GitHub tools are allowed (enables all GitHub-related tools)
+    const hasGeneralGitHubTools = allowedToolsList.includes("mcp__github");
 
-    const hasGitHubMcpTools = allowedToolsList.some((tool) =>
-      tool.startsWith("mcp__github__"),
-    );
+    const hasGitHubCommentTools =
+      hasGeneralGitHubTools ||
+      allowedToolsList.some((tool) => tool.startsWith("mcp__github_comment__"));
 
-    const hasInlineCommentTools = allowedToolsList.some((tool) =>
-      tool.startsWith("mcp__github_inline_comment__"),
-    );
+    const hasGitHubMcpTools =
+      hasGeneralGitHubTools ||
+      allowedToolsList.some((tool) => tool.startsWith("mcp__github__"));
 
-    const hasGitHubCITools = allowedToolsList.some((tool) =>
-      tool.startsWith("mcp__github_ci__"),
-    );
+    const hasInlineCommentTools =
+      hasGeneralGitHubTools ||
+      allowedToolsList.some((tool) =>
+        tool.startsWith("mcp__github_inline_comment__"),
+      );
+
+    const hasGitHubCITools =
+      hasGeneralGitHubTools ||
+      allowedToolsList.some((tool) => tool.startsWith("mcp__github_ci__"));
 
     const baseMcpConfig: { mcpServers: Record<string, unknown> } = {
       mcpServers: {},

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -69,26 +69,26 @@ export async function prepareMcpConfig(
     // Detect if we're in agent mode (explicit prompt provided)
     const isAgentMode = mode === "agent";
 
-    // Check if general GitHub tools are allowed (enables all GitHub-related tools)
-    const hasGeneralGitHubTools = allowedToolsList.includes("mcp__github");
+    const hasGitHubCommentTools = allowedToolsList.some(
+      (tool) =>
+        tool.startsWith("mcp__github_comment__") ||
+        tool === "mcp__github_comment",
+    );
 
-    const hasGitHubCommentTools =
-      hasGeneralGitHubTools ||
-      allowedToolsList.some((tool) => tool.startsWith("mcp__github_comment__"));
+    const hasGitHubMcpTools = allowedToolsList.some(
+      (tool) => tool.startsWith("mcp__github__") || tool === "mcp__github",
+    );
 
-    const hasGitHubMcpTools =
-      hasGeneralGitHubTools ||
-      allowedToolsList.some((tool) => tool.startsWith("mcp__github__"));
+    const hasInlineCommentTools = allowedToolsList.some(
+      (tool) =>
+        tool.startsWith("mcp__github_inline_comment__") ||
+        tool === "mcp__github_inline_comment",
+    );
 
-    const hasInlineCommentTools =
-      hasGeneralGitHubTools ||
-      allowedToolsList.some((tool) =>
-        tool.startsWith("mcp__github_inline_comment__"),
-      );
-
-    const hasGitHubCITools =
-      hasGeneralGitHubTools ||
-      allowedToolsList.some((tool) => tool.startsWith("mcp__github_ci__"));
+    const hasGitHubCITools = allowedToolsList.some(
+      (tool) =>
+        tool.startsWith("mcp__github_ci__") || tool === "mcp__github_ci",
+    );
 
     const baseMcpConfig: { mcpServers: Record<string, unknown> } = {
       mcpServers: {},

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -185,14 +185,14 @@ describe("prepareMcpConfig", () => {
     expect(parsed.mcpServers.github_inline_comment.env.PR_NUMBER).toBe("456");
   });
 
-  test("should include inline comment server when all mcp__github tools are allowed", async () => {
+  test("should include inline comment server when all mcp__github_inline_comment tools are allowed", async () => {
     const result = await prepareMcpConfig({
       githubToken: "test-token",
       owner: "test-owner",
       repo: "test-repo",
       branch: "test-branch",
       baseBranch: "main",
-      allowedTools: ["mcp__github"],
+      allowedTools: ["mcp__github_inline_comment"],
       mode: "tag",
       context: mockPRContext,
     });

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -122,6 +122,27 @@ describe("prepareMcpConfig", () => {
     );
   });
 
+  test("should include github MCP server when all mcp__github tools are allowed", async () => {
+    const result = await prepareMcpConfig({
+      githubToken: "test-token",
+      owner: "test-owner",
+      repo: "test-repo",
+      branch: "test-branch",
+      baseBranch: "main",
+      allowedTools: ["mcp__github"],
+      mode: "tag",
+      context: mockContext,
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.mcpServers.github).toBeDefined();
+    expect(parsed.mcpServers.github.command).toBe("docker");
+    expect(parsed.mcpServers.github.env.GITHUB_PERSONAL_ACCESS_TOKEN).toBe(
+      "test-token",
+    );
+  });
+
   test("should include github MCP server when mcp__github__ tools are allowed", async () => {
     const result = await prepareMcpConfig({
       githubToken: "test-token",
@@ -151,6 +172,27 @@ describe("prepareMcpConfig", () => {
       branch: "test-branch",
       baseBranch: "main",
       allowedTools: ["mcp__github_inline_comment__create_inline_comment"],
+      mode: "tag",
+      context: mockPRContext,
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.mcpServers.github_inline_comment).toBeDefined();
+    expect(parsed.mcpServers.github_inline_comment.env.GITHUB_TOKEN).toBe(
+      "test-token",
+    );
+    expect(parsed.mcpServers.github_inline_comment.env.PR_NUMBER).toBe("456");
+  });
+
+  test("should include inline comment server when all mcp__github tools are allowed", async () => {
+    const result = await prepareMcpConfig({
+      githubToken: "test-token",
+      owner: "test-owner",
+      repo: "test-repo",
+      branch: "test-branch",
+      baseBranch: "main",
+      allowedTools: ["mcp__github"],
       mode: "tag",
       context: mockPRContext,
     });


### PR DESCRIPTION
I'm allowing all github mcp commands in my claude-review.yml following the guide here. Here's my permission setup.
```
claude_args: '--max-turns 20 --allowedTools "mcp__github"'
```
The current logic in `install-mcp-server.ts` is not considering the case where user allows all commands from github mcp with `mcp__github` syntax specified [here](https://code.claude.com/docs/en/slash-commands#mcp-permissions-and-wildcards)
<img width="699" height="272" alt="Screenshot 2025-11-07 at 1 17 05 AM" src="https://github.com/user-attachments/assets/b8b0168c-1394-418a-8ade-e2bf3848b257" />

https://github.com/anthropics/claude-code-action/blob/92d173475f53020b397d7a9bae64c41b1b9e31f7/src/mcp/install-mcp-server.ts#L77

Updated the logic to be consistent with the permission syntax.

