### PR TITLE
fix: resolve zizmor template injection vulnerabilities

### DIFF
--- a/.github/workflows/sync-base-action.yml
+++ b/.github/workflows/sync-base-action.yml
@@ -94,5 +94,5 @@ jobs:
           echo "✅ Successfully synced \`base-action\` directory to [anthropics/claude-code-base-action](https://github.com/anthropics/claude-code-base-action)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Source commit**: [\`${GITHUB_SHA:0:7}\`](https://github.com/anthropics/claude-code-action/commit/${GITHUB_SHA})" >> $GITHUB_STEP_SUMMARY
-          echo "- **Triggered by**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Actor**: @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Triggered by**: $GITHUB_EVENT_NAME" >> $GITHUB_STEP_SUMMARY
+          echo "- **Actor**: @$GITHUB_ACTOR" >> $GITHUB_STEP_SUMMARY

--- a/action.yml
+++ b/action.yml
@@ -140,13 +140,13 @@ runs:
     - name: Setup Custom Bun Path
       if: inputs.path_to_bun_executable != ''
       shell: bash
+      env:
+        PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
       run: |
         echo "Using custom Bun executable: $PATH_TO_BUN_EXECUTABLE"
         # Add the directory containing the custom executable to PATH
         BUN_DIR=$(dirname "$PATH_TO_BUN_EXECUTABLE")
         echo "$BUN_DIR" >> "$GITHUB_PATH"
-      env:
-        PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
 
     - name: Install Dependencies
       shell: bash
@@ -184,6 +184,8 @@ runs:
     - name: Install Base Action Dependencies
       if: steps.prepare.outputs.contains_trigger == 'true'
       shell: bash
+      env:
+        PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
       run: |
         echo "Installing base-action dependencies..."
         cd ${GITHUB_ACTION_PATH}/base-action
@@ -217,8 +219,6 @@ runs:
           CLAUDE_DIR=$(dirname "$PATH_TO_CLAUDE_CODE_EXECUTABLE")
           echo "$CLAUDE_DIR" >> "$GITHUB_PATH"
         fi
-      env:
-        PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
 
     - name: Run Claude Code
       id: claude-code

--- a/action.yml
+++ b/action.yml
@@ -141,10 +141,12 @@ runs:
       if: inputs.path_to_bun_executable != ''
       shell: bash
       run: |
-        echo "Using custom Bun executable: ${{ inputs.path_to_bun_executable }}"
+        echo "Using custom Bun executable: $PATH_TO_BUN_EXECUTABLE"
         # Add the directory containing the custom executable to PATH
-        BUN_DIR=$(dirname "${{ inputs.path_to_bun_executable }}")
+        BUN_DIR=$(dirname "$PATH_TO_BUN_EXECUTABLE")
         echo "$BUN_DIR" >> "$GITHUB_PATH"
+      env:
+        PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
 
     - name: Install Dependencies
       shell: bash
@@ -190,7 +192,7 @@ runs:
         cd -
 
         # Install Claude Code if no custom executable is provided
-        if [ -z "${{ inputs.path_to_claude_code_executable }}" ]; then
+        if [ -z "$PATH_TO_CLAUDE_CODE_EXECUTABLE" ]; then
           CLAUDE_CODE_VERSION="2.0.61"
           echo "Installing Claude Code v${CLAUDE_CODE_VERSION}..."
           for attempt in 1 2 3; do
@@ -210,11 +212,13 @@ runs:
           echo "Claude Code installed successfully"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         else
-          echo "Using custom Claude Code executable: ${{ inputs.path_to_claude_code_executable }}"
+          echo "Using custom Claude Code executable: $PATH_TO_CLAUDE_CODE_EXECUTABLE"
           # Add the directory containing the custom executable to PATH
-          CLAUDE_DIR=$(dirname "${{ inputs.path_to_claude_code_executable }}")
+          CLAUDE_DIR=$(dirname "$PATH_TO_CLAUDE_CODE_EXECUTABLE")
           echo "$CLAUDE_DIR" >> "$GITHUB_PATH"
         fi
+      env:
+        PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
 
     - name: Run Claude Code
       id: claude-code

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -102,10 +102,12 @@ runs:
       if: inputs.path_to_bun_executable != ''
       shell: bash
       run: |
-        echo "Using custom Bun executable: ${{ inputs.path_to_bun_executable }}"
+        echo "Using custom Bun executable: $PATH_TO_BUN_EXECUTABLE"
         # Add the directory containing the custom executable to PATH
-        BUN_DIR=$(dirname "${{ inputs.path_to_bun_executable }}")
+        BUN_DIR=$(dirname "$PATH_TO_BUN_EXECUTABLE")
         echo "$BUN_DIR" >> "$GITHUB_PATH"
+      env:
+        PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
 
     - name: Install Dependencies
       shell: bash
@@ -116,7 +118,7 @@ runs:
     - name: Install Claude Code
       shell: bash
       run: |
-        if [ -z "${{ inputs.path_to_claude_code_executable }}" ]; then
+        if [ -z "$PATH_TO_CLAUDE_CODE_EXECUTABLE" ]; then
           CLAUDE_CODE_VERSION="2.0.61"
           echo "Installing Claude Code v${CLAUDE_CODE_VERSION}..."
           for attempt in 1 2 3; do
@@ -135,11 +137,13 @@ runs:
           done
           echo "Claude Code installed successfully"
         else
-          echo "Using custom Claude Code executable: ${{ inputs.path_to_claude_code_executable }}"
+          echo "Using custom Claude Code executable: $PATH_TO_CLAUDE_CODE_EXECUTABLE"
           # Add the directory containing the custom executable to PATH
-          CLAUDE_DIR=$(dirname "${{ inputs.path_to_claude_code_executable }}")
+          CLAUDE_DIR=$(dirname "$PATH_TO_CLAUDE_CODE_EXECUTABLE")
           echo "$CLAUDE_DIR" >> "$GITHUB_PATH"
         fi
+      env:
+        PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
 
     - name: Run Claude Code Action
       shell: bash

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -101,13 +101,13 @@ runs:
     - name: Setup Custom Bun Path
       if: inputs.path_to_bun_executable != ''
       shell: bash
+      env:
+        PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
       run: |
         echo "Using custom Bun executable: $PATH_TO_BUN_EXECUTABLE"
         # Add the directory containing the custom executable to PATH
         BUN_DIR=$(dirname "$PATH_TO_BUN_EXECUTABLE")
         echo "$BUN_DIR" >> "$GITHUB_PATH"
-      env:
-        PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
 
     - name: Install Dependencies
       shell: bash
@@ -117,6 +117,8 @@ runs:
 
     - name: Install Claude Code
       shell: bash
+      env:
+        PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
       run: |
         if [ -z "$PATH_TO_CLAUDE_CODE_EXECUTABLE" ]; then
           CLAUDE_CODE_VERSION="2.0.61"
@@ -142,8 +144,6 @@ runs:
           CLAUDE_DIR=$(dirname "$PATH_TO_CLAUDE_CODE_EXECUTABLE")
           echo "$CLAUDE_DIR" >> "$GITHUB_PATH"
         fi
-      env:
-        PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
 
     - name: Run Claude Code Action
       shell: bash


### PR DESCRIPTION
## Summary
- Fix high severity template injection vulnerabilities detected by zizmor
- Replace direct `${{ inputs.* }}` and `${{ github.* }}` template expansion in shell scripts with environment variables
- Prevents potential command injection attacks from malicious input values

## Test plan
- [ ] Verify CI passes
- [ ] Test custom executable paths still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)