### PR TITLE
feat: support pull_request.labeled action for track_progress

### DIFF
--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -67,6 +67,7 @@ export function detectMode(context: GitHubContext): AutoDetectedMode {
       "synchronize",
       "ready_for_review",
       "reopened",
+      "labeled",
     ];
     if (context.eventAction && supportedActions.includes(context.eventAction)) {
       // If prompt is provided, use agent mode (default for automation)
@@ -103,6 +104,7 @@ function validateTrackProgressEvent(context: GitHubContext): void {
       "synchronize",
       "ready_for_review",
       "reopened",
+      "labeled",
     ];
     if (!validActions.includes(context.eventAction)) {
       throw new Error(

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -61,6 +61,20 @@ describe("detectMode with enhanced routing", () => {
       expect(detectMode(context)).toBe("tag");
     });
 
+    it("should use tag mode when track_progress is true for pull_request.labeled", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "labeled",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, trackProgress: true },
+      };
+
+      expect(detectMode(context)).toBe("tag");
+    });
+
     it("should use agent mode when track_progress is false for pull_request.opened", () => {
       const context: GitHubContext = {
         ...baseContext,


### PR DESCRIPTION
## Summary

- Adds `"labeled"` to the supported PR actions in both `detectMode()` and `validateTrackProgressEvent()` in `src/modes/detector.ts`
- Enables label-gated PR reviews with `track_progress` enabled
- Adds test for `pull_request.labeled` with `track_progress: true`

## Context

Fixes #418

Currently, using `track_progress: "true"` with `pull_request: types: [labeled]` throws:

```
track_progress for pull_request events is only supported for actions: opened, synchronize, ready_for_review, reopened. Current action: labeled
```

The downstream code (tag mode, prompt construction, branch setup, comment creation) is entirely action-agnostic for PR events, so the restriction was unnecessarily narrow. This change adds `"labeled"` to both validation arrays, enabling label-gated workflows like:

```yaml
on:
  pull_request:
    types: [labeled]

jobs:
  review:
    if: github.event.label.name == 'my-review-label'
    steps:
      - uses: anthropics/claude-code-action@v1
        with:
          prompt: "Review this PR"
          track_progress: "true"
```

## Test plan

- [x] Unit test added for `pull_request.labeled` with `track_progress: true`
- [x] All existing tests pass (`bun test`)
- [x] TypeScript typecheck passes (`bun run typecheck`)
- [x] Formatting passes (`bun run format:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)