### PR TITLE
feat: support SHA pinning in plugin marketplace URLs

### DIFF
--- a/base-action/src/install-plugins.ts
+++ b/base-action/src/install-plugins.ts
@@ -5,7 +5,7 @@ const MAX_PLUGIN_NAME_LENGTH = 512;
 const PATH_TRAVERSAL_REGEX =
   /\.\.\/|\/\.\.|\.\/|\/\.|(?:^|\/)\.\.$|(?:^|\/)\.$|\.\.(?![0-9])/;
 const MARKETPLACE_URL_REGEX =
-  /^https:\/\/[a-zA-Z0-9\-._~:/?#[\]@!$&'()*+,;=%]+\.git$/;
+  /^https:\/\/[a-zA-Z0-9\-._~:/?#[\]@!$&'()*+,;=%]+\.git(#[a-fA-F0-9]+)?$/;
 
 /**
  * Checks if a marketplace input is a local path (not a URL)

--- a/base-action/test/install-plugins.test.ts
+++ b/base-action/test/install-plugins.test.ts
@@ -691,6 +691,74 @@ describe("installPlugins", () => {
     );
   });
 
+  // SHA-pinned marketplace URL tests
+  test("should accept marketplace URL with short SHA pin", async () => {
+    const spy = createMockSpawn();
+    await installPlugins(
+      "https://github.com/org/repo.git#abc123def456",
+      "test-plugin",
+    );
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(
+      1,
+      "claude",
+      [
+        "plugin",
+        "marketplace",
+        "add",
+        "https://github.com/org/repo.git#abc123def456",
+      ],
+      { stdio: "inherit" },
+    );
+    expect(spy).toHaveBeenNthCalledWith(
+      2,
+      "claude",
+      ["plugin", "install", "test-plugin"],
+      { stdio: "inherit" },
+    );
+  });
+
+  test("should accept marketplace URL with full SHA pin", async () => {
+    const spy = createMockSpawn();
+    await installPlugins(
+      "https://github.com/org/repo.git#55b58ec6e5649104f926ba7558b567dc8d33c5ff",
+      "test-plugin",
+    );
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(
+      1,
+      "claude",
+      [
+        "plugin",
+        "marketplace",
+        "add",
+        "https://github.com/org/repo.git#55b58ec6e5649104f926ba7558b567dc8d33c5ff",
+      ],
+      { stdio: "inherit" },
+    );
+    expect(spy).toHaveBeenNthCalledWith(
+      2,
+      "claude",
+      ["plugin", "install", "test-plugin"],
+      { stdio: "inherit" },
+    );
+  });
+
+  test("should reject marketplace URL with non-hex characters after #", async () => {
+    const spy = createMockSpawn();
+
+    await expect(
+      installPlugins(
+        "https://github.com/org/repo.git#not-a-hex",
+        "test-plugin",
+      ),
+    ).rejects.toThrow("Invalid marketplace URL format");
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   test("should accept local path with dots in directory name", async () => {
     const spy = createMockSpawn();
     await installPlugins("./my.plugin.marketplace", "test-plugin");


### PR DESCRIPTION
## Summary

- Allow appending `#<hex-sha>` to marketplace Git URLs (e.g. `https://github.com/org/repo.git#55b58ec...`) to pin a specific commit
- Updated `MARKETPLACE_URL_REGEX` to accept an optional hex SHA fragment after `.git`
- Added tests for short SHA, full SHA, and rejection of non-hex fragments

## Motivation

Pinning plugin marketplaces to specific commit SHAs enables reproducible plugin installations in CI/CD workflows. The Claude CLI already supports SHA pinning for individual plugins (since v2.1.14), but the action's URL validation rejected the `#sha` suffix on marketplace URLs, preventing users from passing SHA-pinned marketplace URLs through to the CLI.

Resolves anthropics/claude-code#10571
Resolves anthropics/claude-code#15439

## Changes

**`base-action/src/install-plugins.ts`**
- Updated `MARKETPLACE_URL_REGEX` from `/^https:\/\/...\.git$/` to `/^https:\/\/...\.git(#[a-fA-F0-9]+)?$/`
- Only hex characters (`[a-fA-F0-9]`) are allowed after `#`, matching the format of Git commit SHAs
- No other code changes needed -- the URL (including the `#sha` fragment) is already passed as-is to `claude plugin marketplace add`

**`base-action/test/install-plugins.test.ts`**
- Added test: marketplace URL with short SHA (`#abc123def456`) is accepted and passed through correctly
- Added test: marketplace URL with full 40-char SHA (`#55b58ec6e5649104f926ba7558b567dc8d33c5ff`) is accepted
- Added test: marketplace URL with non-hex characters after `#` (`#not-a-hex`) is rejected

## Test plan

- [x] All 121 existing + new tests pass (`bun test`)
- [ ] Verify end-to-end with a SHA-pinned marketplace URL in a GitHub Actions workflow