### PR TITLE
fix(examples): add concurrency groups to PR review workflows

### DIFF
--- a/docs/solutions.md
+++ b/docs/solutions.md
@@ -27,6 +27,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
     runs-on: ubuntu-latest
@@ -80,6 +84,10 @@ name: Claude Auto Review with Tracking
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   review:
@@ -145,6 +153,10 @@ on:
       - "src/api/**"
       - "config/security.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   security-review:
     runs-on: ubuntu-latest
@@ -201,6 +213,10 @@ name: External Contributor Review
 on:
   pull_request:
     types: [opened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   external-review:
@@ -259,6 +275,10 @@ name: PR Review Checklist
 on:
   pull_request:
     types: [opened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   checklist-review:
@@ -448,6 +468,10 @@ on:
       - "src/api/**/*.ts"
       - "src/routes/**/*.ts"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   doc-sync:
     runs-on: ubuntu-latest
@@ -503,6 +527,10 @@ name: Security Review
 on:
   pull_request:
     types: [opened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   security:
@@ -589,3 +617,4 @@ prompt: |
 - Set clear success criteria
 - Provide context about the repository
 - Use inline comments for code-specific feedback
+- **Always add a `concurrency` group** for PR-triggered workflows — without it, every push to a PR starts a new review job without cancelling the previous one, causing a pile-up that exhausts your API token and leaves jobs hanging indefinitely

--- a/examples/pr-review-comprehensive.yml
+++ b/examples/pr-review-comprehensive.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   review-with-tracking:
     runs-on: ubuntu-latest

--- a/examples/pr-review-filtered-authors.yml
+++ b/examples/pr-review-filtered-authors.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   review-by-author:
     # Only run for PRs from specific authors

--- a/examples/pr-review-filtered-paths.yml
+++ b/examples/pr-review-filtered-paths.yml
@@ -10,6 +10,10 @@ on:
       - "api/**/*.py"
       # You can add more specific patterns as needed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review-paths:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Every PR review example in this repo is missing a `concurrency` group. Without it, every push to an open PR starts a new review job without cancelling the previous one.

On an active branch this causes a pile-up of concurrent jobs that all share the same API token. This leads to rate limiting, and since there's no timeout either, jobs hang indefinitely until GitHub's 6-hour job limit kills them.

## Fix

Add a `concurrency` block with `cancel-in-progress: true` to all PR-triggered workflow examples:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
  cancel-in-progress: true
```

**Files changed:**
- `examples/pr-review-comprehensive.yml`
- `examples/pr-review-filtered-authors.yml`
- `examples/pr-review-filtered-paths.yml`
- `docs/solutions.md` — all 7 inline PR review YAML blocks + a note in Best Practices

## Why `cancel-in-progress: true` is almost always correct for PR reviews

A PR review is always reviewing the latest commit. If a new push comes in while a review is running, that review is already stale — there's no value in letting it finish. Cancelling it immediately frees the runner and the API token for the review that actually matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)