### PR TITLE
fix: prevent race condition on issue/PR body edits

### DIFF
--- a/src/github/api/queries/github.ts
+++ b/src/github/api/queries/github.ts
@@ -13,6 +13,8 @@ export const PR_QUERY = `
         headRefName
         headRefOid
         createdAt
+        updatedAt
+        lastEditedAt
         additions
         deletions
         state
@@ -96,6 +98,8 @@ export const ISSUE_QUERY = `
           login
         }
         createdAt
+        updatedAt
+        lastEditedAt
         state
         comments(first: 100) {
           nodes {

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -58,6 +58,8 @@ export type GitHubPullRequest = {
   headRefName: string;
   headRefOid: string;
   createdAt: string;
+  updatedAt?: string;
+  lastEditedAt?: string;
   additions: number;
   deletions: number;
   state: string;
@@ -83,6 +85,8 @@ export type GitHubIssue = {
   body: string;
   author: GitHubAuthor;
   createdAt: string;
+  updatedAt?: string;
+  lastEditedAt?: string;
   state: string;
   comments: {
     nodes: GitHubComment[];


### PR DESCRIPTION
Add trigger-time validation for issue/PR body content to prevent attackers from exploiting a race condition where they edit the body between when an authorized user triggers @claude and when Claude processes the request.

The existing filterCommentsToTriggerTime() already protected comments - this extends the same pattern to the main issue/PR body via isBodySafeToUse().

🤖 Generated with [Claude Code](https://claude.com/claude-code)