### PR TITLE
fix: replace deprecated `:*` Bash tool pattern syntax with space wildcard

### DIFF
--- a/.claude/commands/label-issue.md
+++ b/.claude/commands/label-issue.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh search:*)
+allowed-tools: Bash(gh label list *),Bash(gh issue view *),Bash(gh issue edit *),Bash(gh search *)
 description: Apply labels to GitHub issues
 ---
 
@@ -21,10 +21,10 @@ TASK OVERVIEW:
    - Use `gh issue view ${{ github.event.issue.number }}` to retrieve the current issue's details
    - Use `gh search issues` to find similar issues that might provide context for proper categorization
    - You have access to these Bash commands:
-     - Bash(gh label list:\*) - to get available labels
-     - Bash(gh issue view:\*) - to view issue details
-     - Bash(gh issue edit:\*) - to apply labels to the issue
-     - Bash(gh search:\*) - to search for similar issues
+     - Bash(gh label list \*) - to get available labels
+     - Bash(gh issue view \*) - to view issue details
+     - Bash(gh issue edit \*) - to apply labels to the issue
+     - Bash(gh search \*) - to search for similar issues
 
 3. Analyze the issue content, considering:
 

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)
+allowed-tools: Bash(gh pr comment *),Bash(gh pr diff *),Bash(gh pr view *)
 description: Review a pull request
 ---
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,5 +35,5 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --allowedTools "Bash(bun install),Bash(bun test:*),Bash(bun run format),Bash(bun typecheck)"
+            --allowedTools "Bash(bun install),Bash(bun test *),Bash(bun run format),Bash(bun typecheck)"
             --model "claude-opus-4-6"

--- a/.github/workflows/test-settings.yml
+++ b/.github/workflows/test-settings.yml
@@ -21,7 +21,7 @@ jobs:
           settings: |
             {
               "permissions": {
-                "allow": ["Bash(echo:*)"]
+                "allow": ["Bash(echo *)"]
               }
             }
 
@@ -70,7 +70,7 @@ jobs:
           settings: |
             {
               "permissions": {
-                "deny": ["Bash(echo:*)"]
+                "deny": ["Bash(echo *)"]
               }
             }
 
@@ -97,7 +97,7 @@ jobs:
           cat > test-settings.json << EOF
           {
             "permissions": {
-              "allow": ["Bash(echo:*)"]
+              "allow": ["Bash(echo *)"]
             }
           }
           EOF
@@ -151,7 +151,7 @@ jobs:
           cat > test-settings.json << EOF
           {
             "permissions": {
-              "deny": ["Bash(echo:*)"]
+              "deny": ["Bash(echo *)"]
             }
           }
           EOF

--- a/base-action/README.md
+++ b/base-action/README.md
@@ -14,7 +14,7 @@ Add the following to your workflow file:
   uses: anthropics/claude-code-base-action@beta
   with:
     prompt: "Your prompt here"
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
 # Or using a prompt from a file
@@ -22,7 +22,7 @@ Add the following to your workflow file:
   uses: anthropics/claude-code-base-action@beta
   with:
     prompt_file: "/path/to/prompt.txt"
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
 # Or limiting the conversation turns
@@ -30,7 +30,7 @@ Add the following to your workflow file:
   uses: anthropics/claude-code-base-action@beta
   with:
     prompt: "Your prompt here"
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     max_turns: "5" # Limit conversation to 5 turns
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -40,7 +40,7 @@ Add the following to your workflow file:
   with:
     prompt: "Build a REST API"
     system_prompt: "You are a senior backend engineer. Focus on security, performance, and maintainability."
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
 # Or appending to the default system prompt
@@ -49,7 +49,7 @@ Add the following to your workflow file:
   with:
     prompt: "Create a database schema"
     append_system_prompt: "After writing code, be sure to code review yourself."
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
 # Using custom environment variables
@@ -61,7 +61,7 @@ Add the following to your workflow file:
       ENVIRONMENT: staging
       API_URL: https://api-staging.example.com
       DEBUG: true
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
 # Using fallback model for handling API errors
@@ -71,7 +71,7 @@ Add the following to your workflow file:
     prompt: "Review and fix TypeScript errors"
     model: "claude-opus-4-1-20250805"
     fallback_model: "claude-sonnet-4-20250514"
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
 # Using OAuth token instead of API key
@@ -79,7 +79,7 @@ Add the following to your workflow file:
   uses: anthropics/claude-code-base-action@beta
   with:
     prompt: "Update dependencies"
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
 
@@ -155,7 +155,7 @@ The `claude_env` input accepts YAML multiline format with key-value pairs:
       DATABASE_URL: ${{ secrets.STAGING_DB_URL }}
       DEBUG: true
       LOG_LEVEL: debug
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
@@ -204,7 +204,7 @@ Provide a path to a JSON file containing Claude Code settings:
   with:
     prompt: "Your prompt here"
     settings: "path/to/settings.json"
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
@@ -238,7 +238,7 @@ Provide the settings configuration directly as a JSON string:
           }]
         }
       }
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
@@ -267,7 +267,7 @@ Provide a path to a JSON file containing MCP configuration:
   with:
     prompt: "Your prompt here"
     mcp_config: "path/to/mcp-config.json"
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
@@ -292,7 +292,7 @@ Provide the MCP configuration directly as a JSON string:
           }
         }
       }
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
@@ -321,7 +321,7 @@ You can combine MCP config with other inputs like allowed tools:
   with:
     prompt: "Access the custom MCP server and use its tools"
     mcp_config: "mcp-config.json"
-    allowed_tools: "Bash(git:*),View,mcp__server-name__custom_tool"
+    allowed_tools: "Bash(git *),View,mcp__server-name__custom_tool"
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 ```
 
@@ -460,7 +460,7 @@ This example shows how to use OIDC authentication with AWS Bedrock:
     prompt: "Your prompt here"
     use_bedrock: "true"
     model: "anthropic.claude-3-7-sonnet-20250219-v1:0"
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
 ```
 
 ## Example: Using OIDC Authentication for GCP Vertex AI
@@ -480,7 +480,7 @@ This example shows how to use OIDC authentication with GCP Vertex AI:
     prompt: "Your prompt here"
     use_vertex: "true"
     model: "claude-3-7-sonnet@20250219"
-    allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+    allowed_tools: "Bash(git *),View,GlobTool,GrepTool,BatchTool"
 ```
 
 ## Security Best Practices

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -124,16 +124,16 @@ describe("parseSdkOptions", () => {
       // This is the exact scenario from issue #746
       const options: ClaudeOptions = {
         claudeArgs:
-          '--allowed-tools "Bash(git log:*)" "Bash(git diff:*)" "Bash(git fetch:*)" "Bash(gh pr:*)"',
+          '--allowed-tools "Bash(git log *)" "Bash(git diff *)" "Bash(git fetch *)" "Bash(gh pr *)"',
       };
 
       const result = parseSdkOptions(options);
 
       expect(result.sdkOptions.allowedTools).toEqual([
-        "Bash(git log:*)",
-        "Bash(git diff:*)",
-        "Bash(git fetch:*)",
-        "Bash(gh pr:*)",
+        "Bash(git log *)",
+        "Bash(git diff *)",
+        "Bash(git fetch *)",
+        "Bash(gh pr *)",
       ]);
     });
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -72,7 +72,7 @@ You can grant additional tools via the `claude_args` input if needed:
 
 ```yaml
 claude_args: |
-  --allowedTools "Bash(git rebase:*)"  # Use with caution
+  --allowedTools "Bash(git rebase *)"  # Use with caution
 ```
 
 ### Why won't Claude create a pull request?
@@ -177,7 +177,7 @@ The Bash tool is **disabled by default** for security. To enable individual bash
 
 ```yaml
 claude_args: |
-  --allowedTools "Bash(npm:*),Bash(git:*)"  # Allows only npm and git commands
+  --allowedTools "Bash(npm *),Bash(git *)"  # Allows only npm and git commands
 ```
 
 ### Can Claude work across multiple repositories?

--- a/docs/solutions.md
+++ b/docs/solutions.md
@@ -59,7 +59,7 @@ jobs:
             Only post GitHub comments - don't submit review text as messages.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *),Bash(gh pr diff *),Bash(gh pr view *)"
 ```
 
 **Key Configuration:**
@@ -110,7 +110,7 @@ jobs:
             Provide detailed feedback using inline comments for specific issues.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *),Bash(gh pr diff *),Bash(gh pr view *)"
 ```
 
 **Benefits of Progress Tracking:**
@@ -177,7 +177,7 @@ jobs:
             Post detailed security findings as PR comments.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *)"
 ```
 
 **Key Configuration:**
@@ -235,7 +235,7 @@ jobs:
             Be welcoming but thorough in your review. Use inline comments for code-specific feedback.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *),Bash(gh pr view *)"
 ```
 
 **Key Configuration:**
@@ -309,7 +309,7 @@ jobs:
             Post a summary comment with checklist results.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *)"
 ```
 
 **Key Configuration:**
@@ -366,7 +366,7 @@ jobs:
             If critical security issues are found, also comment on open PRs.
 
           claude_args: |
-            --allowedTools "Read,Bash(npm:*),Bash(gh issue:*),Bash(git:*)"
+            --allowedTools "Read,Bash(npm *),Bash(gh issue *),Bash(git *)"
 ```
 
 **Key Configuration:**
@@ -420,7 +420,7 @@ jobs:
             If it appears to be a duplicate, post a comment mentioning the original issue.
 
           claude_args: |
-            --allowedTools "Bash(gh issue:*),Bash(gh search:*)"
+            --allowedTools "Bash(gh issue *),Bash(gh search *)"
 ```
 
 **Key Configuration:**
@@ -479,7 +479,7 @@ jobs:
             Commit any documentation updates to this PR branch.
 
           claude_args: |
-            --allowedTools "Read,Write,Edit,Bash(git:*)"
+            --allowedTools "Read,Write,Edit,Bash(git *)"
 ```
 
 **Key Configuration:**
@@ -551,7 +551,7 @@ jobs:
             Post detailed findings with recommendations.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *),Bash(gh pr diff *)"
 ```
 
 **Key Configuration:**
@@ -577,10 +577,10 @@ prompt: |
 
 ### Common Tool Permissions
 
-- **PR Comments**: `Bash(gh pr comment:*)`
+- **PR Comments**: `Bash(gh pr comment *)`
 - **Inline Comments**: `mcp__github_inline_comment__create_inline_comment`
 - **File Operations**: `Read,Write,Edit`
-- **Git Operations**: `Bash(git:*)`
+- **Git Operations**: `Bash(git *)`
 
 ### Best Practices
 

--- a/examples/ci-failure-auto-fix.yml
+++ b/examples/ci-failure-auto-fix.yml
@@ -94,4 +94,4 @@ jobs:
             Error logs:
             ${{ toJSON(fromJSON(steps.failure_details.outputs.result).errorLogs) }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(bun:*),Bash(npm:*),Bash(npx:*),Bash(gh:*)'"
+          claude_args: "--allowedTools 'Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git *),Bash(bun *),Bash(npm *),Bash(npx *),Bash(gh *)'"

--- a/examples/claude.yml
+++ b/examples/claude.yml
@@ -46,7 +46,7 @@ jobs:
           # claude_args: |
           #   --model claude-opus-4-1-20250805
           #   --max-turns 10
-          #   --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          #   --allowedTools "Bash(npm install),Bash(npm run build),Bash(npm run test *),Bash(npm run lint *)"
           #   --system-prompt "Follow our coding standards. Ensure all new code has tests. Use TypeScript for new files."
 
           # Optional: Advanced settings configuration

--- a/examples/pr-review-comprehensive.yml
+++ b/examples/pr-review-comprehensive.yml
@@ -65,7 +65,7 @@ jobs:
 
           # Tools for comprehensive PR review
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *),Bash(gh pr diff *),Bash(gh pr view *)"
 
 # When track_progress is enabled:
 # - Creates a tracking comment with progress checkboxes

--- a/examples/pr-review-filtered-authors.yml
+++ b/examples/pr-review-filtered-authors.yml
@@ -45,4 +45,4 @@ jobs:
             Provide detailed feedback and suggestions for improvement.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *), Bash(gh pr diff *), Bash(gh pr view *)"

--- a/examples/pr-review-filtered-paths.yml
+++ b/examples/pr-review-filtered-paths.yml
@@ -46,4 +46,4 @@ jobs:
             in your review and provide inline comments where appropriate.
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment *), Bash(gh pr diff *), Bash(gh pr view *)"


### PR DESCRIPTION
## Summary

- Replace all deprecated `Bash(cmd:*)` patterns with the current `Bash(cmd *)` syntax across docs, examples, workflows, skill commands, and tests
- The core runtime code in `src/` was already fixed in #856, but these peripheral files were missed

## Context

The [official Claude Code permissions documentation](https://code.claude.com/docs/en/permissions) states:

> The legacy `:*` suffix syntax is equivalent to ` *` but is deprecated.

This repository still contained ~40 occurrences of the deprecated `:*` syntax in documentation, examples, workflow files, skill commands, and test fixtures — which can mislead users into adopting a pattern that may stop working in the future.

## Changes

| Location | Files | Description |
|----------|-------|-------------|
| `docs/` | `solutions.md`, `faq.md` | Updated all `Bash(cmd:*)` examples |
| `base-action/` | `README.md` | Updated ~17 occurrences of `Bash(git:*)` |
| `examples/` | 5 workflow files | Updated example workflows |
| `.github/workflows/` | `claude.yml`, `test-settings.yml` | Updated CI workflows |
| `.claude/commands/` | `label-issue.md`, `review-pr.md` | Updated skill command frontmatter |
| `base-action/test/` | `parse-sdk-options.test.ts` | Updated test fixtures |
