### PR TITLE
feat: Make Agent SDK the default execution path

### DIFF
--- a/base-action/src/run-claude.ts
+++ b/base-action/src/run-claude.ts
@@ -167,8 +167,8 @@ export async function parseAndSetStructuredOutputs(
 }
 
 export async function runClaude(promptPath: string, options: ClaudeOptions) {
-  // Feature flag: use SDK path when USE_AGENT_SDK=true
-  const useAgentSdk = process.env.USE_AGENT_SDK === "true";
+  // Feature flag: use SDK path by default, set USE_AGENT_SDK=false to use CLI
+  const useAgentSdk = process.env.USE_AGENT_SDK !== "false";
   console.log(
     `Using ${useAgentSdk ? "Agent SDK" : "CLI"} path (USE_AGENT_SDK=${process.env.USE_AGENT_SDK ?? "unset"})`,
   );


### PR DESCRIPTION
## Summary
- Change `USE_AGENT_SDK` to default to `true` instead of `false`
- The Agent SDK path is now used by default
- Set `USE_AGENT_SDK=false` to use the CLI path instead

## Test plan
- [x] TypeScript type checking passes
- [x] All 531 tests pass
- [x] Formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)