### PR TITLE
fix: prevent orphaned installer processes from blocking retries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -213,7 +213,8 @@ runs:
           for attempt in 1 2 3; do
             echo "Installation attempt $attempt..."
             if command -v timeout &> /dev/null; then
-              timeout 120 bash -c "curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_CODE_VERSION" && break
+              # Use --foreground to kill entire process group on timeout, --kill-after to send SIGKILL if SIGTERM fails
+              timeout --foreground --kill-after=10 120 bash -c "curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_CODE_VERSION" && break
             else
               curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_CODE_VERSION" && break
             fi

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -129,7 +129,8 @@ runs:
           for attempt in 1 2 3; do
             echo "Installation attempt $attempt..."
             if command -v timeout &> /dev/null; then
-              timeout 120 bash -c "curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_CODE_VERSION" && break
+              # Use --foreground to kill entire process group on timeout, --kill-after to send SIGKILL if SIGTERM fails
+              timeout --foreground --kill-after=10 120 bash -c "curl -fsSL https://claude.ai/install.sh | bash -s -- $CLAUDE_CODE_VERSION" && break
             else
               curl -fsSL https://claude.ai/install.sh | bash -s -- "$CLAUDE_CODE_VERSION" && break
             fi


### PR DESCRIPTION
## Summary
- Fix flaky CI failures where Claude Code installation retries fail with "another process is currently installing Claude"
- Add `--foreground` flag to `timeout` so it kills the entire process group (not just the direct child)
- Add `--kill-after=10` to send SIGKILL if SIGTERM doesn't terminate processes within 10 seconds
- Applied to both `action.yml` and `base-action/action.yml` for consistency across both entry points

## Test plan
- [ ] Verify the structured outputs CI job no longer fails due to stale lock files from timed-out installation attempts
- [ ] Confirm the `timeout` flags are supported on Ubuntu runners (GNU coreutils)

## Changelog
<!-- CHANGELOG:END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)