### PR TITLE
fix: skip token revocation when no token was acquired

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -278,7 +278,7 @@ runs:
         bun run ${GITHUB_ACTION_PATH}/src/entrypoints/cleanup-ssh-signing.ts
 
     - name: Revoke app token
-      if: always() && inputs.github_token == '' && steps.run.outputs.skipped_due_to_workflow_validation_mismatch != 'true'
+      if: always() && inputs.github_token == '' && steps.run.outputs.github_token != '' && steps.run.outputs.skipped_due_to_workflow_validation_mismatch != 'true'
       shell: bash
       run: |
         curl -L \


### PR DESCRIPTION
## Summary
- Adds `steps.run.outputs.github_token != ''` condition to the "Revoke app token" cleanup step
- Prevents confusing "Bad credentials" 401 error when the prepare phase fails before acquiring a token

## Problem
The "Revoke app token" step runs with `if: always()`, meaning it executes even when the prepare phase fails (e.g., `track_progress` used with an unsupported event type). When no token was acquired, the curl sends an empty `Authorization: Bearer ` header, producing a 401 "Bad credentials" error that confuses users debugging the actual failure.

## Changes
- `action.yml`: Added `steps.run.outputs.github_token != ''` to the existing `if` condition on the "Revoke app token" step

## Test plan
- [x] TypeScript typecheck passes
- [x] Prettier formatting passes
- When prepare fails: token output is empty -> step is skipped -> no 401 error
- When prepare succeeds: token output is populated -> step runs normally -> token revoked

Fixes #858