### PR TITLE
fix: set CLAUDE_CODE_ENTRYPOINT for SDK path to match CLI path

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -212,6 +212,8 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   if (process.env.INPUT_ACTION_INPUTS_PRESENT) {
     env.GITHUB_ACTION_INPUTS = process.env.INPUT_ACTION_INPUTS_PRESENT;
   }
+  // Ensure SDK path uses the same entrypoint as the CLI path
+  env.CLAUDE_CODE_ENTRYPOINT = "claude-code-github-action";
 
   // Build system prompt option - default to claude_code preset
   let systemPrompt: SdkOptions["systemPrompt"];


### PR DESCRIPTION
## Summary
- Sets `CLAUDE_CODE_ENTRYPOINT` to `"claude-code-github-action"` explicitly for the SDK path
- Previously, the SDK path would result in the CLI internally setting the entrypoint to `sdk-ts`, while the non-SDK (CLI) path correctly used `claude-code-github-action` based on `CLAUDE_CODE_ACTION` env var

🤖 Generated with [Claude Code](https://claude.ai/code)