### PR TITLE
fix: `commentBody` may be `null`

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -192,11 +192,6 @@ export function prepareContext(
       if (!isPR) {
         throw new Error("IS_PR must be true for pull_request_review event");
       }
-      if (!commentBody) {
-        throw new Error(
-          "COMMENT_BODY is required for pull_request_review event",
-        );
-      }
       eventData = {
         eventName: "pull_request_review",
         isPR: true,

--- a/src/create-prompt/types.ts
+++ b/src/create-prompt/types.ts
@@ -23,7 +23,7 @@ type PullRequestReviewEvent = {
   eventName: "pull_request_review";
   isPR: true;
   prNumber: string;
-  commentBody: string;
+  commentBody?: string; // May be absent for approvals without comments
   claudeBranch?: string;
   baseBranch?: string;
 };

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -401,6 +401,53 @@ export const mockPullRequestReviewContext: ParsedGitHubContext = {
   inputs: { ...defaultInputs, triggerPhrase: "@claude" },
 };
 
+export const mockPullRequestReviewWithoutCommentContext: ParsedGitHubContext = {
+  runId: "1234567890",
+  eventName: "pull_request_review",
+  eventAction: "dismissed",
+  repository: defaultRepository,
+  actor: "senior-developer",
+  payload: {
+    action: "submitted",
+    review: {
+      id: 11122233,
+      body: null, // Simulating approval without comment
+      user: {
+        login: "senior-developer",
+        id: 44444,
+        avatar_url: "https://avatars.githubusercontent.com/u/44444",
+        html_url: "https://github.com/senior-developer",
+      },
+      state: "approved",
+      html_url:
+        "https://github.com/test-owner/test-repo/pull/321#pullrequestreview-11122233",
+      submitted_at: "2024-01-15T15:30:00Z",
+    },
+    pull_request: {
+      number: 321,
+      title: "Refactor: Improve error handling in API layer",
+      body: "This PR improves error handling across all API endpoints",
+      user: {
+        login: "backend-developer",
+        id: 33333,
+        avatar_url: "https://avatars.githubusercontent.com/u/33333",
+        html_url: "https://github.com/backend-developer",
+      },
+    },
+    repository: {
+      name: "test-repo",
+      full_name: "test-owner/test-repo",
+      private: false,
+      owner: {
+        login: "test-owner",
+      },
+    },
+  } as PullRequestReviewEvent,
+  entityNumber: 321,
+  isPR: true,
+  inputs: { ...defaultInputs, triggerPhrase: "@claude" },
+};
+
 export const mockPullRequestReviewCommentContext: ParsedGitHubContext = {
   runId: "1234567890",
   eventName: "pull_request_review_comment",

--- a/test/prepare-context.test.ts
+++ b/test/prepare-context.test.ts
@@ -10,6 +10,7 @@ import {
   mockPullRequestCommentContext,
   mockPullRequestReviewContext,
   mockPullRequestReviewCommentContext,
+  mockPullRequestReviewWithoutCommentContext,
 } from "./mockContext";
 
 const BASE_ENV = {
@@ -122,6 +123,21 @@ describe("parseEnvVarsWithContext", () => {
         expect(result.eventData.commentBody).toBe(
           "@claude can you check if the error handling is comprehensive enough in this PR?",
         );
+      }
+    });
+  });
+
+  describe("pull_request_review event without comment", () => {
+    test("should parse pull_request_review event correctly", () => {
+      process.env = BASE_ENV;
+      const result = prepareContext(mockPullRequestReviewWithoutCommentContext, "12345");
+
+      expect(result.eventData.eventName).toBe("pull_request_review");
+      expect(result.eventData.isPR).toBe(true);
+      expect(result.triggerUsername).toBe("senior-developer");
+      if (result.eventData.eventName === "pull_request_review") {
+        expect(result.eventData.prNumber).toBe("321");
+        expect(result.eventData.commentBody).toBe("");
       }
     });
   });

--- a/test/prepare-context.test.ts
+++ b/test/prepare-context.test.ts
@@ -130,7 +130,10 @@ describe("parseEnvVarsWithContext", () => {
   describe("pull_request_review event without comment", () => {
     test("should parse pull_request_review event correctly", () => {
       process.env = BASE_ENV;
-      const result = prepareContext(mockPullRequestReviewWithoutCommentContext, "12345");
+      const result = prepareContext(
+        mockPullRequestReviewWithoutCommentContext,
+        "12345",
+      );
 
       expect(result.eventData.eventName).toBe("pull_request_review");
       expect(result.eventData.isPR).toBe(true);


### PR DESCRIPTION
This handles the cases where `pull_request_review` events have no comments (`commentBody` field is `null`). In those cases, the `null` value is converted to the empty string.

The issue was testing `!commentBody` which was triggerring on empty strings as well. This guard was removed (which is the fix), but for clarity, the `commentBody` field was also made optional to make it clear that the comment may be missing.