### PR TITLE
chore: bump Bun to 1.3.6 and setup-bun action to v2.1.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -148,9 +148,9 @@ runs:
   steps:
     - name: Install Bun
       if: inputs.path_to_bun_executable == ''
-      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # https://github.com/oven-sh/setup-bun/releases/tag/v2.0.2
+      uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # https://github.com/oven-sh/setup-bun/releases/tag/v2.1.2
       with:
-        bun-version: 1.2.11
+        bun-version: 1.3.6
 
     - name: Setup Custom Bun Path
       if: inputs.path_to_bun_executable != ''

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -97,9 +97,9 @@ runs:
 
     - name: Install Bun
       if: inputs.path_to_bun_executable == ''
-      uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # https://github.com/oven-sh/setup-bun/releases/tag/v2.0.2
+      uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # https://github.com/oven-sh/setup-bun/releases/tag/v2.1.2
       with:
-        bun-version: 1.2.11
+        bun-version: 1.3.6
 
     - name: Setup Custom Bun Path
       if: inputs.path_to_bun_executable != ''


### PR DESCRIPTION
- Update Bun runtime version from 1.2.11 to 1.3.6
- Update `oven-sh/setup-bun` action from v2.0.2 to v2.1.2