### PR TITLE
fix: set GH_TOKEN alongside GITHUB_TOKEN for gh CLI precedence

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -247,6 +247,7 @@ runs:
 
         # Model configuration
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
         NODE_VERSION: ${{ env.NODE_VERSION }}
         DETAILED_PERMISSION_MESSAGES: "1"
 
@@ -296,6 +297,7 @@ runs:
         CLAUDE_COMMENT_ID: ${{ steps.prepare.outputs.claude_comment_id }}
         GITHUB_RUN_ID: ${{ github.run_id }}
         GITHUB_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ steps.prepare.outputs.GITHUB_TOKEN }}
         GITHUB_EVENT_NAME: ${{ github.event_name }}
         TRIGGER_COMMENT_ID: ${{ github.event.comment.id }}
         CLAUDE_BRANCH: ${{ steps.prepare.outputs.CLAUDE_BRANCH }}


### PR DESCRIPTION
The gh CLI prefers GH_TOKEN over GITHUB_TOKEN. When a calling workflow sets GH_TOKEN in env, the action's GITHUB_TOKEN was being ignored, causing the gh CLI to use the wrong token (e.g., the default workflow token instead of an App token).

This ensures Claude's gh CLI commands use the action's prepared token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)