### PR TITLE
Strip OIDC token request env vars from Claude session environment

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -209,6 +209,14 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
 
   // Build custom environment
   const env: Record<string, string | undefined> = { ...process.env };
+
+  // Strip sensitive GitHub Actions OIDC and runtime token variables.
+  // These allow minting new OIDC tokens and should never be accessible
+  // to the Claude session. See: https://github.com/anthropics/claude-code-action/issues/1010
+  delete env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  delete env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+  delete env.ACTIONS_RUNTIME_TOKEN;
+
   if (process.env.INPUT_ACTION_INPUTS_PRESENT) {
     env.GITHUB_ACTION_INPUTS = process.env.INPUT_ACTION_INPUTS_PRESENT;
   }

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -366,5 +366,28 @@ describe("parseSdkOptions", () => {
         "claude-code-github-action",
       );
     });
+
+    test("should strip OIDC token request env vars from sdkOptions.env", () => {
+      const originalEnv = { ...process.env };
+      process.env.ACTIONS_ID_TOKEN_REQUEST_URL =
+        "https://vstoken.actions.githubusercontent.com/.well-known/openid-configuration";
+      process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = "secret-oidc-token";
+      process.env.ACTIONS_RUNTIME_TOKEN = "secret-runtime-token";
+
+      try {
+        const options: ClaudeOptions = {};
+        const result = parseSdkOptions(options);
+
+        expect(
+          result.sdkOptions.env?.ACTIONS_ID_TOKEN_REQUEST_URL,
+        ).toBeUndefined();
+        expect(
+          result.sdkOptions.env?.ACTIONS_ID_TOKEN_REQUEST_TOKEN,
+        ).toBeUndefined();
+        expect(result.sdkOptions.env?.ACTIONS_RUNTIME_TOKEN).toBeUndefined();
+      } finally {
+        process.env = originalEnv;
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1010

The Claude session environment is built by spreading `process.env` in `parseSdkOptions()` (`base-action/src/parse-sdk-options.ts`). When the workflow has `id-token: write` permission, this includes:

- `ACTIONS_ID_TOKEN_REQUEST_URL` — the GitHub OIDC token endpoint
- `ACTIONS_ID_TOKEN_REQUEST_TOKEN` — the bearer token to call that endpoint
- `ACTIONS_RUNTIME_TOKEN` — the Actions runtime authentication token

These variables allow the Claude session to mint arbitrary OIDC tokens, which can be exchanged for credentials to cloud providers (AWS, GCP, Azure) configured to trust the repository's OIDC identity. This is a privilege escalation — the `id-token: write` permission is intended for the action's own authentication (in `src/github/token.ts`), not for the Claude session.

## Changes

- **`base-action/src/parse-sdk-options.ts`**: Delete `ACTIONS_ID_TOKEN_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, and `ACTIONS_RUNTIME_TOKEN` from the env object after spreading `process.env`, before passing it to the SDK.
- **`base-action/test/parse-sdk-options.test.ts`**: Add test verifying these variables are stripped from `sdkOptions.env`.

## Test plan

- [ ] Existing tests pass (no env vars relied on these being present in the Claude session)
- [ ] New test confirms all three variables are stripped from `sdkOptions.env` even when set in `process.env`
- [ ] Workflows using OIDC auth (Bedrock, Vertex, Foundry) continue to work — the action's own token exchange in `token.ts` reads from `process.env` directly, before `parseSdkOptions()` is called