### PR TITLE
fix: pass GitHub token to setup-bun to avoid rate limits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -151,6 +151,7 @@ runs:
       uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # https://github.com/oven-sh/setup-bun/releases/tag/v2.1.2
       with:
         bun-version: 1.3.6
+        token: ${{ inputs.github_token || github.token }}
 
     - name: Setup Custom Bun Path
       if: inputs.path_to_bun_executable != ''


### PR DESCRIPTION
## Summary

- Pass `github_token` input (or fallback `github.token`) to the `setup-bun` action
- Prevents 403 rate limit errors when fetching Bun release tags from GitHub API on shared runners

## Problem

The `setup-bun` action fetches Bun release tags from the GitHub API. Without an authenticated token, it hits rate limits (403 error) when running from shared GitHub Actions runners:

```
Error: API rate limit exceeded for <IP>. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```

## Solution

Pass the user-provided `github_token` input to `setup-bun`, falling back to `${{ github.token }}` when not provided. This provides authenticated API access without requiring any changes from users.