### PR TITLE
update docs re: commit signing no longer default

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -38,7 +38,7 @@ The following permissions are requested but not yet actively used. These will en
 
 ## Commit Signing
 
-Commits made by Claude through this action are no longer automatically signed with commit signatures. To enable commit signing set `use_commit_signing: True` in the workflow(s).  This ensures the authenticity and integrity of commits, providing a verifiable trail of changes made by the action.
+Commits made by Claude through this action are no longer automatically signed with commit signatures. To enable commit signing set `use_commit_signing: True` in the workflow(s). This ensures the authenticity and integrity of commits, providing a verifiable trail of changes made by the action.
 
 ## ⚠️ Authentication Protection
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -38,7 +38,7 @@ The following permissions are requested but not yet actively used. These will en
 
 ## Commit Signing
 
-All commits made by Claude through this action are automatically signed with commit signatures. This ensures the authenticity and integrity of commits, providing a verifiable trail of changes made by the action.
+Commits made by Claude through this action are no longer automatically signed with commit signatures. To enable commit signing set `use_commit_signing: True` in the workflow(s).  This ensures the authenticity and integrity of commits, providing a verifiable trail of changes made by the action.
 
 ## ⚠️ Authentication Protection
 


### PR DESCRIPTION
https://github.com/anthropics/claude-code-action/blob/14ab4250bbba75883a5af375e83d0e35c777c422/docs/usage.md?plain=1#L74

https://github.com/anthropics/claude-code-action/issues/281#issuecomment-3079793445
> We changed the behavior here because most orgs don't require commit signing

Draft for:
- [x] testing to make sure this is sufficient
  - this test pr shows as signed https://github.com/altendky/ellm/pull/21

---

i'll note that claude's own review of the pr where i manually added `use_commit_signing: true` told me that it was important to also set `contents: write` permissions.  since my test didn't show it as necessary i am not adding commentary on it in this pr.  perhaps it is relevant in some cases though.

https://github.com/altendky/ellm/pull/19#issuecomment-3522380023
> there's a *likely compatibility issue* with the current `contents: read` permission that should be addressed before merging.