### PR TITLE
fix: skip retries for non-retryable errors in file operations

### DIFF
--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -8,7 +8,7 @@ import { resolve } from "path";
 import { constants } from "fs";
 import fetch from "node-fetch";
 import { GITHUB_API_URL } from "../github/api/config";
-import { retryWithBackoff } from "../utils/retry";
+import { retryWithBackoff, NonRetryableError } from "../utils/retry";
 import { validatePathWithinRepo } from "./path-validation";
 
 type GitHubRef = {
@@ -399,14 +399,11 @@ server.tool(
               throw permissionError;
             }
 
-            // For other errors, use the original message
+            // For non-403 errors, fail immediately without retry
             const error = new Error(
               `Failed to update reference: ${updateRefResponse.status} - ${errorText}`,
             );
-
-            // For non-403 errors, fail immediately without retry
-            console.error("Non-retryable error:", updateRefResponse.status);
-            throw error;
+            throw new NonRetryableError(error.message, error);
           }
         },
         {
@@ -615,14 +612,11 @@ server.tool(
               throw permissionError;
             }
 
-            // For other errors, use the original message
+            // For non-403 errors, fail immediately without retry
             const error = new Error(
               `Failed to update reference: ${updateRefResponse.status} - ${errorText}`,
             );
-
-            // For non-403 errors, fail immediately without retry
-            console.error("Non-retryable error:", updateRefResponse.status);
-            throw error;
+            throw new NonRetryableError(error.message, error);
           }
         },
         {

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -5,6 +5,21 @@ export type RetryOptions = {
   backoffFactor?: number;
 };
 
+/**
+ * Error class for errors that should not be retried.
+ * When thrown inside a retryWithBackoff operation, the retry loop
+ * will immediately rethrow without further attempts.
+ */
+export class NonRetryableError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: Error,
+  ) {
+    super(message);
+    this.name = "NonRetryableError";
+  }
+}
+
 export async function retryWithBackoff<T>(
   operation: () => Promise<T>,
   options: RetryOptions = {},
@@ -24,6 +39,11 @@ export async function retryWithBackoff<T>(
       console.log(`Attempt ${attempt} of ${maxAttempts}...`);
       return await operation();
     } catch (error) {
+      // Non-retryable errors should fail immediately without further retries
+      if (error instanceof NonRetryableError) {
+        throw error.cause ?? error;
+      }
+
       lastError = error instanceof Error ? error : new Error(String(error));
       console.error(`Attempt ${attempt} failed:`, lastError.message);
 


### PR DESCRIPTION
## Summary

- **Bug**: In `github-file-ops-server.ts`, both `commit_files` and `delete_files` wrap their reference-update calls in `retryWithBackoff`. The code has comments saying "For non-403 errors, fail immediately without retry", but `retryWithBackoff` in `retry.ts` catches ALL thrown errors and retries them indiscriminately. This means 404, 422, and 500 errors are needlessly retried 3 times with exponential backoff, wasting up to ~7 seconds.
- **Fix**: Add a `NonRetryableError` class to `src/utils/retry.ts` that `retryWithBackoff` checks before retrying. In `github-file-ops-server.ts`, non-403 errors now throw `NonRetryableError`, which `retryWithBackoff` recognizes and rethrows immediately (unwrapping to the original error).

### Changes

1. **`src/utils/retry.ts`**: Added `NonRetryableError` class. Updated `retryWithBackoff` to check for `NonRetryableError` before retrying — if caught, it rethrows the wrapped cause immediately.
2. **`src/mcp/github-file-ops-server.ts`**: Updated both `commit_files` and `delete_files` to throw `NonRetryableError` for non-403 errors instead of a plain `Error`.

## Test plan

- [x] TypeScript type checking passes (`bun run typecheck`)
- [x] All existing tests pass (19 pre-existing failures on Windows unrelated to this change)
- [x] Prettier formatting passes on modified files
- [ ] Verify 403 errors are still retried (behavior unchanged — they throw plain `Error`)
- [ ] Verify non-403 errors (404, 422, 500) fail immediately without retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)