### PR TITLE
docs: add FAQ item about bun install on GHES

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,4 +370,6 @@ Use `path_to_bun_executable` to provide your own Bun runtime instead of the defa
     # ... other inputs
 ```
 
+> **Note for GHES users**: The automatic Bun installation requires authenticated access to github.com to avoid rate limits. On GitHub Enterprise Server, you'll need to either provide a github.com PAT to `setup-bun` or use `path_to_bun_executable`. See the [FAQ](faq.md#how-do-i-fix-bun-installation-issues-on-github-enterprise-server-ghes) for setup instructions.
+
 **Important**: Using incompatible versions may cause the action to fail. Ensure your custom executables are compatible with the action's requirements.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -205,6 +205,32 @@ However, tools from these servers still need to be explicitly allowed via `claud
 
 ## Troubleshooting
 
+### How do I fix Bun installation issues on GitHub Enterprise Server (GHES)?
+
+The `setup-bun` action requires authenticated access to github.com to avoid rate limits when fetching Bun releases. 
+On GHES, we recommend installing Bun externally and providing the path to the executable:
+
+```yaml
+steps:
+  # Install Bun using the official installer
+  - name: Install Bun
+    run: |
+      curl -fsSL https://bun.sh/install | bash
+      echo "$HOME/.bun/bin" >> $GITHUB_PATH
+  # ... or with setup-bun and a github.com token
+  - name: Install Bun
+    uses: oven-sh/setup-bun@v2
+    with:
+      bun-version: 1.3.6
+      token: # PAT with public_repo scope for github.com
+
+  # Use the action with custom Bun path
+  - uses: anthropics/claude-code-action@v1
+    with:
+      path_to_bun_executable: "$HOME/.bun/bin/bun"
+      # ... other inputs
+```
+
 ### How can I debug what Claude is doing?
 
 Check the GitHub Action log for Claude's run for the full execution trace.


### PR DESCRIPTION
## Summary

Relying on the built-in `setup-bun` action to install bun in GHES setups often which fails with 403 rate limit errors as the calls to github.com are not authenticated.

This PR adds a doc section to offer guidance to install bun in such environments and pass the executable as an action parameter

It supersedes https://github.com/anthropics/claude-code-action/pull/861 and https://github.com/anthropics/claude-code-action/pull/901