### PR TITLE
fix: skip SHA computation for ADDED files

### DIFF
--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -275,6 +275,14 @@ export async function fetchGitHubData({
         };
       }
 
+      // Don't compute SHA for newly added files (not in base branch checkout)
+      if (file.changeType === "ADDED") {
+        return {
+          ...file,
+          sha: "added",
+        };
+      }
+
       try {
         // Use git hash-object to compute the SHA for the current file content
         const sha = execFileSync("git", ["hash-object", file.path], {


### PR DESCRIPTION
## Summary                        
  ADDED files don't exist in base branch checkout, causing `git hash-object` to fail with `No such file or directory`.                        
                                                                                                                                                  
  Returns `sha: "added"` for ADDED files, matching the pattern used for DELETED files (PR #115).                                              
                                                                                                                                                  
  Also adds test coverage for SHA computation handling.                                                                                           
                                                                                                                                                  
  ## Test plan                                                                                                                                    
  - [x] `bun test` - all 640 tests pass                                                                                                         
  - [x] `bun run typecheck` - passes                                                                                                            
  - [x] `bun run format:check` - passes