### PR TITLE
fix: modify allowedTools in issue-deduplication.yml

### DIFF
--- a/examples/issue-deduplication.yml
+++ b/examples/issue-deduplication.yml
@@ -60,4 +60,4 @@ jobs:
 
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
-            --allowedTools "mcp__github__get_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__create_issue_comment,mcp__github__update_issue,mcp__github__get_issue_comments"
+            --allowedTools "mcp__github__get_issue,mcp__github__search_issues,mcp__github__list_issues,mcp__github__add_issue_comment,mcp__github__update_issue,mcp__github__get_issue_comments"


### PR DESCRIPTION
## Fix issue deduplication workflow comment permissions

The issue deduplication workflow was failing to post comments on duplicate issues. Claude would complete its analysis correctly but report:

> Note: the comment could not be posted due to missing permission (`mcp__github__add_issue_comment`)

### Root cause

The `--allowedTools` list was missing `mcp__github__add_issue_comment`, the tool required by the `github/github-mcp-server` (bundled with `claude-code-action`) to post issue comments.

The list also included `mcp__github__create_issue_comment`, which belongs to the older community `modelcontextprotocol/servers` implementation — not the MCP server this action uses. It was a no-op.

### Changes

- ✅ Added `mcp__github__add_issue_comment` to `--allowedTools`
- 🗑️ Removed `mcp__github__create_issue_comment` (wrong MCP server, never functional here)