### PR TITLE
fix: skip dev dependencies in CI install step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_ACTION_PATH}
-        bun install
+        bun install --production
 
     - name: Run Claude Code Action
       id: run

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -116,7 +116,7 @@ runs:
       shell: bash
       run: |
         cd ${GITHUB_ACTION_PATH}
-        bun install
+        bun install --production
 
     - name: Install Claude Code
       shell: bash


### PR DESCRIPTION
## Summary
- Changes `bun install` to `bun install --production` in both `action.yml` and `base-action/action.yml`
- Skips installing devDependencies (`@types/*`, `prettier`, `typescript`) that are not needed at runtime
- Reduces installed packages from 151 to 135

## Problem
The "Install Dependencies" step runs `bun install` which installs devDependencies including `@types/bun`, `@types/node`, `@types/node-fetch`, `@types/shell-quote`, `prettier`, and `typescript`. These are only needed for development (type checking, formatting) — Bun runs TypeScript natively without them.

## Changes
- `action.yml` line 179: `bun install` -> `bun install --production`
- `base-action/action.yml` line 119: `bun install` -> `bun install --production`

## Test plan
- [x] Verified `bun install --production` installs 135 packages (vs 151 with dev)
- [x] Verified runtime imports work correctly without devDependencies
- [x] TypeScript typecheck passes
- [x] Prettier formatting passes

Fixes #895