### PR TITLE
fix: respect --allowedTools when building disallowed tools list

### DIFF
--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "fs/promises";
 import { prepareMcpConfig } from "../../mcp/install-mcp-server";
 import { parseAllowedTools } from "./parse-tools";
+import { buildDisallowedToolsString } from "../../create-prompt";
 import {
   configureGitAuth,
   setupSshSigning,
@@ -116,6 +117,14 @@ export async function prepareAgentMode({
   if (ourConfig.mcpServers && Object.keys(ourConfig.mcpServers).length > 0) {
     const escapedOurConfig = ourMcpConfig.replace(/'/g, "'\\''");
     claudeArgs = `--mcp-config '${escapedOurConfig}'`;
+  }
+
+  // Disable WebSearch and WebFetch by default for security, but respect
+  // user's --allowedTools from claude_args (e.g., --allowedTools WebSearch
+  // removes WebSearch from the disallowed list)
+  const disallowedTools = buildDisallowedToolsString([], allowedTools);
+  if (disallowedTools) {
+    claudeArgs = `${claudeArgs} --disallowedTools "${disallowedTools}"`;
   }
 
   // Append user's claude_args (which may have more --mcp-config flags)

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -84,8 +84,11 @@ describe("Agent Mode", () => {
       githubToken: "test-token",
     });
 
-    // Verify claude_args includes user args (no MCP config in agent mode without allowed tools)
-    expect(result.claudeArgs).toBe("--model claude-sonnet-4 --max-turns 10");
+    // Verify claude_args includes disallowed tools and user args
+    expect(result.claudeArgs).toContain("--disallowedTools");
+    expect(result.claudeArgs).toContain("WebSearch");
+    expect(result.claudeArgs).toContain("WebFetch");
+    expect(result.claudeArgs).toContain("--model claude-sonnet-4 --max-turns 10");
     expect(result.claudeArgs).not.toContain("--mcp-config");
 
     // Verify return structure - should use "main" as fallback when no env vars set
@@ -97,7 +100,7 @@ describe("Agent Mode", () => {
         claudeBranch: undefined,
       },
       mcpConfig: expect.any(String),
-      claudeArgs: "--model claude-sonnet-4 --max-turns 10",
+      claudeArgs: expect.stringContaining("--disallowedTools"),
     });
 
     // Clean up
@@ -202,5 +205,104 @@ describe("Agent Mode", () => {
     // should not include any MCP config
     // Should be empty or just whitespace when no MCP servers are included
     expect(result.claudeArgs).not.toContain("--mcp-config");
+  });
+
+
+  test("--allowedTools WebSearch removes WebSearch from disallowed list", async () => {
+    const context = createMockAutomationContext({
+      eventName: "workflow_dispatch",
+    });
+
+    const originalHeadRef = process.env.GITHUB_HEAD_REF;
+    const originalRefName = process.env.GITHUB_REF_NAME;
+    delete process.env.GITHUB_HEAD_REF;
+    delete process.env.GITHUB_REF_NAME;
+
+    // Set CLAUDE_ARGS with --allowedTools WebSearch
+    process.env.CLAUDE_ARGS = '--allowedTools "WebSearch"';
+
+    const mockOctokit = {
+      rest: {
+        users: {
+          getAuthenticated: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345, type: "User" },
+            }),
+          ),
+          getByUsername: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345, type: "User" },
+            }),
+          ),
+        },
+      },
+    } as any;
+
+    const result = await prepareAgentMode({
+      context,
+      octokit: mockOctokit,
+      githubToken: "test-token",
+    });
+
+    // WebSearch should NOT be in disallowed tools since user explicitly allowed it
+    // WebFetch should still be disallowed
+    expect(result.claudeArgs).toContain("--disallowedTools");
+    expect(result.claudeArgs).not.toMatch(/--disallowedTools[^"]*WebSearch/);
+    expect(result.claudeArgs).toContain("WebFetch");
+
+    // Clean up
+    delete process.env.CLAUDE_ARGS;
+    if (originalHeadRef !== undefined)
+      process.env.GITHUB_HEAD_REF = originalHeadRef;
+    if (originalRefName !== undefined)
+      process.env.GITHUB_REF_NAME = originalRefName;
+  });
+
+  test("--allowedTools WebSearch,WebFetch removes both from disallowed list", async () => {
+    const context = createMockAutomationContext({
+      eventName: "workflow_dispatch",
+    });
+
+    const originalHeadRef = process.env.GITHUB_HEAD_REF;
+    const originalRefName = process.env.GITHUB_REF_NAME;
+    delete process.env.GITHUB_HEAD_REF;
+    delete process.env.GITHUB_REF_NAME;
+
+    // Set CLAUDE_ARGS with both tools allowed
+    process.env.CLAUDE_ARGS = '--allowedTools "WebSearch,WebFetch"';
+
+    const mockOctokit = {
+      rest: {
+        users: {
+          getAuthenticated: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345, type: "User" },
+            }),
+          ),
+          getByUsername: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345, type: "User" },
+            }),
+          ),
+        },
+      },
+    } as any;
+
+    const result = await prepareAgentMode({
+      context,
+      octokit: mockOctokit,
+      githubToken: "test-token",
+    });
+
+    // Neither WebSearch nor WebFetch should be in disallowed tools
+    // So --disallowedTools should not be present at all
+    expect(result.claudeArgs).not.toContain("--disallowedTools");
+
+    // Clean up
+    delete process.env.CLAUDE_ARGS;
+    if (originalHeadRef !== undefined)
+      process.env.GITHUB_HEAD_REF = originalHeadRef;
+    if (originalRefName !== undefined)
+      process.env.GITHUB_REF_NAME = originalRefName;
   });
 });


### PR DESCRIPTION
## Summary

Fixes #690

- In agent mode, `WebSearch` and `WebFetch` were not being explicitly disabled via `--disallowedTools`, inconsistent with tag mode's security behavior
- When users specified `--allowedTools WebSearch` in `claude_args`, it had no effect on the disallowed tools list because `buildDisallowedToolsString()` was never called in agent mode
- This PR calls `buildDisallowedToolsString([], allowedTools)` in `prepareAgentMode()` so that WebSearch/WebFetch are disabled by default, but respected when the user explicitly allows them

## Changes

- **`src/modes/agent/index.ts`**: Import and call `buildDisallowedToolsString()` with the parsed `allowedTools` from `claude_args`, adding `--disallowedTools` to `claudeArgs` when tools need to be disabled
- **`test/modes/agent.test.ts`**: Updated existing test and added two new tests:
  - `--allowedTools WebSearch` removes only WebSearch from the disallowed list (WebFetch remains)
  - `--allowedTools WebSearch,WebFetch` removes both, resulting in no `--disallowedTools` flag

## Test plan

- [x] Existing agent mode tests updated and passing
- [x] New test: `--allowedTools WebSearch` removes WebSearch from disallowed list
- [x] New test: `--allowedTools WebSearch,WebFetch` removes both from disallowed list
- [x] All 62 tests across agent, parse-tools, and create-prompt test files pass
- [ ] Manual verification: deploy with `claude_args: '--allowedTools "WebSearch"'` and confirm WebSearch is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>