### PR TITLE
fix: strip shell comments before parsing claude_args

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -24,6 +24,19 @@ const ACCUMULATING_FLAGS = new Set([
 // Delimiter used to join accumulated flag values
 const ACCUMULATE_DELIMITER = "\x00";
 
+/**
+ * Strip shell-style comments from input before parsing.
+ * Shell-quote treats # as a comment character, swallowing all content after it.
+ * This function removes lines that start with # (after trimming) to prevent
+ * flags after comments from being swallowed.
+ */
+function stripShellComments(input: string): string {
+  return input
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("#"))
+    .join("\n");
+}
+
 type McpConfig = {
   mcpServers?: Record<string, unknown>;
 };
@@ -91,8 +104,11 @@ function parseClaudeArgsToExtraArgs(
 ): Record<string, string | null> {
   if (!claudeArgs?.trim()) return {};
 
+  // Strip shell comments before parsing to prevent # from swallowing subsequent flags
+  const strippedArgs = stripShellComments(claudeArgs);
+
   const result: Record<string, string | null> = {};
-  const args = parseShellArgs(claudeArgs).filter(
+  const args = parseShellArgs(strippedArgs).filter(
     (arg): arg is string => typeof arg === "string",
   );
 


### PR DESCRIPTION
## Summary

Prevents `#` characters in `claude_args` from swallowing subsequent flags. The `shell-quote` library treats `#` as a shell comment character, which breaks configurations where users add explanatory comments.

## Problem

When users include shell-style comments in their `claude_args`, all content after `#` is swallowed, including subsequent flags:

```yaml
claude_args: |
  --model 'claude-haiku-4-5'
  # This is a comment
  --allowed-tools 'mcp__github_inline_comment__create_inline_comment'
```

The `--allowed-tools` flag is never parsed because `shell-quote` treats everything after `#` as a comment.

## Solution

Strip shell-style comment lines (lines starting with `#` after trimming) before parsing with `shell-quote`:

```typescript
function stripShellComments(input: string): string {
  return input
    .split("\n")
    .filter((line) => !line.trim().startsWith("#"))
    .join("\n");
}
```

## Fixes

Fixes #802