### PR TITLE
Disable auto-approval of project MCP servers when .mcp.json changes in PR

### DIFF
--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -13,7 +13,7 @@ async function run() {
 
     await setupClaudeCodeSettings(
       process.env.INPUT_SETTINGS,
-      undefined, // homeDir
+      false, // mcpJsonChanged — standalone base-action has no PR context to check
     );
 
     // Install Claude Code plugins if specified

--- a/base-action/src/setup-claude-code-settings.ts
+++ b/base-action/src/setup-claude-code-settings.ts
@@ -4,6 +4,7 @@ import { readFile } from "fs/promises";
 
 export async function setupClaudeCodeSettings(
   settingsInput?: string,
+  mcpJsonChanged = false,
   homeDir?: string,
 ) {
   const home = homeDir ?? homedir();
@@ -59,9 +60,16 @@ export async function setupClaudeCodeSettings(
     console.log(`Merged settings with input settings`);
   }
 
-  // Always set enableAllProjectMcpServers to true
-  settings.enableAllProjectMcpServers = true;
-  console.log(`Updated settings with enableAllProjectMcpServers: true`);
+  if (!mcpJsonChanged) {
+    // Only auto-approve project MCP servers if .mcp.json hasn't changed in this PR.
+    // If .mcp.json changed, the checked-out version may differ from the base branch.
+    settings.enableAllProjectMcpServers = true;
+    console.log(`Updated settings with enableAllProjectMcpServers: true`);
+  } else {
+    console.log(
+      `Skipping enableAllProjectMcpServers=true because .mcp.json changed in this PR`,
+    );
+  }
 
   await $`echo ${JSON.stringify(settings, null, 2)} > ${settingsPath}`.quiet();
   console.log(`Settings saved successfully`);

--- a/base-action/src/setup-claude-code-settings.ts
+++ b/base-action/src/setup-claude-code-settings.ts
@@ -66,8 +66,11 @@ export async function setupClaudeCodeSettings(
     settings.enableAllProjectMcpServers = true;
     console.log(`Updated settings with enableAllProjectMcpServers: true`);
   } else {
+    // .mcp.json is untrusted in this PR — strip any enableAllProjectMcpServers
+    // that came from user input so the protection cannot be bypassed.
+    delete settings.enableAllProjectMcpServers;
     console.log(
-      `Skipping enableAllProjectMcpServers=true because .mcp.json changed in this PR`,
+      `Removing enableAllProjectMcpServers because .mcp.json changed in this PR`,
     );
   }
 

--- a/base-action/test/setup-claude-code-settings.test.ts
+++ b/base-action/test/setup-claude-code-settings.test.ts
@@ -108,7 +108,7 @@ describe("setupClaudeCodeSettings", () => {
     expect(settings.model).toBe("test-model");
   });
 
-  test("should not override enableAllProjectMcpServers when mcpJsonChanged is true and input sets it false", async () => {
+  test("should remove enableAllProjectMcpServers when mcpJsonChanged is true and input sets it false", async () => {
     const inputSettings = JSON.stringify({
       enableAllProjectMcpServers: false,
       model: "test-model",
@@ -119,7 +119,22 @@ describe("setupClaudeCodeSettings", () => {
     const settingsContent = await readFile(settingsPath, "utf-8");
     const settings = JSON.parse(settingsContent);
 
-    expect(settings.enableAllProjectMcpServers).toBe(false);
+    expect(settings.enableAllProjectMcpServers).toBeUndefined();
+    expect(settings.model).toBe("test-model");
+  });
+
+  test("should remove enableAllProjectMcpServers when mcpJsonChanged is true even if input sets it true", async () => {
+    const inputSettings = JSON.stringify({
+      enableAllProjectMcpServers: true,
+      model: "test-model",
+    });
+
+    await setupClaudeCodeSettings(inputSettings, true, testHomeDir);
+
+    const settingsContent = await readFile(settingsPath, "utf-8");
+    const settings = JSON.parse(settingsContent);
+
+    expect(settings.enableAllProjectMcpServers).toBeUndefined();
     expect(settings.model).toBe("test-model");
   });
 

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -217,7 +217,35 @@ async function run() {
 
     validateEnvironmentVariables();
 
-    await setupClaudeCodeSettings(process.env.INPUT_SETTINGS);
+    // Check if .mcp.json changed in this PR to guard against RCE via malicious MCP servers.
+    // If .mcp.json was modified, skip auto-approving project MCP servers so attacker-injected
+    // servers are not trusted automatically.
+    let mcpJsonChanged = false;
+    if (isEntityContext(context) && context.isPR) {
+      try {
+        const { data: changedFiles } = await octokit.rest.pulls.listFiles({
+          owner: context.repository.owner,
+          repo: context.repository.repo,
+          pull_number: context.entityNumber,
+          per_page: 100,
+        });
+        mcpJsonChanged = changedFiles.some(
+          (f) =>
+            f.filename === ".mcp.json" || f.filename.endsWith("/.mcp.json"),
+        );
+        if (mcpJsonChanged) {
+          console.log(
+            ".mcp.json changed in this PR — disabling auto-approval of project MCP servers",
+          );
+        }
+      } catch (e) {
+        console.log(
+          `Could not check PR changed files: ${e}. Defaulting to mcpJsonChanged=false.`,
+        );
+      }
+    }
+
+    await setupClaudeCodeSettings(process.env.INPUT_SETTINGS, mcpJsonChanged);
 
     await installPlugins(
       process.env.INPUT_PLUGIN_MARKETPLACES,

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -223,12 +223,15 @@ async function run() {
     let mcpJsonChanged = false;
     if (isEntityContext(context) && context.isPR) {
       try {
-        const { data: changedFiles } = await octokit.rest.pulls.listFiles({
-          owner: context.repository.owner,
-          repo: context.repository.repo,
-          pull_number: context.entityNumber,
-          per_page: 100,
-        });
+        const changedFiles = await octokit.rest.paginate(
+          octokit.rest.pulls.listFiles,
+          {
+            owner: context.repository.owner,
+            repo: context.repository.repo,
+            pull_number: context.entityNumber,
+            per_page: 100,
+          },
+        );
         mcpJsonChanged = changedFiles.some(
           (f) =>
             f.filename === ".mcp.json" || f.filename.endsWith("/.mcp.json"),
@@ -240,8 +243,9 @@ async function run() {
         }
       } catch (e) {
         console.log(
-          `Could not check PR changed files: ${e}. Defaulting to mcpJsonChanged=false.`,
+          `Could not check PR changed files: ${e}. Defaulting to mcpJsonChanged=true (fail-closed).`,
         );
+        mcpJsonChanged = true;
       }
     }
 


### PR DESCRIPTION
## What and why

When a PR modifies `.mcp.json`, the checked-out working directory contains a version that may differ from the base branch. The current code unconditionally sets `enableAllProjectMcpServers = true` in `setupClaudeCodeSettings`, which auto-approves all project MCP servers — including those introduced in the PR's `.mcp.json` — without the user having reviewed them.

This PR makes auto-approval conditional: if `.mcp.json` changed in the triggering PR, we skip setting `enableAllProjectMcpServers = true` so those servers are not automatically trusted.

## Changes

### `base-action/src/setup-claude-code-settings.ts`

Added a `mcpJsonChanged` boolean parameter (default `false`). The `enableAllProjectMcpServers = true` assignment now only runs when `mcpJsonChanged` is false. When it's true, a log message is emitted instead. All existing behaviour is preserved for non-PR events and for PRs that don't touch `.mcp.json`.

### `src/entrypoints/run.ts`

Before calling `setupClaudeCodeSettings`, use `octokit.rest.pulls.listFiles` to fetch the files changed in the PR (when the event is a PR-type event). If any changed file is `.mcp.json` or ends with `/.mcp.json`, pass `mcpJsonChanged=true`. Errors from the API call are caught and logged; on any failure the flag stays `false` (safe default).

### `base-action/test/setup-claude-code-settings.test.ts`

- Updated all existing test calls to pass `false` for `mcpJsonChanged` (no behaviour change)
- Renamed the override test to clarify it applies when `mcpJsonChanged=false`
- Added two new tests for `mcpJsonChanged=true`: one verifying `enableAllProjectMcpServers` stays `undefined` when not set in input, one verifying it stays `false` when the input sets it to `false`