### PR TITLE
fix: use cross-platform timeout for Claude Code installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -195,20 +195,23 @@ runs:
 
         # Install Claude Code if no custom executable is provided
         if [ -z "${{ inputs.path_to_claude_code_executable }}" ]; then
-          echo "Installing Claude Code..."
+          CLAUDE_CODE_VERSION="2.0.50"
+          echo "Installing Claude Code v${CLAUDE_CODE_VERSION}..."
           for attempt in 1 2 3; do
             echo "Installation attempt $attempt..."
-            if timeout 120 bash -c 'curl -fsSL https://claude.ai/install.sh | bash -s -- 2.0.50'; then
-              echo "Claude Code installed successfully"
-              break
+            if command -v timeout &> /dev/null; then
+              timeout 120 bash -c "curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_CODE_VERSION" && break
+            else
+              curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_CODE_VERSION" && break
             fi
             if [ $attempt -eq 3 ]; then
               echo "Failed to install Claude Code after 3 attempts"
               exit 1
             fi
-            echo "Installation timed out or failed, retrying..."
+            echo "Installation failed, retrying..."
             sleep 5
           done
+          echo "Claude Code installed successfully"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         else
           echo "Using custom Claude Code executable: ${{ inputs.path_to_claude_code_executable }}"

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -117,20 +117,23 @@ runs:
       shell: bash
       run: |
         if [ -z "${{ inputs.path_to_claude_code_executable }}" ]; then
-          echo "Installing Claude Code..."
+          CLAUDE_CODE_VERSION="2.0.50"
+          echo "Installing Claude Code v${CLAUDE_CODE_VERSION}..."
           for attempt in 1 2 3; do
             echo "Installation attempt $attempt..."
-            if timeout 120 bash -c 'curl -fsSL https://claude.ai/install.sh | bash -s -- 2.0.50'; then
-              echo "Claude Code installed successfully"
-              break
+            if command -v timeout &> /dev/null; then
+              timeout 120 bash -c "curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_CODE_VERSION" && break
+            else
+              curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_CODE_VERSION" && break
             fi
             if [ $attempt -eq 3 ]; then
               echo "Failed to install Claude Code after 3 attempts"
               exit 1
             fi
-            echo "Installation timed out or failed, retrying..."
+            echo "Installation failed, retrying..."
             sleep 5
           done
+          echo "Claude Code installed successfully"
         else
           echo "Using custom Claude Code executable: ${{ inputs.path_to_claude_code_executable }}"
           # Add the directory containing the custom executable to PATH


### PR DESCRIPTION
The GNU `timeout` command is not available on macOS. Check if it exists and use it when available, otherwise run without timeout.

Also extracts the version into a CLAUDE_CODE_VERSION variable for easier maintenance.

https://github.com/anthropics/claude-code-action/issues/674

🤖 Generated with [Claude Code](https://claude.com/claude-code)