### PR TITLE
fix: replace setup-bun action with curl-based installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -146,22 +146,24 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Install Bun
-      if: inputs.path_to_bun_executable == ''
-      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # https://github.com/oven-sh/setup-bun/releases/tag/v2.0.2
-      with:
-        bun-version: 1.2.11
-
-    - name: Setup Custom Bun Path
-      if: inputs.path_to_bun_executable != ''
+    - name: Setup Bun
       shell: bash
       env:
         PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
+        BUN_VERSION: "1.2.11"
       run: |
-        echo "Using custom Bun executable: $PATH_TO_BUN_EXECUTABLE"
-        # Add the directory containing the custom executable to PATH
-        BUN_DIR=$(dirname "$PATH_TO_BUN_EXECUTABLE")
-        echo "$BUN_DIR" >> "$GITHUB_PATH"
+        if [ -n "$PATH_TO_BUN_EXECUTABLE" ]; then
+          echo "Using custom Bun executable: $PATH_TO_BUN_EXECUTABLE"
+          # Add the directory containing the custom executable to PATH
+          BUN_DIR=$(dirname "$PATH_TO_BUN_EXECUTABLE")
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+        else
+          echo "Installing Bun v${BUN_VERSION}..."
+          curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.bun/bin:$PATH"
+          echo "Bun $(bun --version) installed successfully"
+        fi
 
     - name: Install Dependencies
       shell: bash

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -95,22 +95,24 @@ runs:
         node-version: ${{ env.NODE_VERSION || '18.x' }}
         cache: ${{ inputs.use_node_cache == 'true' && 'npm' || '' }}
 
-    - name: Install Bun
-      if: inputs.path_to_bun_executable == ''
-      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # https://github.com/oven-sh/setup-bun/releases/tag/v2.0.2
-      with:
-        bun-version: 1.2.11
-
-    - name: Setup Custom Bun Path
-      if: inputs.path_to_bun_executable != ''
+    - name: Setup Bun
       shell: bash
       env:
         PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
+        BUN_VERSION: "1.2.11"
       run: |
-        echo "Using custom Bun executable: $PATH_TO_BUN_EXECUTABLE"
-        # Add the directory containing the custom executable to PATH
-        BUN_DIR=$(dirname "$PATH_TO_BUN_EXECUTABLE")
-        echo "$BUN_DIR" >> "$GITHUB_PATH"
+        if [ -n "$PATH_TO_BUN_EXECUTABLE" ]; then
+          echo "Using custom Bun executable: $PATH_TO_BUN_EXECUTABLE"
+          # Add the directory containing the custom executable to PATH
+          BUN_DIR=$(dirname "$PATH_TO_BUN_EXECUTABLE")
+          echo "$BUN_DIR" >> "$GITHUB_PATH"
+        else
+          echo "Installing Bun v${BUN_VERSION}..."
+          curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+          export PATH="$HOME/.bun/bin:$PATH"
+          echo "Bun $(bun --version) installed successfully"
+        fi
 
     - name: Install Dependencies
       shell: bash


### PR DESCRIPTION
# Replace `oven-sh/setup-bun` action with curl-based installation

## Problem

**This PR fixes bun installation on GitHub Enterprise Server (GHES).** On GHES environments, the `oven-sh/setup-bun` action may not be available at the expected path (it could be synced under a different path like `synced-actions/oven-sh/setup-bun`).

The current implementation uses `oven-sh/setup-bun` with a conditional `if` statement, but GitHub Actions resolves and downloads all referenced actions at workflow parse time, before any conditional logic runs. This causes the action to fail on GHES regardless of the conditional logic.

## Changes

- Replaced `oven-sh/setup-bun` action with inline curl-based installation in both `action.yml` and `base-action/action.yml`
- Combined the "Install Bun" and "Setup Custom Bun Path" steps into a single "Setup Bun" step
- The `path_to_bun_executable` input continues to work for users who want to manage bun installation themselves

## Benefits

- Works on both GitHub.com and GHES without configuration
- No external action dependencies to sync
- Same end result (bun gets installed to `~/.bun/bin`)
- Bun installation via curl is fast (~2-3 seconds)

## Testing

Tested the shell script logic directly:
- ✓ Curl installation installs bun 1.2.11 correctly
- ✓ Custom path logic works correctly when `path_to_bun_executable` is provided

Closes #618

🤖 Generated with [Claude Code](https://claude.ai/code)