### PR TITLE
feat: add display_report option to disable step summary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -121,6 +121,10 @@ inputs:
     description: "Optional path to a custom Bun executable. If provided, skips automatic Bun installation and uses this executable instead. WARNING: Using an incompatible version may cause problems if the action requires specific Bun features. This input is typically not needed unless you're debugging something specific or have unique needs in your environment."
     required: false
     default: ""
+  display_report:
+    description: "Whether to display the Claude Code Report in GitHub Step Summary. Set to 'false' to disable when using custom formatting solutions."
+    required: false
+    default: "true"
   show_full_output:
     description: "Show full JSON output from Claude Code. WARNING: This outputs ALL Claude messages including tool execution results which may contain secrets, API keys, or other sensitive information. These logs are publicly visible in GitHub Actions. Only enable for debugging in non-sensitive environments."
     required: false
@@ -218,6 +222,7 @@ runs:
         INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        DISPLAY_REPORT: ${{ inputs.display_report }}
         INPUT_PLUGINS: ${{ inputs.plugins }}
         INPUT_PLUGIN_MARKETPLACES: ${{ inputs.plugin_marketplaces }}
         PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -295,8 +295,12 @@ async function run() {
       }
     }
 
-    // Write step summary
-    if (executionFile && existsSync(executionFile)) {
+    // Write step summary (unless display_report is set to false)
+    if (
+      executionFile &&
+      existsSync(executionFile) &&
+      process.env.DISPLAY_REPORT !== "false"
+    ) {
       await writeStepSummary(executionFile);
     }
 


### PR DESCRIPTION
Add a `display_report` input parameter (default: "true") that controls whether the Claude Code Report is written to the GitHub Step Summary. Setting it to "false" allows users with custom formatting solutions to avoid duplicate output.

Closes #206

Generated with [Claude Code](https://claude.ai/code)