### PR TITLE
fix: add missing import and update tests for branch template feature

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -6,6 +6,7 @@
  * - For Issues: Create a new branch
  */
 
+import { $ } from "bun";
 import { execFileSync } from "child_process";
 import * as core from "@actions/core";
 import type { ParsedGitHubContext } from "../context";

--- a/src/utils/branch-template.ts
+++ b/src/utils/branch-template.ts
@@ -7,7 +7,7 @@
 const NUM_DESCRIPTION_WORDS = 5;
 
 /**
- * Extracts the first `numWords` words from a title and converts them to kebab-case
+ * Extracts the first 5 words from a title and converts them to kebab-case
  */
 function extractDescription(
   title: string,

--- a/src/utils/branch-template.ts
+++ b/src/utils/branch-template.ts
@@ -9,7 +9,10 @@ const NUM_DESCRIPTION_WORDS = 5;
 /**
  * Extracts the first `numWords` words from a title and converts them to kebab-case
  */
-function extractDescription(title: string, numWords: number = NUM_DESCRIPTION_WORDS): string {
+function extractDescription(
+  title: string,
+  numWords: number = NUM_DESCRIPTION_WORDS,
+): string {
   if (!title || title.trim() === "") {
     return "";
   }

--- a/test/branch-template.test.ts
+++ b/test/branch-template.test.ts
@@ -192,6 +192,19 @@ describe("branch template utilities", () => {
       expect(result).toBe("fix/add-user-registration-email-789");
     });
 
+    it("should truncate descriptions to exactly 5 words", () => {
+      const result = generateBranchName(
+        "{{prefix}}{{description}}/{{entityNumber}}",
+        "feature/",
+        "issue",
+        999,
+        undefined,
+        undefined,
+        "This is a very long title with many more than five words in it",
+      );
+      expect(result).toBe("feature/this-is-a-very-long/999");
+    });
+
     it("should handle empty description in template", () => {
       const template = "{{prefix}}{{description}}-{{entityNumber}}";
       const result = generateBranchName(

--- a/test/branch-template.test.ts
+++ b/test/branch-template.test.ts
@@ -156,7 +156,7 @@ describe("branch template utilities", () => {
         "Fix login bug with OAuth",
       );
 
-      expect(result).toBe("feature/fix-login-bug/123");
+      expect(result).toBe("feature/fix-login-bug-with-oauth/123");
     });
 
     it("should handle template with multiple variables including description", () => {
@@ -172,7 +172,9 @@ describe("branch template utilities", () => {
         "User authentication fails completely",
       );
 
-      expect(result).toBe("dev/bug/user-authentication-fails-issue_456");
+      expect(result).toBe(
+        "dev/bug/user-authentication-fails-completely-issue_456",
+      );
     });
 
     it("should handle description with special characters in template", () => {
@@ -187,7 +189,7 @@ describe("branch template utilities", () => {
         "Add: User Registration & Email Validation",
       );
 
-      expect(result).toBe("fix/add-user-registration-789");
+      expect(result).toBe("fix/add-user-registration-email-789");
     });
 
     it("should handle empty description in template", () => {

--- a/test/pull-request-target.test.ts
+++ b/test/pull-request-target.test.ts
@@ -87,6 +87,7 @@ describe("pull_request_target event support", () => {
       },
       comments: { nodes: [] },
       reviews: { nodes: [] },
+      labels: { nodes: [] },
     },
     comments: [],
     changedFiles: [],


### PR DESCRIPTION
Fixes issues introduced by #571 (custom branch name templates):

- Add missing `import { $ } from 'bun'` in `branch.ts` for Bun shell syntax
- Add missing `labels` property to `pull-request-target.test.ts` fixture
- Update `branch-template.test.ts` to expect 5-word descriptions (changed from 3 per reviewer feedback in #571, but tests weren't updated)

All checks pass:
- `bun run typecheck` ✓
- `bun test` ✓ (628 pass, 0 fail)
- `bun run format:check` ✓
