### PR TITLE
fix: skip SHA computation for newly added files in PRs

### DIFF
--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -341,11 +341,19 @@ export async function fetchGitHubData({
   let changedFilesWithSHA: GitHubFileWithSHA[] = [];
   if (isPR && changedFiles.length > 0) {
     changedFilesWithSHA = changedFiles.map((file) => {
-      // Don't compute SHA for deleted files
+      // Don't compute SHA for deleted or added files - deleted files no longer
+      // exist, and added files may not exist yet if the PR branch hasn't been
+      // checked out (fetchGitHubData runs before setupBranch).
       if (file.changeType === "DELETED") {
         return {
           ...file,
           sha: "deleted",
+        };
+      }
+      if (file.changeType === "ADDED") {
+        return {
+          ...file,
+          sha: "added",
         };
       }
 


### PR DESCRIPTION
`fetchGitHubData()` runs before `setupBranch()` in `prepareTagMode()`, so files marked as `ADDED` in a PR don't exist on disk yet when `git hash-object` is called. This causes `fatal: could not open '<file>' for reading: No such file or directory` errors for PRs that add new files.

## Changes

Skip SHA computation for `ADDED` files (like we already do for `DELETED`), using `"added"` as the SHA placeholder.

## Execution order

1. `fetchGitHubData()` — calls `git hash-object` on changed files (fails for ADDED files)
2. `setupBranch()` — checks out PR branch (files become available, but too late)

Closes #979