### PR TITLE
fix: add CLAUDE_WORKING_DIR support to main action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -186,6 +186,11 @@ runs:
       id: run
       shell: bash
       run: |
+        # Change to CLAUDE_WORKING_DIR if set (for running in custom directories)
+        if [ -n "$CLAUDE_WORKING_DIR" ]; then
+          echo "Changing directory to CLAUDE_WORKING_DIR: $CLAUDE_WORKING_DIR"
+          cd "$CLAUDE_WORKING_DIR"
+        fi
         bun run ${GITHUB_ACTION_PATH}/src/entrypoints/run.ts
       env:
         # Prepare inputs


### PR DESCRIPTION
## Summary

- Add `CLAUDE_WORKING_DIR` environment variable support to the main composite action (`action.yml`)
- The `base-action/action.yml` already has this feature (L156-160), but the main action was missing it after the refactor in #285
- This is a 4-line addition that checks for `CLAUDE_WORKING_DIR` and `cd`s to it before running the entrypoint

## Motivation

Monorepo users need to run Claude Code in a subdirectory (e.g., `systems/journey` within a larger repo). The `CLAUDE_WORKING_DIR` environment variable was designed for this, but currently only works with `claude-code-base-action`, not the main `claude-code-action`.

This causes Claude Code to:
- Start in the repository root instead of the intended subdirectory
- Miss project-specific `.claude/` configurations (CLAUDE.md, settings, skills)
- Require workarounds like prompt-based `cd` instructions

## Changes

Added the same `CLAUDE_WORKING_DIR` check from `base-action/action.yml` to the main `action.yml`:

```bash
if [ -n "$CLAUDE_WORKING_DIR" ]; then
  echo "Changing directory to CLAUDE_WORKING_DIR: $CLAUDE_WORKING_DIR"
  cd "$CLAUDE_WORKING_DIR"
fi
```

The guard (`if [ -n ... ]`) ensures no behavior change when the variable is not set.

## Usage

```yaml
- uses: anthropics/claude-code-action@v1
  env:
    CLAUDE_WORKING_DIR: ${{ github.workspace }}/my-subdirectory
```

Fixes #315