### PR TITLE
fix: strip shell comment lines before parsing claude_args

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -80,6 +80,20 @@ function mergeMcpConfigs(configValues: string[]): string {
 }
 
 /**
+ * Strip comment lines from a shell argument string.
+ * Lines whose first non-whitespace character is `#` are removed entirely.
+ * Inline `#` within a line (e.g. inside a quoted value) is left untouched
+ * because shell-quote handles quoting — we only need to remove full comment lines
+ * before shell-quote sees them.
+ */
+function stripShellComments(input: string): string {
+  return input
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("#"))
+    .join("\n");
+}
+
+/**
  * Parse claudeArgs string into extraArgs record for SDK pass-through
  * The SDK/CLI will handle --mcp-config, --json-schema, etc.
  * For allowedTools and disallowedTools, multiple occurrences are accumulated (null-char joined).
@@ -92,7 +106,7 @@ function parseClaudeArgsToExtraArgs(
   if (!claudeArgs?.trim()) return {};
 
   const result: Record<string, string | null> = {};
-  const args = parseShellArgs(claudeArgs).filter(
+  const args = parseShellArgs(stripShellComments(claudeArgs)).filter(
     (arg): arg is string => typeof arg === "string",
   );
 

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -313,6 +313,42 @@ describe("parseSdkOptions", () => {
     });
   });
 
+  describe("shell comment stripping", () => {
+    test("should parse flags before and after a comment line", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--model 'claude-haiku'\n# comment\n--allowed-tools 'Edit'",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-haiku");
+      expect(result.sdkOptions.allowedTools).toEqual(["Edit"]);
+    });
+
+    test("should parse flags correctly when no comments are present", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--model 'claude-haiku'",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-haiku");
+    });
+
+    test("should not strip inline # that appears inside a quoted value", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--model 'claude-haiku' --prompt 'use color #ff0000'",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-haiku");
+      expect(result.sdkOptions.extraArgs?.["prompt"]).toBe(
+        "use color #ff0000",
+      );
+    });
+  });
+
   describe("environment variables passthrough", () => {
     test("should include OTEL environment variables in sdkOptions.env", () => {
       // Set up test environment variables


### PR DESCRIPTION
## Summary

- The `shell-quote` library treats `#` as a shell comment character, causing all content after a `#` (including subsequent flags on new lines) to be silently swallowed
- Users adding documentation comments to their `claude_args` YAML inadvertently break flag parsing
- Fix: strip full comment lines (lines starting with `#`) before passing input to `shell-quote`

### Before
```yaml
claude_args: |
  --model 'claude-haiku-4-5'
  # This is a comment
  --allowed-tools 'mcp__github_inline_comment__create_inline_comment'
```
`--allowed-tools` is silently dropped — shell-quote puts it inside a comment object.

### After
Comment lines are stripped before parsing, so both `--model` and `--allowed-tools` are correctly parsed. Inline `#` within quoted values (e.g., `--prompt 'use color #ff0000'`) is preserved.

### Changes

- `base-action/src/parse-sdk-options.ts`: Add `stripShellComments()` function, apply before `parseShellArgs()`
- `base-action/test/parse-sdk-options.test.ts`: Add 3 test cases covering comments, no comments, and inline `#` in values

## Test plan
- [x] Test: flags before and after comment line are both parsed
- [x] Test: no-comment input still works
- [x] Test: inline `#` in quoted values is NOT stripped
- [ ] Manual test with GitHub Actions workflow using comment-containing `claude_args`

Fixes #802