### PR TITLE
fix: show error result in sanitized SDK output

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -86,7 +86,7 @@ async function createPromptConfig(
 /**
  * Sanitizes SDK output to match CLI sanitization behavior
  */
-function sanitizeSdkOutput(
+export function sanitizeSdkOutput(
   message: SDKMessage,
   showFullOutput: boolean,
 ): string | null {
@@ -120,6 +120,9 @@ function sanitizeSdkOutput(
         num_turns: resultMsg.num_turns,
         total_cost_usd: resultMsg.total_cost_usd,
         permission_denials: resultMsg.permission_denials,
+        // Include result field when there's an error so users can see what went wrong
+        ...(resultMsg.is_error &&
+          "result" in resultMsg && { result: resultMsg.result }),
       },
       null,
       2,

--- a/test/sanitize-sdk-output.test.ts
+++ b/test/sanitize-sdk-output.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "bun:test";
+import { sanitizeSdkOutput } from "../base-action/src/run-claude-sdk";
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+
+describe("sanitizeSdkOutput", () => {
+  it("should show full output when showFullOutput is true", () => {
+    const message = {
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "some sensitive result",
+      duration_ms: 100,
+      num_turns: 1,
+      total_cost_usd: 0.01,
+      permission_denials: [],
+    } as unknown as SDKMessage;
+
+    const output = sanitizeSdkOutput(message, true);
+    expect(output).toContain("some sensitive result");
+  });
+
+  it("should not include result field for successful results", () => {
+    const message = {
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "successful output that should be hidden",
+      duration_ms: 100,
+      num_turns: 1,
+      total_cost_usd: 0.01,
+      permission_denials: [],
+    } as unknown as SDKMessage;
+
+    const output = sanitizeSdkOutput(message, false);
+    const parsed = JSON.parse(output!);
+    expect(parsed.result).toBeUndefined();
+    expect(parsed.is_error).toBe(false);
+  });
+
+  it("should include result field when is_error is true", () => {
+    const message = {
+      type: "result",
+      subtype: "success",
+      is_error: true,
+      result:
+        'API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-5-20250514"}}',
+      duration_ms: 230,
+      num_turns: 1,
+      total_cost_usd: 0,
+      permission_denials: [],
+    } as unknown as SDKMessage;
+
+    const output = sanitizeSdkOutput(message, false);
+    const parsed = JSON.parse(output!);
+    expect(parsed.is_error).toBe(true);
+    expect(parsed.result).toContain("API Error: 404");
+    expect(parsed.result).toContain("not_found_error");
+  });
+
+  it("should suppress non-result non-init messages", () => {
+    const message = {
+      type: "assistant",
+      content: "some assistant content",
+    } as unknown as SDKMessage;
+
+    const output = sanitizeSdkOutput(message, false);
+    expect(output).toBeNull();
+  });
+
+  it("should show sanitized init messages", () => {
+    const message = {
+      type: "system",
+      subtype: "init",
+      model: "claude-sonnet-4-5-20250929",
+    } as unknown as SDKMessage;
+
+    const output = sanitizeSdkOutput(message, false);
+    const parsed = JSON.parse(output!);
+    expect(parsed.type).toBe("system");
+    expect(parsed.subtype).toBe("init");
+    expect(parsed.model).toBe("claude-sonnet-4-5-20250929");
+  });
+});


### PR DESCRIPTION
## Summary
- Includes the `result` field in sanitized SDK output when `is_error` is true
- Non-error results remain hidden to protect sensitive output
- Exports `sanitizeSdkOutput` for testability and adds 5 unit tests

## Problem
When a Claude SDK execution fails (e.g., invalid model ID, API errors), the `sanitizeSdkOutput` function strips the `result` field from the output. This hides the actual error message, leaving users with only an opaque "process exited with code 1" and minified code context.

Users see:
```json
{"type": "result", "is_error": true, "duration_ms": 230}
```
Instead of:
```json
{"type": "result", "is_error": true, "result": "API Error: 404 model not found", "duration_ms": 230}
```

## Changes
- `base-action/src/run-claude-sdk.ts`: Conditionally spread `result` when `is_error` is true, with `"result" in resultMsg` type guard for the `SDKResultSuccess`/`SDKResultError` union
- `test/sanitize-sdk-output.test.ts`: 5 tests covering error result inclusion, success result omission, init messages, and message suppression

## Test plan
- [x] 5/5 sanitize-sdk-output tests pass
- [x] TypeScript typecheck passes
- [x] Prettier formatting passes

Fixes #880