### PR TITLE
fix: allow Unicode letters in branch name validation

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -85,14 +85,24 @@ function mergeMcpConfigs(configValues: string[]): string {
  * For allowedTools and disallowedTools, multiple occurrences are accumulated (null-char joined).
  * Accumulating flags also consume all consecutive non-flag values
  * (e.g., --allowed-tools "Tool1" "Tool2" "Tool3" captures all three).
+ *
+ * Note: Lines starting with # are treated as comments and stripped before parsing.
+ * This allows users to add documentation comments to claude_args without breaking subsequent flags.
  */
 function parseClaudeArgsToExtraArgs(
   claudeArgs?: string,
 ): Record<string, string | null> {
   if (!claudeArgs?.trim()) return {};
 
+  // Strip comment lines (lines starting with # after trimming)
+  const lines = claudeArgs.split("\n");
+  const nonCommentLines = lines
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+  const filteredArgs = nonCommentLines.join(" ");
+
   const result: Record<string, string | null> = {};
-  const args = parseShellArgs(claudeArgs).filter(
+  const args = parseShellArgs(filteredArgs).filter(
     (arg): arg is string => typeof arg === "string",
   );
 

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -59,9 +59,10 @@ export function validateBranchName(branchName: string): void {
     );
   }
 
-  // Strict whitelist pattern: alphanumeric start (including Unicode), then alphanumeric/slash/hyphen/underscore/period
-  // Using \p{L} for Unicode letters and \p{N} for Unicode numbers
-  const validPattern = /^\p{L}\p{L}*[\p{L}\p{N}/._-]*$/u;
+  // Strict whitelist pattern: alphanumeric start (including Unicode), then alphanumeric/slash/hyphen/underscore/period/pound
+  // Using \p{L} for Unicode letters, \p{N} for Unicode numbers
+  // Allow # for Azure DevOps ticket linking (e.g., feature/AB#1992-sentry)
+  const validPattern = /^\p{L}\p{L}*[\p{L}\p{N}/._#-]*$/u;
 
   if (!validPattern.test(branchName)) {
     throw new Error(

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -44,6 +44,7 @@ export function validateBranchName(branchName: string): void {
   }
 
   // Check for leading dash (prevents option injection like --help, -x)
+  // Allow Unicode letters (\p{L}) and numbers (\p{N}) at start
   if (branchName.startsWith("-")) {
     throw new Error(
       `Invalid branch name: "${branchName}". Branch names cannot start with a dash.`,
@@ -58,8 +59,9 @@ export function validateBranchName(branchName: string): void {
     );
   }
 
-  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/period
-  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$/;
+  // Strict whitelist pattern: alphanumeric start (including Unicode), then alphanumeric/slash/hyphen/underscore/period
+  // Using \p{L} for Unicode letters and \p{N} for Unicode numbers
+  const validPattern = /^\p{L}\p{L}*[\p{L}\p{N}/._-]*$/u;
 
   if (!validPattern.test(branchName)) {
     throw new Error(

--- a/src/github/validation/permissions.ts
+++ b/src/github/validation/permissions.ts
@@ -43,9 +43,10 @@ export async function checkWritePermissions(
       }
     }
 
-    // Check if the actor is a GitHub App (bot user)
-    if (actor.endsWith("[bot]")) {
-      core.info(`Actor is a GitHub App: ${actor}`);
+    // Check if the actor is a GitHub App (bot user) or known service account
+    // Copilot is not a regular user but has write access via GitHub App
+    if (actor.endsWith("[bot]") || actor === "Copilot") {
+      core.info(`Actor is a GitHub App or known service: ${actor}`);
       return true;
     }
 


### PR DESCRIPTION
## Summary

This PR adds multiple fixes for branch validation and permission checking:

### 1. Unicode Branch Names (#1020)
- Allows branch names with Unicode characters (e.g., Japanese like `機能/fix`)
- Uses Unicode property escapes (`\p{L}` for letters, `\p{N}` for numbers)

### 2. Azure DevOps # Character (#1024)
- Allows `#` in branch names for Azure DevOps ticket linking
- Azure DevOps uses `#` for ticket linking (e.g., `feature/AB#1992-sentry`)

### 3. Shell Comment Stripping (#1019)
- Strips lines starting with `#` before parsing `claude_args`
- Allows users to add documentation comments without breaking flags

### 4. Copilot Permission Check (#1018)
- Adds `Copilot` to the bypass list for permission checking
- Copilot-initiated workflows return 404 for user permission lookup

## Changes

- Modified `validPattern` regex for Unicode and # support
- Added comment stripping in `parseClaudeArgsToExtraArgs()`
- Added `Copilot` check alongside `[bot]` accounts

## Related

Fixes #1020, Fixes #1024, Fixes #1019, Fixes #1018