### PR TITLE
fix: replace deprecated :* with modern * wildcard in git permissions

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -57,13 +57,13 @@ export function buildAllowedToolsString(
   } else {
     // When not using commit signing, add specific Bash git commands
     baseTools.push(
-      "Bash(git add:*)",
-      "Bash(git commit:*)",
-      "Bash(git push:*)",
-      "Bash(git status:*)",
-      "Bash(git diff:*)",
-      "Bash(git log:*)",
-      "Bash(git rm:*)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git rm *)",
     );
   }
 

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -135,13 +135,13 @@ export async function prepareTagMode({
   // SSH signing still uses git CLI, just with signing enabled
   if (!useApiCommitSigning) {
     tagModeTools.push(
-      "Bash(git add:*)",
-      "Bash(git commit:*)",
-      "Bash(git push:*)",
-      "Bash(git status:*)",
-      "Bash(git diff:*)",
-      "Bash(git log:*)",
-      "Bash(git rm:*)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(git status *)",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git rm *)",
     );
   } else {
     // When using API commit signing, use MCP file ops tools

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -894,9 +894,9 @@ describe("buildAllowedToolsString", () => {
     expect(result).toContain("Write");
 
     // Default is no commit signing, so should have specific Bash git commands
-    expect(result).toContain("Bash(git add:*)");
-    expect(result).toContain("Bash(git commit:*)");
-    expect(result).toContain("Bash(git push:*)");
+    expect(result).toContain("Bash(git add *)");
+    expect(result).toContain("Bash(git commit *)");
+    expect(result).toContain("Bash(git push *)");
     expect(result).toContain("mcp__github_comment__update_claude_comment");
 
     // Should not have commit signing tools
@@ -916,8 +916,8 @@ describe("buildAllowedToolsString", () => {
     expect(result).toContain("Write");
 
     // Should have specific Bash git commands for non-signing mode
-    expect(result).toContain("Bash(git add:*)");
-    expect(result).toContain("Bash(git commit:*)");
+    expect(result).toContain("Bash(git add *)");
+    expect(result).toContain("Bash(git commit *)");
     expect(result).toContain("mcp__github_comment__update_claude_comment");
 
     // Should not have commit signing tools
@@ -1009,13 +1009,13 @@ describe("buildAllowedToolsString", () => {
     expect(result).toContain("Write");
 
     // Specific Bash git commands should be included
-    expect(result).toContain("Bash(git add:*)");
-    expect(result).toContain("Bash(git commit:*)");
-    expect(result).toContain("Bash(git push:*)");
-    expect(result).toContain("Bash(git status:*)");
-    expect(result).toContain("Bash(git diff:*)");
-    expect(result).toContain("Bash(git log:*)");
-    expect(result).toContain("Bash(git rm:*)");
+    expect(result).toContain("Bash(git add *)");
+    expect(result).toContain("Bash(git commit *)");
+    expect(result).toContain("Bash(git push *)");
+    expect(result).toContain("Bash(git status *)");
+    expect(result).toContain("Bash(git diff *)");
+    expect(result).toContain("Bash(git log *)");
+    expect(result).toContain("Bash(git rm *)");
 
     // Comment tool from minimal server should be included
     expect(result).toContain("mcp__github_comment__update_claude_comment");
@@ -1031,7 +1031,7 @@ describe("buildAllowedToolsString", () => {
 
     // Base tools should be present
     expect(result).toContain("Edit");
-    expect(result).toContain("Bash(git add:*)");
+    expect(result).toContain("Bash(git add *)");
 
     // Custom tools should be included
     expect(result).toContain("CustomTool1");


### PR DESCRIPTION
## Summary

Replace deprecated `Bash(git add:*)` colon-prefixed wildcard syntax with the modern `Bash(git add *)` space-separated syntax in default git tool permissions. The old syntax causes SDK validation errors when triggering the action via `@claude`.

Closes #856

## Changes

- `src/modes/tag/index.ts` — 7 permission strings updated
- `src/create-prompt/index.ts` — 7 permission strings updated
- `test/create-prompt.test.ts` — test assertions updated to match

The `base-action/test/parse-sdk-options.test.ts` was intentionally left unchanged as it tests parsing of user-provided `claude_args` input (backwards compatibility).

## Test plan

- [x] `bun test test/create-prompt.test.ts` — 40/40 pass
- [x] Full test suite — all pre-existing passes still pass (20 failures are pre-existing Windows symlink/path issues)
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)