### PR TITLE
Strip OIDC token request env vars from Claude session

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -215,6 +215,12 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   // Set the entrypoint for Claude Code to identify this as the GitHub Action
   env.CLAUDE_CODE_ENTRYPOINT = "claude-code-github-action";
 
+  // Remove OIDC token request variables so Claude cannot mint new tokens.
+  // These are only needed by the action itself (via @actions/core.getIDToken()),
+  // not by the Claude session.
+  delete env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  delete env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+
   // Build system prompt option - default to claude_code preset
   let systemPrompt: SdkOptions["systemPrompt"];
   if (options.systemPrompt) {

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -366,5 +366,26 @@ describe("parseSdkOptions", () => {
         "claude-code-github-action",
       );
     });
+
+    test("should strip ACTIONS_ID_TOKEN_REQUEST_URL and ACTIONS_ID_TOKEN_REQUEST_TOKEN from env", () => {
+      const originalEnv = { ...process.env };
+      process.env.ACTIONS_ID_TOKEN_REQUEST_URL =
+        "https://token.actions.githubusercontent.com";
+      process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = "secret-token-value";
+
+      try {
+        const options: ClaudeOptions = {};
+        const result = parseSdkOptions(options);
+
+        expect(
+          result.sdkOptions.env?.ACTIONS_ID_TOKEN_REQUEST_URL,
+        ).toBeUndefined();
+        expect(
+          result.sdkOptions.env?.ACTIONS_ID_TOKEN_REQUEST_TOKEN,
+        ).toBeUndefined();
+      } finally {
+        process.env = originalEnv;
+      }
+    });
   });
 });


### PR DESCRIPTION
When `id-token: write` permission is enabled, `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` are passed to the Claude session via the `process.env` spread in `parseSdkOptions()`. This allows Claude to mint new OIDC tokens, which is an unintended capability.
                                                                                                                                                                                                                                                                                        
  This PR deletes these two variables from the env object before passing it to the Claude SDK. The OIDC flow in `token.ts` reads directly from `process.env` and runs before `parseSdkOptions()`, so it is unaffected.                                                                  
                                                                                                                                                                                                                                                                                        
  ## Changes                                                                                                                                                                                                                                                                            
  - Strip `ACTIONS_ID_TOKEN_REQUEST_URL` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` in `base-action/src/parse-sdk-options.ts`                                                                                                                                                                 
  - Add test coverage in `base-action/test/parse-sdk-options.test.ts`                                                                                                                                                                                                                   

Fixes #1010