### PR TITLE
fix: allow '@' in branch names (block only '@{' refspec syntax)

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -28,7 +28,7 @@ function extractFirstLabel(githubData: FetchDataResult): string | undefined {
  *
  * Valid branch names:
  * - Start with alphanumeric character (not dash, to prevent option injection)
- * - Contain only alphanumeric, forward slash, hyphen, underscore, or period
+ * - Contain only alphanumeric, forward slash, hyphen, underscore, period, or '@'
  * - Do not start or end with a period
  * - Do not end with a slash
  * - Do not contain '..' (path traversal)
@@ -58,12 +58,13 @@ export function validateBranchName(branchName: string): void {
     );
   }
 
-  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/period
-  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$/;
+  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/period/@
+  // '@' alone is safe in git branch names; '@{' (refspec syntax) is blocked by a separate check below
+  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/@_.-]*$/;
 
   if (!validPattern.test(branchName)) {
     throw new Error(
-      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, or periods.`,
+      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, periods, or '@'.`,
     );
   }
 

--- a/test/validate-branch-name.test.ts
+++ b/test/validate-branch-name.test.ts
@@ -36,6 +36,14 @@ describe("validateBranchName", () => {
       expect(() => validateBranchName("refs/heads/main")).not.toThrow();
       expect(() => validateBranchName("bugfix/JIRA-1234")).not.toThrow();
     });
+
+    it("should accept names with '@' (e.g. polecat-style branches)", () => {
+      expect(() =>
+        validateBranchName("polecat/rust/tw-w1y@mm95deze"),
+      ).not.toThrow();
+      expect(() => validateBranchName("feature/thing@abc123")).not.toThrow();
+      expect(() => validateBranchName("user@host/branch")).not.toThrow();
+    });
   });
 
   describe("command injection attempts", () => {


### PR DESCRIPTION
## Problem

The `validateBranchName` whitelist regex currently blocks `@` in branch names:

```ts
const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$/;
```

This breaks tools that use `@` as a separator in branch names (e.g. `polecat/rust/tw-w1y@mm95deze`), causing the action to error with:

> Invalid branch name: "polecat/rust/tw-w1y@mm95deze". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, or periods.

## Root Cause

Standalone `@` is a valid git branch name character and poses no shell injection risk — git commands are invoked via `execFileSync`, not a shell. Only `@{` has special meaning in git (refspec syntax for accessing upstream/reflog entries like `HEAD@{upstream}`).

The existing `@{` check already handles the dangerous form correctly. The regex was just overly strict.

## Fix

- Add `@` to the whitelist pattern: `/^[a-zA-Z0-9][a-zA-Z0-9/@_.-]*$/`
- The existing `branchName.includes("@{")` check continues to block the dangerous git refspec form
- Add test cases for `@`-containing branch names