### PR TITLE
Fix SDK path: add settingSources and default system prompt

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -101,7 +101,7 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
     env.GITHUB_ACTION_INPUTS = process.env.INPUT_ACTION_INPUTS_PRESENT;
   }
 
-  // Build system prompt option
+  // Build system prompt option - default to claude_code preset
   let systemPrompt: SdkOptions["systemPrompt"];
   if (options.systemPrompt) {
     systemPrompt = options.systemPrompt;
@@ -110,6 +110,12 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
       type: "preset",
       preset: "claude_code",
       append: options.appendSystemPrompt,
+    };
+  } else {
+    // Default to claude_code preset when no custom prompt is specified
+    systemPrompt = {
+      type: "preset",
+      preset: "claude_code",
     };
   }
 
@@ -130,6 +136,9 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
     // Note: allowedTools and disallowedTools have been removed from extraArgs to prevent duplicates
     extraArgs,
     env,
+
+    // Load settings from all sources to pick up CLI-installed plugins, CLAUDE.md, etc.
+    settingSources: ["user", "project", "local"],
   };
 
   return {

--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -75,6 +75,9 @@ export async function runClaudeWithSdk(
   }
 
   console.log(`Running Claude with prompt from file: ${promptPath}`);
+  // Log SDK options without env (which could contain sensitive data)
+  const { env, ...optionsToLog } = sdkOptions;
+  console.log("SDK options:", JSON.stringify(optionsToLog, null, 2));
 
   const messages: SDKMessage[] = [];
   let resultMessage: SDKResultMessage | undefined;


### PR DESCRIPTION
## Summary
Two fixes for the Agent SDK path (`USE_AGENT_SDK=true`):

1. **Add `settingSources` to load filesystem settings**
   - Without this, CLI-installed plugins aren't available to the SDK
   - Also needed to load CLAUDE.md files from the project

2. **Default `systemPrompt` to `claude_code` preset**
   - Without an explicit systemPrompt, the SDK would use no system prompt
   - Now defaults to `{ type: "preset", preset: "claude_code" }` to match CLI behavior

Also adds logging of SDK options for easier debugging.

## Test plan
- [x] Tested with `USE_AGENT_SDK=true` in a workflow - plugins and system prompt now work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)