### PR TITLE
feat: send additional_permissions in token exchange request

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -174,8 +174,11 @@ jobs:
 
 - The GitHub token must have the corresponding permission in your workflow
 - If the permission is missing, Claude will warn you and suggest adding it
-- Any GitHub App permission can be requested (e.g. `actions: read`, `workflows: write`, `deployments: read`)
-- The GitHub App installation must have the requested permission enabled for it to take effect
+- The following additional permissions can be requested beyond the defaults:
+  - `actions: read`
+  - `checks: read`
+  - `discussions: read` or `discussions: write`
+  - `workflows: read` or `workflows: write`
 - Standard permissions (`contents: write`, `pull_requests: write`, `issues: write`) are always included and do not need to be specified
 
 ## Custom Environment Variables

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,9 +172,11 @@ jobs:
 
 **Important Notes**:
 
-- The GitHub token must have the `actions: read` permission in your workflow
+- The GitHub token must have the corresponding permission in your workflow
 - If the permission is missing, Claude will warn you and suggest adding it
-- Currently, only `actions: read` is supported, but the format allows for future extensions
+- Any GitHub App permission can be requested (e.g. `actions: read`, `workflows: write`, `deployments: read`)
+- The GitHub App installation must have the requested permission enabled for it to take effect
+- Standard permissions (`contents: write`, `pull_requests: write`, `issues: write`) are always included and do not need to be specified
 
 ## Custom Environment Variables
 

--- a/test/parse-permissions.test.ts
+++ b/test/parse-permissions.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { parseAdditionalPermissions } from "../src/github/token";
+
+describe("parseAdditionalPermissions", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.ADDITIONAL_PERMISSIONS;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ADDITIONAL_PERMISSIONS;
+    } else {
+      process.env.ADDITIONAL_PERMISSIONS = originalEnv;
+    }
+  });
+
+  test("returns undefined when env var is not set", () => {
+    delete process.env.ADDITIONAL_PERMISSIONS;
+    expect(parseAdditionalPermissions()).toBeUndefined();
+  });
+
+  test("returns undefined when env var is empty string", () => {
+    process.env.ADDITIONAL_PERMISSIONS = "";
+    expect(parseAdditionalPermissions()).toBeUndefined();
+  });
+
+  test("returns undefined when env var is only whitespace", () => {
+    process.env.ADDITIONAL_PERMISSIONS = "   \n  \n  ";
+    expect(parseAdditionalPermissions()).toBeUndefined();
+  });
+
+  test("parses single permission and merges with defaults", () => {
+    process.env.ADDITIONAL_PERMISSIONS = "actions: read";
+    expect(parseAdditionalPermissions()).toEqual({
+      contents: "write",
+      pull_requests: "write",
+      issues: "write",
+      actions: "read",
+    });
+  });
+
+  test("parses multiple permissions", () => {
+    process.env.ADDITIONAL_PERMISSIONS = "actions: read\nworkflows: write";
+    expect(parseAdditionalPermissions()).toEqual({
+      contents: "write",
+      pull_requests: "write",
+      issues: "write",
+      actions: "read",
+      workflows: "write",
+    });
+  });
+
+  test("additional permissions can override defaults", () => {
+    process.env.ADDITIONAL_PERMISSIONS = "contents: read";
+    expect(parseAdditionalPermissions()).toEqual({
+      contents: "read",
+      pull_requests: "write",
+      issues: "write",
+    });
+  });
+
+  test("handles extra whitespace around keys and values", () => {
+    process.env.ADDITIONAL_PERMISSIONS = "  actions :  read  ";
+    expect(parseAdditionalPermissions()).toEqual({
+      contents: "write",
+      pull_requests: "write",
+      issues: "write",
+      actions: "read",
+    });
+  });
+
+  test("skips empty lines", () => {
+    process.env.ADDITIONAL_PERMISSIONS =
+      "actions: read\n\n\nworkflows: write\n\n";
+    expect(parseAdditionalPermissions()).toEqual({
+      contents: "write",
+      pull_requests: "write",
+      issues: "write",
+      actions: "read",
+      workflows: "write",
+    });
+  });
+
+  test("skips lines without colons", () => {
+    process.env.ADDITIONAL_PERMISSIONS =
+      "actions: read\ninvalid line\nworkflows: write";
+    expect(parseAdditionalPermissions()).toEqual({
+      contents: "write",
+      pull_requests: "write",
+      issues: "write",
+      actions: "read",
+      workflows: "write",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Parse the `additional_permissions` input and send it as a JSON body in the OIDC token exchange request. The API endpoint already supports this — this change wires up the client side.

## Changes

### `src/github/token.ts`
- Added `parseAdditionalPermissions()` — reads `ADDITIONAL_PERMISSIONS` env var, parses the `key: value` per-line format, and merges with the standard defaults (`contents: write`, `pull_requests: write`, `issues: write`)
- Updated `exchangeForAppToken()` to accept optional `permissions` param and send JSON body with `Content-Type: application/json` when provided
- Updated `setupGitHubToken()` to call `parseAdditionalPermissions()` and pass the result (only in the OIDC path, not when `OVERRIDE_GITHUB_TOKEN` is set)

### `test/parse-permissions.test.ts` (new)
9 unit tests covering: undefined/empty returns, single/multiple permission parsing, default merging, override behavior, whitespace handling, empty lines, and invalid lines.

### `docs/configuration.md`
Updated the "Additional Permissions" section to document that any GitHub App permission can be requested (removed the "only `actions: read` is supported" limitation).

## API Contract

`POST /api/github/github-app-token-exchange`
- Header: `Authorization: Bearer <oidc_token>`
- Body (optional): `{ "permissions": { "actions": "read", "workflows": "write", ... } }`
- If no body/permissions: defaults to `{contents: write, pull_requests: write, issues: write}`