### PR TITLE
fix: add checkHumanActor to agent mode

### DIFF
--- a/src/github/validation/actor.ts
+++ b/src/github/validation/actor.ts
@@ -6,11 +6,11 @@
  */
 
 import type { Octokit } from "@octokit/rest";
-import type { ParsedGitHubContext } from "../context";
+import type { GitHubContext } from "../context";
 
 export async function checkHumanActor(
   octokit: Octokit,
-  githubContext: ParsedGitHubContext,
+  githubContext: GitHubContext,
 ) {
   // Fetch user information from GitHub API
   const { data: userData } = await octokit.users.getByUsername({

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -8,6 +8,7 @@ import {
   configureGitAuth,
   setupSshSigning,
 } from "../../github/operations/git-config";
+import { checkHumanActor } from "../../github/validation/actor";
 import type { GitHubContext } from "../../github/context";
 import { isEntityContext } from "../../github/context";
 
@@ -80,7 +81,14 @@ export const agentMode: Mode = {
     return false;
   },
 
-  async prepare({ context, githubToken }: ModeOptions): Promise<ModeResult> {
+  async prepare({
+    context,
+    octokit,
+    githubToken,
+  }: ModeOptions): Promise<ModeResult> {
+    // Check if actor is human (prevents bot-triggered loops)
+    await checkHumanActor(octokit.rest, context);
+
     // Configure git authentication for agent mode (same as tag mode)
     // SSH signing takes precedence if provided
     const useSshSigning = !!context.inputs.sshSigningKey;


### PR DESCRIPTION
Fixes issue #641 where users were getting banned due to rapid successive Claude runs triggered by the synchronize event.

Changes:
- Add checkHumanActor call to agent mode's prepare() method to reject bot-triggered workflows unless explicitly allowed via allowed_bots
- Update checkHumanActor to accept GitHubContext (union type) instead of just ParsedGitHubContext
- Add tests for bot rejection/allowance in agent mode
