### PR TITLE
chore: comment out release-base-action job in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,48 +109,48 @@ jobs:
 
           echo "Updated $major_version tag to point to $next_version"
 
-  release-base-action:
-    needs: create-release
-    if: ${{ !inputs.dry_run }}
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - name: Checkout base-action repo
-        uses: actions/checkout@v5
-        with:
-          repository: anthropics/claude-code-base-action
-          token: ${{ secrets.CLAUDE_CODE_BASE_ACTION_PAT }}
-          fetch-depth: 0
-
-      # - name: Create and push tag
-      #   run: |
-      #     next_version="${{ needs.create-release.outputs.next_version }}"
-
-      #     git config user.name "github-actions[bot]"
-      #     git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      #     # Create the version tag
-      #     git tag -a "$next_version" -m "Release $next_version - synced from claude-code-action"
-      #     git push origin "$next_version"
-
-      #     # Update the beta tag
-      #     git tag -fa beta -m "Update beta tag to ${next_version}"
-      #     git push origin beta --force
-
-      # - name: Create GitHub release
-      #   env:
-      #     GH_TOKEN: ${{ secrets.CLAUDE_CODE_BASE_ACTION_PAT }}
-      #   run: |
-      #     next_version="${{ needs.create-release.outputs.next_version }}"
-
-      #     # Create the release
-      #     gh release create "$next_version" \
-      #       --repo anthropics/claude-code-base-action \
-      #       --title "$next_version" \
-      #       --notes "Release $next_version - synced from anthropics/claude-code-action" \
-      #       --latest=false
-
-      #     # Update beta release to be latest
-      #     gh release edit beta \
-      #       --repo anthropics/claude-code-base-action \
-      #       --latest
+  # release-base-action:
+  #   needs: create-release
+  #   if: ${{ !inputs.dry_run }}
+  #   runs-on: ubuntu-latest
+  #   environment: production
+  #   steps:
+  #     - name: Checkout base-action repo
+  #       uses: actions/checkout@v5
+  #       with:
+  #         repository: anthropics/claude-code-base-action
+  #         token: ${{ secrets.CLAUDE_CODE_BASE_ACTION_PAT }}
+  #         fetch-depth: 0
+  #
+  #     - name: Create and push tag
+  #       run: |
+  #         next_version="${{ needs.create-release.outputs.next_version }}"
+  #
+  #         git config user.name "github-actions[bot]"
+  #         git config user.email "github-actions[bot]@users.noreply.github.com"
+  #
+  #         # Create the version tag
+  #         git tag -a "$next_version" -m "Release $next_version - synced from claude-code-action"
+  #         git push origin "$next_version"
+  #
+  #         # Update the beta tag
+  #         git tag -fa beta -m "Update beta tag to ${next_version}"
+  #         git push origin beta --force
+  #
+  #     - name: Create GitHub release
+  #       env:
+  #         GH_TOKEN: ${{ secrets.CLAUDE_CODE_BASE_ACTION_PAT }}
+  #       run: |
+  #         next_version="${{ needs.create-release.outputs.next_version }}"
+  #
+  #         # Create the release
+  #         gh release create "$next_version" \
+  #           --repo anthropics/claude-code-base-action \
+  #           --title "$next_version" \
+  #           --notes "Release $next_version - synced from anthropics/claude-code-action" \
+  #           --latest=false
+  #
+  #         # Update beta release to be latest
+  #         gh release edit beta \
+  #           --repo anthropics/claude-code-base-action \
+  #           --latest


### PR DESCRIPTION
## Summary
- Temporarily disables the `release-base-action` job in the release workflow
- The job that syncs releases to the `claude-code-base-action` repository is now commented out
- All steps including checkout, tag creation, and GitHub release creation are disabled

## Test plan
- [ ] Verify the release workflow still runs successfully without the release-base-action job
- [ ] Confirm other release jobs (create-release) continue to function normally

## Changelog
<!-- CHANGELOG:START -->
<!-- CHANGELOG:END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code) (100% 3-shotted by claude-opus-4-5)