### PR TITLE
fix: use word-boundary lookaround for trigger phrase regex

### DIFF
--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -48,10 +48,11 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
   if (isIssuesEvent(context) && context.eventAction === "opened") {
     const issueBody = context.payload.issue.body || "";
     const issueTitle = context.payload.issue.title || "";
-    // Check for exact match with word boundaries or punctuation
-    const regex = new RegExp(
-      `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
-    );
+    // Match trigger phrase at word boundaries using lookaround.
+    // Negative lookbehind/lookahead for word characters (\w) ensures the
+    // phrase isn't embedded inside another word (e.g. "email@claude.com")
+    // while still matching after punctuation like (, ", >, : etc.
+    const regex = new RegExp(`(?<!\\w)${escapeRegExp(triggerPhrase)}(?!\\w)`);
 
     // Check in body
     if (regex.test(issueBody)) {
@@ -74,10 +75,7 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
   if (isPullRequestEvent(context)) {
     const prBody = context.payload.pull_request.body || "";
     const prTitle = context.payload.pull_request.title || "";
-    // Check for exact match with word boundaries or punctuation
-    const regex = new RegExp(
-      `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
-    );
+    const regex = new RegExp(`(?<!\\w)${escapeRegExp(triggerPhrase)}(?!\\w)`);
 
     // Check in body
     if (regex.test(prBody)) {
@@ -102,10 +100,7 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     (context.eventAction === "submitted" || context.eventAction === "edited")
   ) {
     const reviewBody = context.payload.review.body || "";
-    // Check for exact match with word boundaries or punctuation
-    const regex = new RegExp(
-      `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
-    );
+    const regex = new RegExp(`(?<!\\w)${escapeRegExp(triggerPhrase)}(?!\\w)`);
     if (regex.test(reviewBody)) {
       console.log(
         `Pull request review contains exact trigger phrase '${triggerPhrase}'`,
@@ -122,10 +117,7 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     const commentBody = isIssueCommentEvent(context)
       ? context.payload.comment.body
       : context.payload.comment.body;
-    // Check for exact match with word boundaries or punctuation
-    const regex = new RegExp(
-      `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
-    );
+    const regex = new RegExp(`(?<!\\w)${escapeRegExp(triggerPhrase)}(?!\\w)`);
     if (regex.test(commentBody)) {
       console.log(`Comment contains exact trigger phrase '${triggerPhrase}'`);
       return true;


### PR DESCRIPTION
## Summary
- Replaces the `(^|\s)...([\s.,!?;:]|$)` trigger phrase regex with `(?<!\w)...(?!\w)` negative lookaround
- Patterns like `(@claude)`, `"@claude"`, `>@claude`, and `cc:@claude` now correctly trigger instead of being silently rejected
- Keeps existing protections against false positives inside words (e.g. `email@claude.com` still rejected)

## Problem
The leading boundary `(^|\s)` only matched start-of-string or whitespace. Common patterns where the trigger phrase follows punctuation like `(`, `"`, `>`, or `:` were silently rejected — the GitHub workflow ran (because `contains()` is looser) but the action logged "No trigger was met" and exited with code 0.

The trailing boundary `([\s.,!?;:]|$)` had the same issue — `(@claude)` failed on both sides since neither `(` nor `)` were in the allowed character sets.

## Fix
Replaced both boundary groups with negative lookaround for word characters (`\w` = `[a-zA-Z0-9_]`):

```typescript
// Before:
`(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`

// After:
`(?<!\\w)${escapeRegExp(triggerPhrase)}(?!\\w)`
```

This matches the trigger phrase as long as it isn't embedded inside a word. Any non-word character (or start/end of string) is a valid boundary.

## Test plan
- [x] Added 8 new test cases covering all patterns from #941 (`(@claude)`, `"@claude"`, `>@claude`, `cc:@claude`, etc.)
- [x] Added negative test for underscore boundary (`test_@claude_test` → rejected)
- [x] All 653 existing tests pass
- [x] TypeScript typecheck passes (`bun run typecheck`)
- [x] Prettier format check passes (`bun run format:check`)

Fixes #941