### PR TITLE
fix: handle shell-quote treating # as comment in claude_args

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -92,9 +92,17 @@ function parseClaudeArgsToExtraArgs(
   if (!claudeArgs?.trim()) return {};
 
   const result: Record<string, string | null> = {};
-  const args = parseShellArgs(claudeArgs).filter(
-    (arg): arg is string => typeof arg === "string",
-  );
+  const args = parseShellArgs(claudeArgs)
+    .map((arg) => {
+      if (typeof arg === "string") return arg;
+      // shell-quote treats # as a comment and returns {comment: "..."} objects.
+      // Convert these back to strings since # is valid in flag values.
+      if (typeof arg === "object" && arg !== null && "comment" in arg) {
+        return `#${(arg as { comment: string }).comment}`;
+      }
+      return undefined;
+    })
+    .filter((arg): arg is string => arg !== undefined);
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -313,7 +313,8 @@ describe("parseSdkOptions", () => {
 
     test("should handle unquoted # by converting comment object back to string", () => {
       const options: ClaudeOptions = {
-        claudeArgs: "--model claude-sonnet-4-5-20250929 --append-system-prompt #Use",
+        claudeArgs:
+          "--model claude-sonnet-4-5-20250929 --append-system-prompt #Use",
       };
 
       const result = parseSdkOptions(options);

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -298,6 +298,32 @@ describe("parseSdkOptions", () => {
     });
   });
 
+  describe("hash character handling", () => {
+    test("should preserve # in flag values instead of treating as comment", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: '--append-system-prompt "# Use best practices"',
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.extraArgs?.["append-system-prompt"]).toBe(
+        "# Use best practices",
+      );
+    });
+
+    test("should handle unquoted # by converting comment object back to string", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--model claude-sonnet-4-5-20250929 --append-system-prompt #Use",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.extraArgs?.["append-system-prompt"]).toBe(
+        "#Use",
+      );
+    });
+  });
+
   describe("other extraArgs passthrough", () => {
     test("should pass through json-schema in extraArgs", () => {
       const options: ClaudeOptions = {


### PR DESCRIPTION
`shell-quote`'s `parse()` treats `#` as the start of a shell comment and returns `{comment: "..."}` objects instead of strings. The existing `.filter(arg => typeof arg === 'string')` drops these objects, leaving the preceding flag with no value (`null`). This `null` propagates into the SDK config and triggers an AJV schema validation crash.

## Changes

- Convert `{comment: "..."}` objects back to strings (prepending `#`) instead of dropping them
- Add test cases for `#` in quoted and unquoted flag values

## Reproduction (before fix)

```yaml
claude_args: |
  --append-system-prompt \#\ Use\ best\ practices
```

Crashes with AJV validation error because `append-system-prompt` receives `null`.

Closes #980