### PR TITLE
fix: update broken link in cloud-providers.md

### DIFF
--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -7,7 +7,7 @@ You can authenticate with Claude using any of these four methods:
 3. Google Vertex AI with OIDC authentication
 4. Microsoft Foundry with OIDC authentication
 
-For detailed setup instructions for AWS Bedrock and Google Vertex AI, see the [official documentation](https://docs.anthropic.com/en/docs/claude-code/github-actions#using-with-aws-bedrock-%26-google-vertex-ai).
+For detailed setup instructions for AWS Bedrock and Google Vertex AI, see the [official documentation](https://code.claude.com/docs/en/github-actions#for-aws-bedrock:).
 
 **Note**:
 


### PR DESCRIPTION
Fixes the broken link to AWS Bedrock documentation in `docs/cloud-providers.md`.

Fixes #756

Generated with [Claude Code](https://claude.ai/code)