### PR TITLE
Use default github token only on public github instance

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -163,7 +163,7 @@ runs:
       uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # https://github.com/oven-sh/setup-bun/releases/tag/v2.1.2
       with:
         bun-version: 1.3.6
-        token: ${{ inputs.github_token || (github.server_url == 'https://github.com' && github.token || '') }}
+        token: ${{ github.server_url == 'https://github.com' && (inputs.github_token || github.token) || '' }}
 
     - name: Setup Custom Bun Path
       if: inputs.path_to_bun_executable != ''

--- a/action.yml
+++ b/action.yml
@@ -163,7 +163,7 @@ runs:
       uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # https://github.com/oven-sh/setup-bun/releases/tag/v2.1.2
       with:
         bun-version: 1.3.6
-        token: ${{ inputs.github_token || github.token }}
+        token: ${{ inputs.github_token || (github.server_url == 'https://github.com' && github.token || '') }}
 
     - name: Setup Custom Bun Path
       if: inputs.path_to_bun_executable != ''


### PR DESCRIPTION
This fixes https://github.com/anthropics/claude-code-action/issues/896 and replaces https://github.com/anthropics/claude-code-action/pull/913 the same way as it is done in oven-sh/setup-bun itself: https://github.com/oven-sh/setup-bun/pull/157


Tested and works with GitHub Enterprise Server