### PR TITLE
fix: handle fork PRs by fetching via refs/pull/N/head

### DIFF
--- a/src/github/api/queries/github.ts
+++ b/src/github/api/queries/github.ts
@@ -12,6 +12,13 @@ export const PR_QUERY = `
         baseRefName
         headRefName
         headRefOid
+        isCrossRepository
+        headRepository {
+          owner {
+            login
+          }
+          name
+        }
         createdAt
         updatedAt
         lastEditedAt

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -164,9 +164,23 @@ export async function setupBranch(
       // Validate branch names before use to prevent command injection
       validateBranchName(branchName);
 
-      // Execute git commands to checkout PR branch (dynamic depth based on PR size)
-      // Using execFileSync instead of shell template literals for security
-      execGit(["fetch", "origin", `--depth=${fetchDepth}`, branchName]);
+      // For cross-repository (fork) PRs, fetch via the pull ref since the
+      // branch only exists on the fork's remote, not on origin.
+      if (prData.isCrossRepository) {
+        console.log(
+          `PR #${entityNumber} is from a fork, fetching via refs/pull/${entityNumber}/head...`,
+        );
+        execGit([
+          "fetch",
+          "origin",
+          `--depth=${fetchDepth}`,
+          `pull/${entityNumber}/head:${branchName}`,
+        ]);
+      } else {
+        // Execute git commands to checkout PR branch (dynamic depth based on PR size)
+        // Using execFileSync instead of shell template literals for security
+        execGit(["fetch", "origin", `--depth=${fetchDepth}`, branchName]);
+      }
       execGit(["checkout", branchName, "--"]);
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -57,6 +57,13 @@ export type GitHubPullRequest = {
   baseRefName: string;
   headRefName: string;
   headRefOid: string;
+  isCrossRepository: boolean;
+  headRepository: {
+    owner: {
+      login: string;
+    };
+    name: string;
+  } | null;
   createdAt: string;
   updatedAt?: string;
   lastEditedAt?: string;

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -23,6 +23,8 @@ describe("generatePrompt", () => {
       baseRefName: "main",
       headRefName: "feature-branch",
       headRefOid: "abc123",
+      isCrossRepository: false,
+      headRepository: { owner: { login: "testowner" }, name: "testrepo" },
       commits: {
         totalCount: 2,
         nodes: [

--- a/test/data-fetcher.test.ts
+++ b/test/data-fetcher.test.ts
@@ -1006,6 +1006,8 @@ describe("fetchGitHubData integration with time filtering", () => {
             baseRefName: "main",
             headRefName: "feature",
             headRefOid: "abc123",
+            isCrossRepository: false,
+            headRepository: { owner: { login: "testowner" }, name: "testrepo" },
             createdAt: "2024-01-15T10:00:00Z",
             updatedAt: "2024-01-15T12:30:00Z", // Edited after trigger
             lastEditedAt: "2024-01-15T12:30:00Z", // Edited after trigger

--- a/test/data-formatter.test.ts
+++ b/test/data-formatter.test.ts
@@ -24,6 +24,8 @@ describe("formatContext", () => {
       baseRefName: "main",
       headRefName: "feature/test",
       headRefOid: "abc123",
+      isCrossRepository: false,
+      headRepository: { owner: { login: "testowner" }, name: "testrepo" },
       createdAt: "2023-01-01T00:00:00Z",
       additions: 50,
       deletions: 30,

--- a/test/pull-request-target.test.ts
+++ b/test/pull-request-target.test.ts
@@ -17,6 +17,8 @@ describe("pull_request_target event support", () => {
       baseRefName: "main",
       headRefName: "feature-branch",
       headRefOid: "abc123",
+      isCrossRepository: false,
+      headRepository: { owner: { login: "testowner" }, name: "testrepo" },
       commits: {
         totalCount: 2,
         nodes: [


### PR DESCRIPTION
## Summary

Fixes #962.

When `claude-code-action` is triggered via `@claude` on a pull request from a fork, the action fails with:

```
fatal: couldn't find remote ref feat/add-archive-timestamp
```

This happens because `git fetch origin <branch>` is used, but the branch only exists on the fork's remote.

## Fix

Detect cross-repository PRs using the `isCrossRepository` GraphQL field and fetch via `pull/<number>/head:<branch>` refspec — the standard GitHub mechanism for accessing fork PR branches.

## Changes

- **GraphQL query**: Add `isCrossRepository` and `headRepository` fields to `PR_QUERY`
- **Types**: Add corresponding fields to `GitHubPullRequest`
- **Branch checkout**: Use `pull/N/head` refspec for fork PRs, keeping the existing `fetch origin <branch>` path for same-repo PRs
- **Tests**: Update all PR test fixtures with the new fields

## Testing

- All 652 existing tests pass
- TypeScript typecheck passes
- The fix is minimal and only changes the fetch strategy for cross-repo PRs