### PR TITLE
fix: truncate step summary to stay under GitHub's 1024k limit

### DIFF
--- a/src/entrypoints/format-turns.ts
+++ b/src/entrypoints/format-turns.ts
@@ -412,6 +412,46 @@ export function formatGroupedContent(groupedContent: GroupedContent[]): string {
   return markdown;
 }
 
+// GitHub's hard limit for $GITHUB_STEP_SUMMARY content.
+// Using 1000k instead of 1024k to leave headroom for any existing content
+// that may have been appended by earlier steps in the same job.
+const STEP_SUMMARY_MAX_BYTES = 1000 * 1024;
+
+/**
+ * Truncate markdown to fit within GitHub's step summary size limit (1024k).
+ * Cuts at the last complete section boundary (---) before the limit,
+ * then appends a truncation notice.
+ */
+export function truncateStepSummary(
+  markdown: string,
+  maxBytes: number = STEP_SUMMARY_MAX_BYTES,
+): string {
+  const encoded = new TextEncoder().encode(markdown);
+  if (encoded.byteLength <= maxBytes) {
+    return markdown;
+  }
+
+  const truncationNotice =
+    "\n\n---\n\n" +
+    "> **Note:** This report was truncated to fit within GitHub's step summary size limit (1024k).\n" +
+    "> To disable the report entirely, set `display_report: false` in your workflow.\n";
+
+  const noticeBytes = new TextEncoder().encode(truncationNotice).byteLength;
+  const budget = maxBytes - noticeBytes;
+
+  // Decode back to string at the byte budget boundary
+  const truncated = new TextDecoder().decode(encoded.slice(0, budget));
+
+  // Find the last section separator to cut at a clean boundary
+  const lastSeparator = truncated.lastIndexOf("\n---\n");
+  const cutPoint =
+    lastSeparator > truncated.length * 0.5
+      ? lastSeparator
+      : truncated.length;
+
+  return truncated.substring(0, cutPoint) + truncationNotice;
+}
+
 export function formatTurnsFromData(data: Turn[]): string {
   // Group turns naturally
   const groupedContent = groupTurnsNaturally(data);

--- a/src/entrypoints/format-turns.ts
+++ b/src/entrypoints/format-turns.ts
@@ -439,8 +439,19 @@ export function truncateStepSummary(
   const noticeBytes = new TextEncoder().encode(truncationNotice).byteLength;
   const budget = maxBytes - noticeBytes;
 
-  // Decode back to string at the byte budget boundary
-  const truncated = new TextDecoder().decode(encoded.slice(0, budget));
+  // If maxBytes is smaller than the notice itself, return just the notice
+  // trimmed to fit (extremely unlikely in practice, but handles the edge case)
+  if (budget <= 0) {
+    return truncationNotice.substring(0, maxBytes);
+  }
+
+  // Decode back to string at the byte budget boundary.
+  // TextDecoder replaces incomplete multi-byte sequences at the boundary with
+  // U+FFFD, so re-verify the encoded size and trim if needed.
+  let truncated = new TextDecoder().decode(encoded.slice(0, budget));
+  while (new TextEncoder().encode(truncated).byteLength > budget && truncated.length > 0) {
+    truncated = truncated.substring(0, truncated.length - 1);
+  }
 
   // Find the last section separator to cut at a clean boundary
   const lastSeparator = truncated.lastIndexOf("\n---\n");

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -23,7 +23,7 @@ import { prepareAgentMode } from "../modes/agent";
 import { checkContainsTrigger } from "../github/validation/trigger";
 import { collectActionInputsPresence } from "./collect-inputs";
 import { updateCommentLink } from "./update-comment-link";
-import { formatTurnsFromData } from "./format-turns";
+import { formatTurnsFromData, truncateStepSummary } from "./format-turns";
 import type { Turn } from "./format-turns";
 // Base-action imports (used directly instead of subprocess)
 import { validateEnvironmentVariables } from "../../base-action/src/validate-env";
@@ -103,7 +103,7 @@ async function writeStepSummary(executionFile: string): Promise<void> {
   try {
     const fileContent = readFileSync(executionFile, "utf-8");
     const data: Turn[] = JSON.parse(fileContent);
-    const markdown = formatTurnsFromData(data);
+    const markdown = truncateStepSummary(formatTurnsFromData(data));
     await appendFile(summaryFile, markdown);
     console.log("Successfully formatted Claude Code report");
   } catch (error) {
@@ -116,7 +116,7 @@ async function writeStepSummary(executionFile: string): Promise<void> {
       fallback += "```json\n";
       fallback += readFileSync(executionFile, "utf-8");
       fallback += "\n```\n";
-      await appendFile(summaryFile, fallback);
+      await appendFile(summaryFile, truncateStepSummary(fallback));
     } catch {
       console.error("Failed to write raw output to step summary");
     }

--- a/test/format-turns.test.ts
+++ b/test/format-turns.test.ts
@@ -8,6 +8,7 @@ import {
   detectContentType,
   formatResultContent,
   formatToolWithResult,
+  truncateStepSummary,
   type Turn,
   type ToolUse,
   type ToolResult,
@@ -414,6 +415,57 @@ describe("formatTurnsFromData", () => {
     expect(result).toContain("### 🔧 `read_file`");
     expect(result).toContain("## ✅ Final Result");
     expect(result).toContain("Done");
+  });
+});
+
+describe("truncateStepSummary", () => {
+  test("returns markdown unchanged when under the limit", () => {
+    const small = "## Report\n\nSome content\n";
+    expect(truncateStepSummary(small, 1024)).toBe(small);
+  });
+
+  test("truncates markdown that exceeds the byte limit", () => {
+    const large = "x".repeat(2000);
+    const result = truncateStepSummary(large, 500);
+    const resultBytes = new TextEncoder().encode(result).byteLength;
+    expect(resultBytes).toBeLessThanOrEqual(500);
+    expect(result).toContain("truncated");
+    expect(result).toContain("display_report");
+  });
+
+  test("cuts at last section separator when possible", () => {
+    // Build content with section separators
+    let content = "## Section 1\n\nContent A\n\n---\n\n";
+    content += "## Section 2\n\nContent B\n\n---\n\n";
+    content += "## Section 3\n\n" + "C".repeat(500);
+
+    // Set limit so it fits section 1+2 but not section 3
+    const section12 = "## Section 1\n\nContent A\n\n---\n\n## Section 2\n\nContent B\n";
+    const limit = new TextEncoder().encode(section12).byteLength + 300;
+
+    const result = truncateStepSummary(content, limit);
+    // Should have cut at the separator after section 2
+    expect(result).toContain("Section 1");
+    expect(result).toContain("Section 2");
+    expect(result).toContain("truncated");
+  });
+
+  test("handles multi-byte characters without corruption", () => {
+    // Unicode content with multi-byte chars
+    const content = "## Report\n\n" + "\u{1F600}".repeat(300) + "\n\n---\n\n" + "end";
+    const result = truncateStepSummary(content, 500);
+    // Should not throw or produce invalid UTF-8
+    expect(result).toContain("Report");
+    expect(result).toContain("truncated");
+    // Verify it's valid UTF-8 by encoding/decoding
+    const roundTrip = new TextDecoder().decode(new TextEncoder().encode(result));
+    expect(roundTrip).toBe(result);
+  });
+
+  test("uses default limit matching GitHub's 1024k constraint", () => {
+    // Just verify the default doesn't throw for small content
+    const small = "## Report\n";
+    expect(truncateStepSummary(small)).toBe(small);
   });
 });
 

--- a/test/format-turns.test.ts
+++ b/test/format-turns.test.ts
@@ -435,18 +435,21 @@ describe("truncateStepSummary", () => {
 
   test("cuts at last section separator when possible", () => {
     // Build content with section separators
-    let content = "## Section 1\n\nContent A\n\n---\n\n";
-    content += "## Section 2\n\nContent B\n\n---\n\n";
-    content += "## Section 3\n\n" + "C".repeat(500);
+    const section1 = "## Section 1\n\nContent A\n\n---\n\n";
+    const section2 = "## Section 2\n\nContent B\n\n---\n\n";
+    const section3 = "## Section 3\n\n" + "C".repeat(500);
+    const content = section1 + section2 + section3;
 
-    // Set limit so it fits section 1+2 but not section 3
-    const section12 = "## Section 1\n\nContent A\n\n---\n\n## Section 2\n\nContent B\n";
-    const limit = new TextEncoder().encode(section12).byteLength + 300;
+    // Set limit so the truncation notice + sections 1+2 fit, but section 3 doesn't.
+    // The notice is ~180 bytes, so we need section1+section2+notice to fit but not section3.
+    const s12Bytes = new TextEncoder().encode(section1 + section2).byteLength;
+    const limit = s12Bytes + 200; // enough for s1+s2+notice, but not s3
 
     const result = truncateStepSummary(content, limit);
-    // Should have cut at the separator after section 2
     expect(result).toContain("Section 1");
     expect(result).toContain("Section 2");
+    expect(result).not.toContain("Section 3");
+    expect(result).not.toContain("C".repeat(50));
     expect(result).toContain("truncated");
   });
 
@@ -462,10 +465,18 @@ describe("truncateStepSummary", () => {
     expect(roundTrip).toBe(result);
   });
 
-  test("uses default limit matching GitHub's 1024k constraint", () => {
-    // Just verify the default doesn't throw for small content
+  test("uses default limit with headroom below GitHub's 1024k constraint", () => {
+    // Default budget is 1000k (leaving 24k headroom for earlier steps)
     const small = "## Report\n";
     expect(truncateStepSummary(small)).toBe(small);
+  });
+
+  test("handles edge case where maxBytes is smaller than truncation notice", () => {
+    const content = "x".repeat(100);
+    // Very small limit that can't even fit the notice
+    const result = truncateStepSummary(content, 50);
+    const resultBytes = new TextEncoder().encode(result).byteLength;
+    expect(resultBytes).toBeLessThanOrEqual(50);
   });
 });
 


### PR DESCRIPTION
long Claude sessions (30+ min, many tool calls) generate step summary markdown that exceeds GitHub's hard 1024k limit for `$GITHUB_STEP_SUMMARY`, causing:

```
$GITHUB_STEP_SUMMARY upload aborted, supports content up to a size of 1024k, got 1026k.
```

the error is non-fatal (Claude's work still succeeds), but it's noisy and prevents viewing the execution summary. users currently have to set `display_report: false` to avoid it entirely, losing the summary for all sessions.

fixes #927

### what changed

added `truncateStepSummary()` in `format-turns.ts` that:

1. checks the markdown's byte size against a 1000k budget (leaves 24k headroom for content from earlier steps in the same job)
2. if over budget, cuts at the last section boundary (`---`) to avoid breaking mid-content
3. appends a truncation notice explaining the limit and pointing to `display_report: false`
4. handles multi-byte characters correctly via `TextEncoder`/`TextDecoder` (no mid-codepoint cuts)

applied in both the formatted report path and the raw JSON fallback path in `writeStepSummary()`.

### tests

5 new tests in `format-turns.test.ts`:

- under-limit content passes through unchanged
- over-limit content is truncated with notice
- cuts at last section separator when one exists in the latter half
- multi-byte characters (emoji) survive without corruption
- default limit matches GitHub's constraint

all 35 tests pass.