### PR TITLE
Only expose permission_denials count in sanitized output

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -119,7 +119,7 @@ function sanitizeSdkOutput(
         duration_ms: resultMsg.duration_ms,
         num_turns: resultMsg.num_turns,
         total_cost_usd: resultMsg.total_cost_usd,
-        permission_denials: resultMsg.permission_denials,
+        permission_denials_count: resultMsg.permission_denials?.length ?? 0,
       },
       null,
       2,


### PR DESCRIPTION
When `show_full_output: false` (default), replace the full `permission_denials` array with just a count. The full details (including `tool_input`) are still available when `show_full_output: true`.

This makes the sanitized output more consistent with the intent of hiding tool call details by default.