### PR TITLE
fix: use correct fallback type for reviewData in fetcher

### DIFF
--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -299,7 +299,7 @@ export async function fetchGitHubData({
           includeCommentsByActor,
           excludeCommentsByActor,
         );
-        reviewData = pullRequest.reviews || [];
+        reviewData = pullRequest.reviews || { nodes: [] };
 
         console.log(`Successfully fetched PR #${prNumber} data`);
       } else {


### PR DESCRIPTION
## Summary

- **Bug**: `reviewData` is typed as `{ nodes: GitHubReview[] } | null` but the fallback on line 302 was `[]` (a plain array), causing a type mismatch when `pullRequest.reviews` is nullish
- **Impact**: When `pullRequest.reviews` is null/undefined, `reviewData.nodes` returns `undefined` instead of `[]`, breaking downstream iteration in `filterReviewsToTriggerTime` and `filterCommentsByActor`
- **Fix**: Change fallback from `[]` to `{ nodes: [] }` to match the declared type

## Test plan

- [x] `bun run typecheck` passes cleanly
- [x] All `data-fetcher.test.ts` tests pass
- [x] Change is a single-line fix with no behavioral change when `pullRequest.reviews` is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)