### PR TITLE
chore: bump claude code to 2.1.39 in entry point

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -51,7 +51,7 @@ async function installClaudeCode(): Promise<void> {
     return;
   }
 
-  const claudeCodeVersion = "2.1.31";
+  const claudeCodeVersion = "2.1.39";
   console.log(`Installing Claude Code v${claudeCodeVersion}...`);
 
   for (let attempt = 1; attempt <= 3; attempt++) {


### PR DESCRIPTION
this PR bump claude code in entry point.
I believe this is needed to fix  ability to claude code in github action , when run without custom prompt, to be able to commit