### PR TITLE
fix: allow @, +, and Unicode branch names

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -28,7 +28,7 @@ function extractFirstLabel(githubData: FetchDataResult): string | undefined {
  *
  * Valid branch names:
  * - Start with alphanumeric character (not dash, to prevent option injection)
- * - Contain only alphanumeric, forward slash, hyphen, underscore, period, or hash (#)
+ * - Contain only alphanumeric, forward slash, hyphen, underscore, period, hash (#), @, or plus
  * - Do not start or end with a period
  * - Do not end with a slash
  * - Do not contain '..' (path traversal)
@@ -59,9 +59,10 @@ export function validateBranchName(branchName: string): void {
   }
 
   // Strict whitelist pattern: alphanumeric or Unicode letter start, then those plus
-  // slash/hyphen/underscore/period/#/@/+. `#`, `@`, and `+` are valid in git branch
-  // names; only `@{` is reserved (checked separately below). Unicode letters (\p{L})
-  // support non-ASCII branch names (e.g. Japanese, Chinese characters).
+  // slash/hyphen/underscore/period/@/+. `@` and `+` are valid in git branch names;
+  // only `@{` is reserved (checked separately below). Unicode letters (\p{L}) support
+  // non-ASCII branch names (e.g. Japanese, Chinese characters).
+  // `#` is also valid per git-check-ref-format and commonly used in issue-linked names.
   const validPattern = /^[\p{L}\p{N}][\p{L}\p{N}/_.#\-@+]*$/u;
 
   if (!validPattern.test(branchName)) {

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -58,14 +58,15 @@ export function validateBranchName(branchName: string): void {
     );
   }
 
-  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/period/hash.
-  // # is valid per git-check-ref-format and commonly used in branch names like "fix/#123-description".
-  // All git calls use execFileSync (not shell interpolation), so # carries no injection risk.
-  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_.#-]*$/;
+  // Strict whitelist pattern: alphanumeric or Unicode letter start, then those plus
+  // slash/hyphen/underscore/period/#/@/+. `#`, `@`, and `+` are valid in git branch
+  // names; only `@{` is reserved (checked separately below). Unicode letters (\p{L})
+  // support non-ASCII branch names (e.g. Japanese, Chinese characters).
+  const validPattern = /^[\p{L}\p{N}][\p{L}\p{N}/_.#\-@+]*$/u;
 
   if (!validPattern.test(branchName)) {
     throw new Error(
-      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, periods, or hashes (#).`,
+      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric or Unicode letter character and contain only alphanumeric characters, Unicode letters, forward slashes, hyphens, underscores, periods, hashes (#), @, or +.`,
     );
   }
 

--- a/test/validate-branch-name.test.ts
+++ b/test/validate-branch-name.test.ts
@@ -45,6 +45,22 @@ describe("validateBranchName", () => {
       ).not.toThrow();
       expect(() => validateBranchName("fix/issue-#42")).not.toThrow();
     });
+
+    it("should accept branch names with @ character", () => {
+      expect(() => validateBranchName("TICKET-123@add-feature")).not.toThrow();
+      expect(() => validateBranchName("user@branch")).not.toThrow();
+    });
+
+    it("should accept branch names with + character", () => {
+      expect(() => validateBranchName("TICKET-123+add-feature")).not.toThrow();
+      expect(() => validateBranchName("release+hotfix")).not.toThrow();
+    });
+
+    it("should accept branch names with non-ASCII Unicode characters", () => {
+      expect(() => validateBranchName("feat/add-機能追加")).not.toThrow();
+      expect(() => validateBranchName("修复/bug-123")).not.toThrow();
+      expect(() => validateBranchName("фича/новая")).not.toThrow();
+    });
   });
 
   describe("command injection attempts", () => {


### PR DESCRIPTION
## Summary

Fixes #998 and #1020

The whitelist regex in `validateBranchName` (`src/github/operations/branch.ts`) previously rejected valid git branch names containing `@`, `+`, or non-ASCII Unicode characters.

### Changes

- update `src/github/operations/branch.ts` to allow `@`, `+`, and Unicode letters/numbers in branch names
- keep rejecting Git-reserved patterns like `@{`, `.lock`, `..`, consecutive `/`, and invalid ref characters
- extend `test/validate-branch-name.test.ts` with coverage for `+` alongside the existing `@` and Unicode cases

### Security

The `@{` reflog syntax is still rejected explicitly. Control characters, shell metacharacters, and Git-special characters like `~`, `^`, `:`, `?`, `*`, `[`, `]`, and `\` remain blocked. The validator still forbids names that could trigger option injection or path traversal.

## Test plan

- [x] `bun test test/validate-branch-name.test.ts`
- [x] `bun run typecheck`