### PR TITLE
fix: correct syntax errors in issue-triage.yml

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,5 +1,4 @@
 name: Claude Issue Triage
-description: Run Claude Code for issue triage in GitHub Actions
 on:
   issues:
     types: [opened]
@@ -21,7 +20,7 @@ jobs:
       - name: Run Claude Code for Issue Triage
         uses: anthropics/claude-code-action@main
         with:
-          prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER${{ github.event.issue.number }}"
+          prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ github.event.issue.number }}"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_non_write_users: "*" # Required for issue triage workflow, if users without repo write access create issues
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/issue-triage.yml
+++ b/examples/issue-triage.yml
@@ -1,5 +1,4 @@
 name: Claude Issue Triage
-description: Run Claude Code for issue triage in GitHub Actions
 on:
   issues:
     types: [opened]
@@ -22,7 +21,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           # NOTE: /label-issue here requires a .claude/commands/label-issue.md file in your repo (see this repo's .claude directory for an example)
-          prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER${{ github.event.issue.number }}"
+          prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ github.event.issue.number }}"
 
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_non_write_users: "*" # Required for issue triage workflow, if users without repo write access create issues


### PR DESCRIPTION
Fix syntax errors in issue-triage.yml workflow files.

- Remove invalid `description` property (not valid in workflow files)
- Add missing colon after `ISSUE_NUMBER` in prompt parameter