### PR TITLE
fix: use correct claude[bot] ID (209825114) instead of github-actions[bot] ID

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ inputs:
   bot_id:
     description: "GitHub user ID to use for git operations (defaults to Claude's bot ID)"
     required: false
-    default: "41898282" # Claude's bot ID - see src/github/constants.ts
+    default: "209825114" # claude[bot] ID - see src/github/constants.ts
   bot_name:
     description: "GitHub username to use for git operations (defaults to Claude's bot name)"
     required: false

--- a/src/github/constants.ts
+++ b/src/github/constants.ts
@@ -4,8 +4,9 @@
 
 /**
  * Claude App bot user ID
+ * Verified via: curl -s https://api.github.com/users/claude%5Bbot%5D | jq .id
  */
-export const CLAUDE_APP_BOT_ID = 41898282;
+export const CLAUDE_APP_BOT_ID = 209825114;
 
 /**
  * Claude bot username


### PR DESCRIPTION
## Summary

Fixes #759

The `CLAUDE_APP_BOT_ID` constant was incorrectly set to `41898282`, which is the ID for `github-actions[bot]`, not `claude[bot]`.

The correct ID for `claude[bot]` is `209825114` (verified via GitHub API).

## Problem

This mismatch caused commits made via git CLI fallback to be unsigned, because the email format uses the bot ID:
- Wrong: `41898282+claude[bot]@users.noreply.github.com`
- Correct: `209825114+claude[bot]@users.noreply.github.com`

## Changes

- `src/github/constants.ts`: Updated `CLAUDE_APP_BOT_ID` from `41898282` to `209825114`
- `action.yml`: Updated default `bot_id` from `41898282` to `209825114`

## Verification

```bash
curl -s https://api.github.com/users/claude%5Bbot%5D | jq .id
# Returns: 209825114
```