### PR TITLE
fix: allow # character in branch name validation

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -28,7 +28,7 @@ function extractFirstLabel(githubData: FetchDataResult): string | undefined {
  *
  * Valid branch names:
  * - Start with alphanumeric character (not dash, to prevent option injection)
- * - Contain only alphanumeric, forward slash, hyphen, underscore, or period
+ * - Contain only alphanumeric, forward slash, hyphen, underscore, period, or hash (#)
  * - Do not start or end with a period
  * - Do not end with a slash
  * - Do not contain '..' (path traversal)
@@ -58,12 +58,14 @@ export function validateBranchName(branchName: string): void {
     );
   }
 
-  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/period
-  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$/;
+  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/period/hash
+  // The # character is valid per git-check-ref-format and is safe with execFileSync
+  // (no shell interpolation). Common in branch naming conventions like "bugfix/#123-desc".
+  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_.\-#]*$/;
 
   if (!validPattern.test(branchName)) {
     throw new Error(
-      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, or periods.`,
+      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, periods, or hash (#).`,
     );
   }
 

--- a/test/validate-branch-name.test.ts
+++ b/test/validate-branch-name.test.ts
@@ -29,6 +29,14 @@ describe("validateBranchName", () => {
       expect(() => validateBranchName("release.1.2.3")).not.toThrow();
     });
 
+    it("should accept names with hash characters", () => {
+      expect(() => validateBranchName("bugfix/#123-fix-bug")).not.toThrow();
+      expect(() => validateBranchName("feature/#456-new-feature")).not.toThrow();
+      expect(() =>
+        validateBranchName("design/#789-update-layout"),
+      ).not.toThrow();
+    });
+
     it("should accept typical branch name formats", () => {
       expect(() =>
         validateBranchName("claude/issue-123-20250101-1234"),


### PR DESCRIPTION
## Summary

- Adds `#` to the branch name validation whitelist regex in `validateBranchName()`
- The `#` character is valid per [git-check-ref-format](https://git-scm.com/docs/git-check-ref-format) and commonly used in branch naming conventions like `bugfix/#123-description`
- Since PR #736 switched git commands to `execFileSync` (no shell interpolation), `#` poses no injection risk — it's only meaningful in shell contexts (as a comment character)
- Adds test cases for branch names containing `#`

Fixes #751
