### PR TITLE
fix: validate paths in delete_files with validatePathWithinRepo

### DIFF
--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -479,21 +479,18 @@ server.tool(
         throw new Error("GITHUB_TOKEN environment variable is required");
       }
 
-      // Convert absolute paths to relative if they match CWD
-      const cwd = process.cwd();
-      const processedPaths = paths.map((filePath) => {
-        if (filePath.startsWith("/")) {
-          if (filePath.startsWith(cwd)) {
-            // Strip CWD from absolute path
-            return filePath.slice(cwd.length + 1);
-          } else {
-            throw new Error(
-              `Path '${filePath}' must be relative to repository root or within current working directory`,
-            );
-          }
-        }
-        return filePath;
-      });
+      // Validate all paths are within the repository root — mirrors
+      // the validation used in commit_files to prevent path-traversal
+      // attacks via ".." sequences or symlinks escaping the repo.
+      const resolvedRepoDir = resolve(REPO_DIR);
+      const processedPaths = await Promise.all(
+        paths.map(async (filePath) => {
+          await validatePathWithinRepo(filePath, REPO_DIR);
+          // Normalise to a relative path for the Git tree entry
+          const normalizedPath = resolve(resolvedRepoDir, filePath);
+          return normalizedPath.slice(resolvedRepoDir.length + 1);
+        }),
+      );
 
       // 1. Get the branch reference (create if doesn't exist)
       const baseSha = await getOrCreateBranchRef(


### PR DESCRIPTION
## Summary

The `delete_files` MCP tool in `github-file-ops-server.ts` uses a weaker path validation than `commit_files`. While `commit_files` correctly calls `validatePathWithinRepo()` (which resolves symlinks and blocks `..` traversal), `delete_files` only checks if absolute paths start with `cwd` and passes relative paths through without any validation.

## The inconsistency

```typescript
// commit_files — ✅ validated
const fullPath = await validatePathWithinRepo(filePath, REPO_DIR);

// delete_files — ❌ ad-hoc check only
if (filePath.startsWith("/")) {
  if (filePath.startsWith(cwd)) {
    return filePath.slice(cwd.length + 1);  // no symlink check
  }
}
return filePath;  // relative paths not checked at all
```

## Fix

Replace the ad-hoc path processing in `delete_files` with the same `validatePathWithinRepo()` + relative path normalisation pattern used by `commit_files`:

```typescript
const resolvedRepoDir = resolve(REPO_DIR);
const processedPaths = await Promise.all(
  paths.map(async (filePath) => {
    await validatePathWithinRepo(filePath, REPO_DIR);
    const normalizedPath = resolve(resolvedRepoDir, filePath);
    return normalizedPath.slice(resolvedRepoDir.length + 1);
  }),
);
```

This ensures both tools enforce identical path safety guarantees:
- `..` traversal is caught by `realpath` resolution
- Symlinks escaping the repository root are blocked
- Absolute paths outside the repo are rejected
- Path normalisation is consistent

## Checklist
- [x] Uses existing validated `validatePathWithinRepo()` function
- [x] Consistent with `commit_files` implementation
- [x] No breaking changes for legitimate paths
- [x] No new dependencies