### PR TITLE
chore: update model to claude-opus-4-5 in workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,4 +36,4 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --allowedTools "Bash(bun install),Bash(bun test:*),Bash(bun run format),Bash(bun typecheck)"
-            --model "claude-opus-4-1-20250805"
+            --model "claude-opus-4-5"


### PR DESCRIPTION
## Summary
- Updates the `--model` flag in `.github/workflows/claude.yml` from `claude-opus-4-1-20250805` to `claude-opus-4-5`

## Test plan
- [x] Tests pass
- [x] Typecheck passes
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)