### PR TITLE
fix: make trigger_phrase matching case-insensitive

### DIFF
--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -48,9 +48,10 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
   if (isIssuesEvent(context) && context.eventAction === "opened") {
     const issueBody = context.payload.issue.body || "";
     const issueTitle = context.payload.issue.title || "";
-    // Check for exact match with word boundaries or punctuation
+    // Check for exact match with word boundaries or punctuation (case-insensitive)
     const regex = new RegExp(
       `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
+      "i",
     );
 
     // Check in body
@@ -74,9 +75,10 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
   if (isPullRequestEvent(context)) {
     const prBody = context.payload.pull_request.body || "";
     const prTitle = context.payload.pull_request.title || "";
-    // Check for exact match with word boundaries or punctuation
+    // Check for exact match with word boundaries or punctuation (case-insensitive)
     const regex = new RegExp(
       `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
+      "i",
     );
 
     // Check in body
@@ -102,9 +104,10 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     (context.eventAction === "submitted" || context.eventAction === "edited")
   ) {
     const reviewBody = context.payload.review.body || "";
-    // Check for exact match with word boundaries or punctuation
+    // Check for exact match with word boundaries or punctuation (case-insensitive)
     const regex = new RegExp(
       `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
+      "i",
     );
     if (regex.test(reviewBody)) {
       console.log(
@@ -122,9 +125,10 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     const commentBody = isIssueCommentEvent(context)
       ? context.payload.comment.body
       : context.payload.comment.body;
-    // Check for exact match with word boundaries or punctuation
+    // Check for exact match with word boundaries or punctuation (case-insensitive)
     const regex = new RegExp(
       `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
+      "i",
     );
     if (regex.test(commentBody)) {
       console.log(`Comment contains exact trigger phrase '${triggerPhrase}'`);


### PR DESCRIPTION
## Summary
- Adds the `i` (case-insensitive) flag to all four `RegExp` constructions in `checkContainsTrigger`
- Fixes silent trigger rejection when iOS autocorrect capitalizes `@claude` to `@Claude`
- Adds 4 new test cases covering case-insensitive matching across all trigger paths (issue comments, issue body, PR body, PR review body)

## Problem
The `trigger_phrase` regex was constructed without the `i` flag, making matching case-sensitive. GitHub's workflow-level `contains()` guard is case-insensitive, so the workflow would run but the action's internal check would silently reject the trigger — a confusing UX gap.

## Changes
- `src/github/validation/trigger.ts`: Added `"i"` flag to all 4 `new RegExp()` calls
- `test/trigger-validation.test.ts`: Added `case-insensitive trigger matching` describe block with tests for `@Claude`, `@CLAUDE`, and `@cLaUdE` variants

## Test plan
- [x] All 30 trigger validation tests pass (`bun test test/trigger-validation.test.ts`)
- [x] TypeScript typecheck passes (`bun run typecheck`)
- [x] Prettier formatting passes (`bun run format:check`)

Fixes #910