### PR TITLE
Fix PR checkout to support fork PRs

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -167,7 +167,13 @@ export async function setupBranch(
 
       // Execute git commands to checkout PR branch (dynamic depth based on PR size)
       // Using execFileSync instead of shell template literals for security
-      execGit(["fetch", "origin", `--depth=${fetchDepth}`, branchName]);
+      // Use GitHub's PR ref which works for both same-repo and fork PRs
+      execGit([
+        "fetch",
+        "origin",
+        `--depth=${fetchDepth}`,
+        `pull/${entityNumber}/head:${branchName}`,
+      ]);
       execGit(["checkout", branchName, "--"]);
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);


### PR DESCRIPTION
Use GitHub's PR refs (pull/NUMBER/head) instead of fetching branch by name. This works for both same-repo and fork PRs because GitHub automatically creates these refs in the base repository for all PRs.

The branch name doesn't exist on origin for fork PRs, causing:
  fatal: couldn't find remote ref <branch-name>

Using pull/${entityNumber}/head:${branchName} fetches the PR head and creates a local branch with the correct name.

Fixes issues with tag mode failing on fork PRs.