### PR TITLE
fix: allow '#' in branch names for Azure DevOps integration

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -28,14 +28,14 @@ function extractFirstLabel(githubData: FetchDataResult): string | undefined {
  *
  * Valid branch names:
  * - Start with alphanumeric character (not dash, to prevent option injection)
- * - Contain only alphanumeric, forward slash, hyphen, underscore, or period
+ * - Contain only alphanumeric, forward slash, hyphen, underscore, hash, or period
  * - Do not start or end with a period
  * - Do not end with a slash
  * - Do not contain '..' (path traversal)
  * - Do not contain '//' (consecutive slashes)
  * - Do not end with '.lock'
  * - Do not contain '@{'
- * - Do not contain control characters or special git characters (~^:?*[\])
+ * - Do not contain control characters or special git characters (~^:?*[\\])
  */
 export function validateBranchName(branchName: string): void {
   // Check for empty or whitespace-only names
@@ -58,12 +58,12 @@ export function validateBranchName(branchName: string): void {
     );
   }
 
-  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/period
-  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$/;
+  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/hash/period
+  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_#.-]*$/;
 
   if (!validPattern.test(branchName)) {
     throw new Error(
-      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, or periods.`,
+      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, hashes, or periods.`,
     );
   }
 

--- a/test/validate-branch-name.test.ts
+++ b/test/validate-branch-name.test.ts
@@ -29,6 +29,14 @@ describe("validateBranchName", () => {
       expect(() => validateBranchName("release.1.2.3")).not.toThrow();
     });
 
+    it("should accept names with hash characters (Azure DevOps work items)", () => {
+      expect(() =>
+        validateBranchName("feature/AB#1992-sentry-enhancements"),
+      ).not.toThrow();
+      expect(() => validateBranchName("fix/PROJ#123-bug")).not.toThrow();
+      expect(() => validateBranchName("user/task#42")).not.toThrow();
+    });
+
     it("should accept typical branch name formats", () => {
       expect(() =>
         validateBranchName("claude/issue-123-20250101-1234"),


### PR DESCRIPTION
## Summary

- Fixes branch name validation rejecting the `#` character, which breaks Azure DevOps integration where branch names commonly include work item references (e.g., `feature/AB#1992-sentry-enhancements`)
- Updates the whitelist regex pattern from `[a-zA-Z0-9/_.-]` to `[a-zA-Z0-9/_#.-]`
- Adds test cases covering branch names with `#` characters

## Details

The `#` character is valid in git branch names and poses no command injection risk (it's a comment character in shell but `execFileSync` is used, which bypasses shell interpretation). Azure DevOps automatically creates branch names containing `#` when linking branches to work items.

**Changed files:**
- `src/github/operations/branch.ts` — Added `#` to the valid character whitelist pattern and updated comments/error message
- `test/validate-branch-name.test.ts` — Added test case for hash-containing branch names

Fixes #1024

## Test plan

- [x] All 31 existing + new branch validation tests pass (`bun test test/validate-branch-name.test.ts`)
- [x] New test covers Azure DevOps-style branch names: `feature/AB#1992-sentry-enhancements`, `fix/PROJ#123-bug`, `user/task#42`
- [x] No other validation rules were modified — all security checks (command injection, option injection, path traversal) remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>