### PR TITLE
Add support for push events in agent mode

### DIFF
--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -7,6 +7,7 @@ import type {
   PullRequestReviewEvent,
   PullRequestReviewCommentEvent,
   WorkflowRunEvent,
+  PushEvent,
 } from "@octokit/webhooks-types";
 import { CLAUDE_APP_BOT_ID, CLAUDE_BOT_LOGIN } from "./constants";
 // Custom types for GitHub Actions events that aren't webhooks
@@ -65,6 +66,7 @@ const AUTOMATION_EVENT_NAMES = [
   "repository_dispatch",
   "schedule",
   "workflow_run",
+  "push",
 ] as const;
 
 // Derive types from constants for better maintainability
@@ -111,14 +113,15 @@ export type ParsedGitHubContext = BaseContext & {
   isPR: boolean;
 };
 
-// Context for automation events (workflow_dispatch, repository_dispatch, schedule, workflow_run)
+// Context for automation events (workflow_dispatch, repository_dispatch, schedule, workflow_run, push)
 export type AutomationContext = BaseContext & {
   eventName: AutomationEventName;
   payload:
     | WorkflowDispatchEvent
     | RepositoryDispatchEvent
     | ScheduleEvent
-    | WorkflowRunEvent;
+    | WorkflowRunEvent
+    | PushEvent;
 };
 
 // Union type for all contexts
@@ -231,6 +234,13 @@ export function parseGitHubContext(): GitHubContext {
         ...commonFields,
         eventName: "workflow_run",
         payload: context.payload as unknown as WorkflowRunEvent,
+      };
+    }
+    case "push": {
+      return {
+        ...commonFields,
+        eventName: "push",
+        payload: context.payload as unknown as PushEvent,
       };
     }
     default:


### PR DESCRIPTION
## Summary

This PR adds support for `push` events in agent/automation mode, enabling CI integration testing of skills without requiring manual `workflow_dispatch` triggers.

## Changes

- Import `PushEvent` type from `@octokit/webhooks-types`
- Add `"push"` to `AUTOMATION_EVENT_NAMES` constant
- Add `PushEvent` to `AutomationContext` payload union type
- Add case handler for `"push"` events in `parseGitHubContext`

## Use Case

This enables reusable CI workflows (like skill testing) to run on push events to main branches, not just on PRs or manual triggers. For example:

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]

jobs:
  test:
    uses: anthropics/skills/.github/workflows/skill-ci.yml@main
    with:
      run_claude_code_test: true
    secrets: inherit
```

Without this change, the action throws `Error: Unsupported event type: push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)