### PR TITLE
fix: sync CLI install version in run.ts (2.1.31 → 2.1.37)

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -51,7 +51,7 @@ async function installClaudeCode(): Promise<void> {
     return;
   }
 
-  const claudeCodeVersion = "2.1.31";
+  const claudeCodeVersion = "2.1.37";
   console.log(`Installing Claude Code v${claudeCodeVersion}...`);
 
   for (let attempt = 1; attempt <= 3; attempt++) {


### PR DESCRIPTION
## Summary

The unified entrypoint `src/entrypoints/run.ts` hardcodes `const claudeCodeVersion = "2.1.31"` (line 54), while `base-action/action.yml` has been bumped to `2.1.37`. Since `action.yml` runs `run.ts` as the entrypoint, the stale version in `run.ts` is what actually gets installed.

The automated version bump commits (e.g., `6c61301` "bump to 2.1.37") update `package.json`, `bun.lock`, `base-action/action.yml`, and `base-action/package.json` — but never touch `run.ts`.

This means **features added after v2.1.31 are unavailable** when using the action via `@v1`, even though `base-action/action.yml` references the correct version.

### Evidence

| Location | Version |
|----------|---------|
| `base-action/action.yml:127` | `2.1.37` ✅ |
| `src/entrypoints/run.ts:54` | `2.1.31` ❌ (stale) |
| `package.json` SDK | `^0.2.37` ✅ |

### Impact

Any CLI feature added after v2.1.31 doesn't work through the action. For example, agent teams (added in v2.1.32) fail silently — the `TeamCreate`, `SendMessage`, etc. tools simply don't exist in the installed CLI.

### Fix

This PR updates the hardcoded version in `run.ts` to `2.1.37` to match `base-action/action.yml`.

### Suggestion

The version bump automation should be updated to also modify `src/entrypoints/run.ts` so this doesn't drift again.

## Test plan

- [ ] Verify the action installs Claude Code v2.1.37 (check install log output)
- [ ] Verify features from v2.1.32+ (e.g., agent teams) work when enabled via settings