### PR TITLE
fix: Use frozen lockfile for reproducible builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -152,7 +152,7 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_ACTION_PATH}
-        bun install
+        bun install --frozen-lockfile
 
     - name: Prepare action
       id: prepare
@@ -189,7 +189,7 @@ runs:
       run: |
         echo "Installing base-action dependencies..."
         cd ${GITHUB_ACTION_PATH}/base-action
-        bun install
+        bun install --frozen-lockfile
         echo "Base-action dependencies installed"
         cd -
 

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -113,7 +113,7 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_ACTION_PATH}
-        bun install
+        bun install --frozen-lockfile
 
     - name: Install Claude Code
       shell: bash


### PR DESCRIPTION
This ensures the action installs using the lockfile so we get reproducible builds. Given the increase in supply chain attacks recently this is good practice to have.