### PR TITLE
fix: use original title from webhook payload instead of fetched title

### DIFF
--- a/src/github/data/formatter.ts
+++ b/src/github/data/formatter.ts
@@ -14,7 +14,8 @@ export function formatContext(
 ): string {
   if (isPR) {
     const prData = contextData as GitHubPullRequest;
-    return `PR Title: ${prData.title}
+    const sanitizedTitle = sanitizeContent(prData.title);
+    return `PR Title: ${sanitizedTitle}
 PR Author: ${prData.author.login}
 PR Branch: ${prData.headRefName} -> ${prData.baseRefName}
 PR State: ${prData.state}
@@ -24,7 +25,8 @@ Total Commits: ${prData.commits.totalCount}
 Changed Files: ${prData.files.nodes.length} files`;
   } else {
     const issueData = contextData as GitHubIssue;
-    return `Issue Title: ${issueData.title}
+    const sanitizedTitle = sanitizeContent(issueData.title);
+    return `Issue Title: ${sanitizedTitle}
 Issue Author: ${issueData.author.login}
 Issue State: ${issueData.state}`;
   }

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -12,6 +12,7 @@ import { prepareMcpConfig } from "../../mcp/install-mcp-server";
 import {
   fetchGitHubData,
   extractTriggerTimestamp,
+  extractOriginalTitle,
 } from "../../github/data/fetcher";
 import { createPrompt, generateDefaultPrompt } from "../../create-prompt";
 import { isEntityContext } from "../../github/context";
@@ -78,6 +79,7 @@ export const tagMode: Mode = {
     const commentId = commentData.id;
 
     const triggerTime = extractTriggerTimestamp(context);
+    const originalTitle = extractOriginalTitle(context);
 
     const githubData = await fetchGitHubData({
       octokits: octokit,
@@ -86,6 +88,7 @@ export const tagMode: Mode = {
       isPR: context.isPR,
       triggerUsername: context.actor,
       triggerTime,
+      originalTitle,
     });
 
     // Setup branch

--- a/test/data-fetcher.test.ts
+++ b/test/data-fetcher.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, jest } from "bun:test";
 import {
   extractTriggerTimestamp,
+  extractOriginalTitle,
   fetchGitHubData,
   filterCommentsToTriggerTime,
   filterReviewsToTriggerTime,
@@ -9,6 +10,7 @@ import {
 import {
   createMockContext,
   mockIssueCommentContext,
+  mockPullRequestCommentContext,
   mockPullRequestReviewContext,
   mockPullRequestReviewCommentContext,
   mockPullRequestOpenedContext,
@@ -60,6 +62,47 @@ describe("extractTriggerTimestamp", () => {
     });
     const timestamp = extractTriggerTimestamp(context);
     expect(timestamp).toBeUndefined();
+  });
+});
+
+describe("extractOriginalTitle", () => {
+  it("should extract title from IssueCommentEvent on PR", () => {
+    const title = extractOriginalTitle(mockPullRequestCommentContext);
+    expect(title).toBe("Fix: Memory leak in user service");
+  });
+
+  it("should extract title from PullRequestReviewEvent", () => {
+    const title = extractOriginalTitle(mockPullRequestReviewContext);
+    expect(title).toBe("Refactor: Improve error handling in API layer");
+  });
+
+  it("should extract title from PullRequestReviewCommentEvent", () => {
+    const title = extractOriginalTitle(mockPullRequestReviewCommentContext);
+    expect(title).toBe("Performance: Optimize search algorithm");
+  });
+
+  it("should extract title from pull_request event", () => {
+    const title = extractOriginalTitle(mockPullRequestOpenedContext);
+    expect(title).toBe("Feature: Add user authentication");
+  });
+
+  it("should extract title from issues event", () => {
+    const title = extractOriginalTitle(mockIssueOpenedContext);
+    expect(title).toBe("Bug: Application crashes on startup");
+  });
+
+  it("should return undefined for event without title", () => {
+    const context = createMockContext({
+      eventName: "issue_comment",
+      payload: {
+        comment: {
+          id: 123,
+          body: "test",
+        },
+      } as any,
+    });
+    const title = extractOriginalTitle(context);
+    expect(title).toBeUndefined();
   });
 });
 
@@ -944,5 +987,76 @@ describe("fetchGitHubData integration with time filtering", () => {
       key.includes("pr_body"),
     );
     expect(hasPrBodyInMap).toBe(false);
+  });
+
+  it("should use originalTitle when provided instead of fetched title", async () => {
+    const mockOctokits = {
+      graphql: jest.fn().mockResolvedValue({
+        repository: {
+          pullRequest: {
+            number: 123,
+            title: "Fetched Title From GraphQL",
+            body: "PR body",
+            author: { login: "author" },
+            createdAt: "2024-01-15T10:00:00Z",
+            additions: 10,
+            deletions: 5,
+            state: "OPEN",
+            commits: { totalCount: 1, nodes: [] },
+            files: { nodes: [] },
+            comments: { nodes: [] },
+            reviews: { nodes: [] },
+          },
+        },
+        user: { login: "trigger-user" },
+      }),
+      rest: jest.fn() as any,
+    };
+
+    const result = await fetchGitHubData({
+      octokits: mockOctokits as any,
+      repository: "test-owner/test-repo",
+      prNumber: "123",
+      isPR: true,
+      triggerUsername: "trigger-user",
+      originalTitle: "Original Title From Webhook",
+    });
+
+    expect(result.contextData.title).toBe("Original Title From Webhook");
+  });
+
+  it("should use fetched title when originalTitle is not provided", async () => {
+    const mockOctokits = {
+      graphql: jest.fn().mockResolvedValue({
+        repository: {
+          pullRequest: {
+            number: 123,
+            title: "Fetched Title From GraphQL",
+            body: "PR body",
+            author: { login: "author" },
+            createdAt: "2024-01-15T10:00:00Z",
+            additions: 10,
+            deletions: 5,
+            state: "OPEN",
+            commits: { totalCount: 1, nodes: [] },
+            files: { nodes: [] },
+            comments: { nodes: [] },
+            reviews: { nodes: [] },
+          },
+        },
+        user: { login: "trigger-user" },
+      }),
+      rest: jest.fn() as any,
+    };
+
+    const result = await fetchGitHubData({
+      octokits: mockOctokits as any,
+      repository: "test-owner/test-repo",
+      prNumber: "123",
+      isPR: true,
+      triggerUsername: "trigger-user",
+    });
+
+    expect(result.contextData.title).toBe("Fetched Title From GraphQL");
   });
 });


### PR DESCRIPTION
## Summary

Use the original PR/issue title from the webhook payload instead of the title fetched via GraphQL. This ensures the title used in prompts is the one that existed when the trigger event occurred.

## Changes

- Add `extractOriginalTitle()` helper to extract title from webhook payload for all entity event types
- Add `originalTitle` parameter to `fetchGitHubData()` that overrides the fetched title
- Update tag mode to extract and pass the original title from webhook context
- Add tests for `extractOriginalTitle` and the `originalTitle` parameter

## Testing

- Added 6 tests for `extractOriginalTitle()` covering all event types
- Added 2 tests for `fetchGitHubData()` verifying title override behavior
- All 586 tests pass