### PR TITLE
Consolidate CI workflows into a single entry point

### DIFF
--- a/.github/workflows/ci-all.yml
+++ b/.github/workflows/ci-all.yml
@@ -1,0 +1,32 @@
+name: CI All
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  test-base-action:
+    uses: ./.github/workflows/test-base-action.yml
+    secrets: inherit
+
+  test-custom-executables:
+    uses: ./.github/workflows/test-custom-executables.yml
+    secrets: inherit
+
+  test-mcp-servers:
+    uses: ./.github/workflows/test-mcp-servers.yml
+    secrets: inherit
+
+  test-settings:
+    uses: ./.github/workflows/test-settings.yml
+    secrets: inherit
+
+  test-structured-output:
+    uses: ./.github/workflows/test-structured-output.yml
+    secrets: inherit

--- a/.github/workflows/ci-all.yml
+++ b/.github/workflows/ci-all.yml
@@ -1,3 +1,5 @@
+# Orchestrates all CI workflows - runs on PRs, pushes to main, and manual dispatch
+# Individual test workflows are called as reusable workflows
 name: CI All
 
 on:
@@ -7,13 +9,16 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
 
   test-base-action:
     uses: ./.github/workflows/test-base-action.yml
-    secrets: inherit
+    secrets: inherit # Required for ANTHROPIC_API_KEY
 
   test-custom-executables:
     uses: ./.github/workflows/test-custom-executables.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.event == 'push' &&
        startsWith(github.event.workflow_run.head_commit.message, 'chore: bump Claude Code to'))
     environment: production
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,21 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_run:
+    workflows: ["CI All"]
+    types:
+      - completed
+    branches:
+      - main
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    # Run if: manual dispatch OR (CI All succeeded AND commit is a version bump)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_commit.message, 'chore: bump Claude Code to'))
     environment: production
     permissions:
       contents: write
@@ -84,7 +95,8 @@ jobs:
 
   update-major-tag:
     needs: create-release
-    if: ${{ !inputs.dry_run }}
+    # Skip for dry runs (workflow_run events are never dry runs)
+    if: github.event_name == 'workflow_run' || !inputs.dry_run
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/test-base-action.yml
+++ b/.github/workflows/test-base-action.yml
@@ -1,9 +1,6 @@
 name: Test Claude Code Action
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
     inputs:
@@ -11,6 +8,7 @@ on:
         description: "Test prompt for Claude"
         required: false
         default: "List the files in the current directory starting with 'package'"
+  workflow_call:
 
 jobs:
   test-inline-prompt:

--- a/.github/workflows/test-custom-executables.yml
+++ b/.github/workflows/test-custom-executables.yml
@@ -1,11 +1,9 @@
 name: Test Custom Executables
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   test-custom-executables:

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -1,11 +1,9 @@
 name: Test MCP Servers
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   test-mcp-integration:

--- a/.github/workflows/test-settings.yml
+++ b/.github/workflows/test-settings.yml
@@ -1,11 +1,9 @@
 name: Test Settings Feature
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   test-settings-inline-allow:

--- a/.github/workflows/test-structured-output.yml
+++ b/.github/workflows/test-structured-output.yml
@@ -1,11 +1,9 @@
 name: Test Structured Outputs
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Creates a new `ci-all.yml` workflow that orchestrates all CI workflows (ci, test-base-action, test-custom-executables, test-mcp-servers, test-settings, test-structured-output)
- Updates individual test workflows to support `workflow_call` for reuse and removes redundant `push` triggers
- Modifies `release.yml` to auto-trigger on successful `CI All` runs for version bump commits

## Test plan
- [ ] Verify `CI All` workflow triggers on PRs and runs all sub-workflows
- [ ] Verify `CI All` workflow triggers on pushes to main
- [ ] Verify individual workflows can still be triggered via `workflow_dispatch`
- [ ] Verify release workflow auto-triggers after successful `CI All` on version bump commits
- [ ] Verify manual `workflow_dispatch` for releases still works

## Changelog
<!-- CHANGELOG:START -->
<!-- CHANGELOG:END -->

🤖 Generated with [Claude Code](https://claude.com/claude-code) (100% 10-shotted by claude-opus-4-5)