### PR TITLE
fix(validate-env): add IRSA and EKS Pod Identity support for Bedrock …

### DIFF
--- a/base-action/src/validate-env.ts
+++ b/base-action/src/validate-env.ts
@@ -36,13 +36,40 @@ export function validateEnvironmentVariables() {
       errors.push("AWS_REGION is required when using AWS Bedrock.");
     }
 
-    // Either bearer token OR access key credentials must be provided
+    // IRSA (IAM Roles for Service Accounts) — requires both vars together
+    const awsWebIdentityTokenFile = process.env.AWS_WEB_IDENTITY_TOKEN_FILE;
+    const awsRoleArn = process.env.AWS_ROLE_ARN;
+
+    // EKS Pod Identity — requires both vars together
+    const awsContainerCredentialsFullUri = process.env.AWS_CONTAINER_CREDENTIALS_FULL_URI;
+    const awsContainerAuthorizationTokenFile = process.env.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE;
+
     const hasAccessKeyCredentials = awsAccessKeyId && awsSecretAccessKey;
     const hasBearerToken = awsBearerToken;
+    const hasIRSA = !!(awsWebIdentityTokenFile && awsRoleArn);
+    const hasPodIdentity = !!(awsContainerCredentialsFullUri && awsContainerAuthorizationTokenFile);
 
-    if (!hasAccessKeyCredentials && !hasBearerToken) {
+    // Warn on incomplete IRSA configuration
+    if (!!(awsWebIdentityTokenFile || awsRoleArn) && !hasIRSA) {
       errors.push(
-        "Either AWS_BEARER_TOKEN_BEDROCK or both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required when using AWS Bedrock.",
+        "Incomplete IRSA configuration: both AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN must be set together.",
+      );
+    }
+
+    // Warn on incomplete EKS Pod Identity configuration
+    if (!!(awsContainerCredentialsFullUri || awsContainerAuthorizationTokenFile) && !hasPodIdentity) {
+      errors.push(
+        "Incomplete EKS Pod Identity configuration: both AWS_CONTAINER_CREDENTIALS_FULL_URI and AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE must be set together.",
+      );
+    }
+
+    if (!hasAccessKeyCredentials && !hasBearerToken && !hasIRSA && !hasPodIdentity) {
+      errors.push(
+        "No valid AWS credentials found for Bedrock. Please provide one of the following:\n" +
+        "  1. Static credentials:   AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY\n" +
+        "  2. Bedrock bearer token: AWS_BEARER_TOKEN_BEDROCK\n" +
+        "  3. IRSA:                 AWS_WEB_IDENTITY_TOKEN_FILE + AWS_ROLE_ARN\n" +
+        "  4. EKS Pod Identity:     AWS_CONTAINER_CREDENTIALS_FULL_URI + AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
       );
     }
   } else if (useVertex) {


### PR DESCRIPTION
## Summary

This PR fixes a security gap in `validate-env.ts` where Bedrock authentication only accepted static long-lived IAM user credentials, making it incompatible with recommended AWS security practices for containerized workloads (EKS, GitHub Actions OIDC, etc.).

## Problem

The existing validation required either:
- `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (long-lived IAM user keys), or
- `AWS_BEARER_TOKEN_BEDROCK` (static bearer token)

This forced users running Claude Code in EKS or GitHub Actions to create IAM users with long-lived credentials — which violates AWS best practices and introduces unnecessary security risk (credential leakage, no automatic rotation, no expiry).

The AWS SDK already supports temporary credentials via its credential provider chain, but the hard validation failure prevented it from ever being reached.

## Changes

- Added support for **IRSA** (IAM Roles for Service Accounts) via `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN`
- Added support for **EKS Pod Identity** via `AWS_CONTAINER_CREDENTIALS_FULL_URI` + `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`
- Added validation that detects and errors on **partial configuration** of either mechanism (e.g. only one of a required pair set)
- Improved the fallback error message to clearly list all 4 supported auth methods

## Security Impact

Users can now authenticate using short-lived, automatically rotated credentials via IAM Roles — no IAM users or long-lived keys required. This aligns with [AWS security best practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html) for containerized workloads.

## Supported Auth Methods (after this PR)

| Method | Environment Variables |
|---|---|
| Static IAM credentials | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |
| Bedrock bearer token | `AWS_BEARER_TOKEN_BEDROCK` |
| IRSA | `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` |
| EKS Pod Identity | `AWS_CONTAINER_CREDENTIALS_FULL_URI` + `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` |