### PR TITLE
docs: add session_id output documentation

### DIFF
--- a/base-action/README.md
+++ b/base-action/README.md
@@ -113,10 +113,12 @@ Add the following to your workflow file:
 
 ## Outputs
 
-| Output           | Description                                                |
-| ---------------- | ---------------------------------------------------------- |
-| `conclusion`     | Execution status of Claude Code ('success' or 'failure')   |
-| `execution_file` | Path to the JSON file containing Claude Code execution log |
+| Output              | Description                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `conclusion`        | Execution status of Claude Code ('success' or 'failure')                                                            |
+| `execution_file`    | Path to the JSON file containing Claude Code execution log                                                          |
+| `structured_output` | JSON string containing all structured output fields when `--json-schema` is provided in `claude_args`               |
+| `session_id`        | The Claude Code session ID that can be used with `--resume` to continue the conversation in subsequent workflow steps |
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

Add documentation for the `session_id` output that was added in #739.

## Changes

- **base-action/README.md**: Added `session_id` and `structured_output` to the Outputs table
- **docs/custom-automations.md**: Added "Conversation Resumption" section with:
  - Multi-step workflow example showing how to resume conversations
  - Use cases (multi-repo analysis, external data integration, staged execution, human-in-the-loop)

## Related

- Closes the documentation gap from #739
