### PR TITLE
fix: handle 404 errors in checkWritePermissions for non-user actors

### DIFF
--- a/src/github/validation/permissions.ts
+++ b/src/github/validation/permissions.ts
@@ -66,7 +66,18 @@ export async function checkWritePermissions(
       core.warning(`Actor has insufficient permissions: ${permissionLevel}`);
       return false;
     }
-  } catch (error) {
+  } catch (error: any) {
+    // Handle 404 errors for non-user actors (e.g., "Copilot")
+    // The collaborator permission API returns 404 when the actor is not a
+    // regular GitHub user. These are GitHub system actors that inherently
+    // operate with the permissions granted by the workflow configuration.
+    if (error?.status === 404) {
+      core.info(
+        `Actor "${actor}" is not a GitHub user (received 404). Treating as a non-user actor and allowing.`,
+      );
+      return true;
+    }
+
     core.error(`Failed to check permissions: ${error}`);
     throw new Error(`Failed to check permissions for ${actor}: ${error}`);
   }

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -140,7 +140,53 @@ describe("checkWritePermissions", () => {
     expect(result).toBe(true);
   });
 
-  test("should throw error when permission check fails", async () => {
+  test("should return true when API returns 404 for non-user actor", async () => {
+    const httpError = Object.assign(
+      new Error("Copilot is not a user"),
+      { status: 404 },
+    );
+    const mockOctokit = {
+      repos: {
+        getCollaboratorPermissionLevel: async () => {
+          throw httpError;
+        },
+      },
+    } as any;
+    const context = createContext();
+    context.actor = "Copilot";
+
+    const result = await checkWritePermissions(mockOctokit, context);
+
+    expect(result).toBe(true);
+    expect(coreInfoSpy).toHaveBeenCalledWith(
+      'Actor "Copilot" is not a GitHub user (received 404). Treating as a non-user actor and allowing.',
+    );
+  });
+
+  test("should return true when API returns 404 for any non-user actor name", async () => {
+    const httpError = Object.assign(
+      new Error("some-service is not a user"),
+      { status: 404 },
+    );
+    const mockOctokit = {
+      repos: {
+        getCollaboratorPermissionLevel: async () => {
+          throw httpError;
+        },
+      },
+    } as any;
+    const context = createContext();
+    context.actor = "some-service";
+
+    const result = await checkWritePermissions(mockOctokit, context);
+
+    expect(result).toBe(true);
+    expect(coreInfoSpy).toHaveBeenCalledWith(
+      'Actor "some-service" is not a GitHub user (received 404). Treating as a non-user actor and allowing.',
+    );
+  });
+
+  test("should throw error when permission check fails with non-404 error", async () => {
     const error = new Error("API error");
     const mockOctokit = {
       repos: {
@@ -158,6 +204,27 @@ describe("checkWritePermissions", () => {
     expect(coreErrorSpy).toHaveBeenCalledWith(
       "Failed to check permissions: Error: API error",
     );
+  });
+
+  test("should throw error for 500 server errors", async () => {
+    const httpError = Object.assign(
+      new Error("Internal Server Error"),
+      { status: 500 },
+    );
+    const mockOctokit = {
+      repos: {
+        getCollaboratorPermissionLevel: async () => {
+          throw httpError;
+        },
+      },
+    } as any;
+    const context = createContext();
+
+    await expect(checkWritePermissions(mockOctokit, context)).rejects.toThrow(
+      "Failed to check permissions for test-user",
+    );
+
+    expect(coreErrorSpy).toHaveBeenCalled();
   });
 
   test("should call API with correct parameters", async () => {


### PR DESCRIPTION
## Summary

Fixes #1018

`checkWritePermissions` calls `octokit.repos.getCollaboratorPermissionLevel()` with `github.actor` as the username. When the actor is a non-user entity like `Copilot` (from a Copilot-initiated `pull_request_review`), this API returns a 404 because `Copilot` is not a regular GitHub user.

The existing bot bypass only checks for actors ending in `[bot]`, but `Copilot` does not follow that naming convention.

### Changes

- **`src/github/validation/permissions.ts`**: Added 404 error handling in the `catch` block. When the collaborator permissions API returns a 404 (indicating the actor is not a GitHub user), the function now logs an informational message and returns `true` instead of throwing. Non-404 errors continue to throw as before.

- **`test/permissions.test.ts`**: Added 4 new test cases:
  - 404 from API for `Copilot` actor returns `true`
  - 404 from API for any non-user actor name returns `true`
  - Non-404 errors (e.g., generic `Error`) still throw
  - 500 server errors still throw

### Why this approach

Rather than maintaining a hardcoded list of non-user actor names (which would need updating as GitHub adds new system actors), this fix catches the 404 response that GitHub already returns when an actor is not a user. This is robust against future non-user actors being added by GitHub.

This is consistent with how other parts of the codebase handle 404s from GitHub APIs (e.g., `branch-cleanup.ts`, `update-claude-comment.ts`).

## Test plan

- [x] All 17 permissions tests pass (including 4 new ones)
- [x] Full test suite passes (19 pre-existing Windows-specific failures unrelated to this change)
- [ ] Verify with a Copilot-triggered `pull_request_review` workflow