### PR TITLE
Add support for ANTHROPIC_AUTH_TOKEN authentication

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,9 @@ inputs:
   claude_code_oauth_token:
     description: "Claude Code OAuth token (alternative to anthropic_api_key)"
     required: false
+  anthropic_auth_token:
+    description: "Anthropic auth token for third-party API providers like LiteLLM proxy (alternative to anthropic_api_key)"
+    required: false
   github_token:
     description: "GitHub token with repo and pull request permissions (optional if using GitHub App)"
     required: false
@@ -233,6 +236,7 @@ runs:
         # Provider configuration
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.anthropic_auth_token }}
         ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
         ANTHROPIC_CUSTOM_HEADERS: ${{ env.ANTHROPIC_CUSTOM_HEADERS }}
         CLAUDE_CODE_USE_BEDROCK: ${{ inputs.use_bedrock == 'true' && '1' || '' }}

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Claude Code OAuth token (alternative to anthropic_api_key)"
     required: false
     default: ""
+  anthropic_auth_token:
+    description: "Anthropic auth token for third-party API providers like LiteLLM proxy (alternative to anthropic_api_key)"
+    required: false
+    default: ""
   use_bedrock:
     description: "Use Amazon Bedrock with OIDC authentication instead of direct Anthropic API"
     required: false
@@ -175,6 +179,7 @@ runs:
         # Provider configuration
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
+        ANTHROPIC_AUTH_TOKEN: ${{ inputs.anthropic_auth_token }}
         ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
         ANTHROPIC_CUSTOM_HEADERS: ${{ env.ANTHROPIC_CUSTOM_HEADERS }}
         # Only set provider flags if explicitly true, since any value (including "false") is truthy

--- a/base-action/src/validate-env.ts
+++ b/base-action/src/validate-env.ts
@@ -8,6 +8,7 @@ export function validateEnvironmentVariables() {
   const useFoundry = process.env.CLAUDE_CODE_USE_FOUNDRY === "1";
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY;
   const claudeCodeOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  const anthropicAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
 
   const errors: string[] = [];
 
@@ -20,9 +21,9 @@ export function validateEnvironmentVariables() {
   }
 
   if (!useBedrock && !useVertex && !useFoundry) {
-    if (!anthropicApiKey && !claudeCodeOAuthToken) {
+    if (!anthropicApiKey && !claudeCodeOAuthToken && !anthropicAuthToken) {
       errors.push(
-        "Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.",
+        "Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or ANTHROPIC_AUTH_TOKEN is required when using direct Anthropic API.",
       );
     }
   } else if (useBedrock) {

--- a/base-action/test/validate-env.test.ts
+++ b/base-action/test/validate-env.test.ts
@@ -26,6 +26,7 @@ describe("validateEnvironmentVariables", () => {
     delete process.env.ANTHROPIC_VERTEX_BASE_URL;
     delete process.env.ANTHROPIC_FOUNDRY_RESOURCE;
     delete process.env.ANTHROPIC_FOUNDRY_BASE_URL;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
   });
 
   afterEach(() => {
@@ -40,9 +41,15 @@ describe("validateEnvironmentVariables", () => {
       expect(() => validateEnvironmentVariables()).not.toThrow();
     });
 
-    test("should fail when ANTHROPIC_API_KEY is missing", () => {
+    test("should pass when ANTHROPIC_AUTH_TOKEN is provided", () => {
+      process.env.ANTHROPIC_AUTH_TOKEN = "test-auth-token";
+
+      expect(() => validateEnvironmentVariables()).not.toThrow();
+    });
+
+    test("should fail when no auth token is provided", () => {
       expect(() => validateEnvironmentVariables()).toThrow(
-        "Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.",
+        "Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or ANTHROPIC_AUTH_TOKEN is required when using direct Anthropic API.",
       );
     });
   });


### PR DESCRIPTION
## Summary
This PR adds support for a new `anthropic_auth_token` input parameter to enable authentication with [third-party API providers like LiteLLM proxy](https://code.claude.com/docs/en/llm-gateway#basic-litellm-setup), in addition to the existing `anthropic_api_key` and `claude_code_oauth_token` options.

## Key Changes
- **Added new input parameter**: `anthropic_auth_token` in both `action.yml` and `base-action/action.yml` for third-party API provider authentication
- **Updated environment variable handling**: Pass `ANTHROPIC_AUTH_TOKEN` through to the action execution environment
- **Enhanced validation logic**: Modified `validateEnvironmentVariables()` to accept `ANTHROPIC_AUTH_TOKEN` as a valid authentication method alongside existing options
- **Updated error messaging**: Changed validation error message to reflect all three supported authentication methods
- **Added test coverage**: New test case verifying `ANTHROPIC_AUTH_TOKEN` is accepted as valid authentication
- **Documentation updates**: Minor formatting fixes in README and documentation files (removed extra blank lines for consistency)

## Implementation Details
The authentication validation now checks for any of three valid credentials in this order:
1. `ANTHROPIC_API_KEY` (direct Anthropic API)
2. `CLAUDE_CODE_OAUTH_TOKEN` (OAuth token)
3. `ANTHROPIC_AUTH_TOKEN` (third-party providers)

This maintains backward compatibility while enabling new integration scenarios with proxy services and alternative API providers.

https://claude.ai/code/session_01Q7hAv9Ah5eeZjXPEqmhYoW