### PR TITLE
fix: allow @ character in branch name validation

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -28,7 +28,7 @@ function extractFirstLabel(githubData: FetchDataResult): string | undefined {
  *
  * Valid branch names:
  * - Start with alphanumeric character (not dash, to prevent option injection)
- * - Contain only alphanumeric, forward slash, hyphen, underscore, or period
+ * - Contain only alphanumeric, forward slash, hyphen, underscore, period, or at sign
  * - Do not start or end with a period
  * - Do not end with a slash
  * - Do not contain '..' (path traversal)
@@ -58,12 +58,13 @@ export function validateBranchName(branchName: string): void {
     );
   }
 
-  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/period
-  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$/;
+  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/period/at
+  // Note: '@' is valid in git branch names; the dangerous '@{' sequence is caught separately below
+  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_.@-]*$/;
 
   if (!validPattern.test(branchName)) {
     throw new Error(
-      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, or periods.`,
+      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, periods, or at signs.`,
     );
   }
 

--- a/test/validate-branch-name.test.ts
+++ b/test/validate-branch-name.test.ts
@@ -29,6 +29,14 @@ describe("validateBranchName", () => {
       expect(() => validateBranchName("release.1.2.3")).not.toThrow();
     });
 
+    it("should accept names with at signs", () => {
+      expect(() =>
+        validateBranchName("TICKET-123@add-feature"),
+      ).not.toThrow();
+      expect(() => validateBranchName("user@feature-branch")).not.toThrow();
+      expect(() => validateBranchName("feature@v2")).not.toThrow();
+    });
+
     it("should accept typical branch name formats", () => {
       expect(() =>
         validateBranchName("claude/issue-123-20250101-1234"),


### PR DESCRIPTION
## Summary

- Updates the branch name validation regex to allow `@` in branch names
- The `@` character is valid in git branch names and commonly used in workflows (e.g., `TICKET-123@add-feature`)
- The dangerous `@{` sequence (git reflog syntax) is already caught by a separate dedicated check, so allowing `@` in the whitelist regex is safe
- Adds test cases for valid branch names containing `@`

Fixes #998

## Test plan

- [x] All existing tests pass (31 tests, 0 failures)
- [x] New test cases added for `@` in branch names (`TICKET-123@add-feature`, `user@feature-branch`, `feature@v2`)
- [x] Existing `@{` rejection test still passes (caught by the separate `@{` check)
- [ ] Manual verification: branch names like `TICKET-123@add-feature` no longer cause validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)