### PR TITLE
docs: add oauth token alternative to example workflow

### DIFF
--- a/examples/claude.yml
+++ b/examples/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}  # Alternative: for Pro/Max users
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Summary
- Add commented example showing `claude_code_oauth_token` as an alternative authentication method for Pro/Max users
- Aligns `examples/claude.yml` with the documentation in `docs/setup.md`

## Test plan
- [x] Verify YAML syntax is valid
- [x] Confirm comment style matches existing patterns in the file