### PR TITLE
fix: clean up stale lock files and validate installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -202,6 +202,10 @@ runs:
           echo "Installing Claude Code v${CLAUDE_CODE_VERSION}..."
           for attempt in 1 2 3; do
             echo "Installation attempt $attempt..."
+
+            # Clean up stale lock files before retry
+            rm -rf ~/.claude/.locks 2>/dev/null || true
+
             if command -v timeout &> /dev/null; then
               timeout 120 bash -c "curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_CODE_VERSION" && break
             else
@@ -214,8 +218,15 @@ runs:
             echo "Installation failed, retrying..."
             sleep 5
           done
-          echo "Claude Code installed successfully"
+
+          # Add to PATH and validate installation
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
+          if ! command -v claude &> /dev/null; then
+            echo "Installation failed: claude binary not found in PATH"
+            exit 1
+          fi
+          echo "Claude Code installed successfully"
         else
           echo "Using custom Claude Code executable: $PATH_TO_CLAUDE_CODE_EXECUTABLE"
           # Add the directory containing the custom executable to PATH

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -128,6 +128,10 @@ runs:
           echo "Installing Claude Code v${CLAUDE_CODE_VERSION}..."
           for attempt in 1 2 3; do
             echo "Installation attempt $attempt..."
+
+            # Clean up stale lock files before retry
+            rm -rf ~/.claude/.locks 2>/dev/null || true
+
             if command -v timeout &> /dev/null; then
               timeout 120 bash -c "curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_CODE_VERSION" && break
             else
@@ -140,6 +144,14 @@ runs:
             echo "Installation failed, retrying..."
             sleep 5
           done
+
+          # Add to PATH and validate installation
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.local/bin:$PATH"
+          if ! command -v claude &> /dev/null; then
+            echo "Installation failed: claude binary not found in PATH"
+            exit 1
+          fi
           echo "Claude Code installed successfully"
         else
           echo "Using custom Claude Code executable: $PATH_TO_CLAUDE_CODE_EXECUTABLE"


### PR DESCRIPTION
- Remove ~/.claude/.locks before each retry attempt to prevent "another process is currently installing" errors after timeout
- Validate claude binary is in PATH before reporting success
- Add missing PATH setup to base-action/action.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)