### PR TITLE
Restore .claude/ and .mcp.json from PR base branch before CLI runs

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -15,13 +15,20 @@ import { setupGitHubToken, WorkflowValidationSkipError } from "../github/token";
 import { checkWritePermissions } from "../github/validation/permissions";
 import { createOctokit } from "../github/api/client";
 import type { Octokits } from "../github/api/client";
-import { parseGitHubContext, isEntityContext } from "../github/context";
+import {
+  parseGitHubContext,
+  isEntityContext,
+  isPullRequestEvent,
+  isPullRequestReviewEvent,
+  isPullRequestReviewCommentEvent,
+} from "../github/context";
 import type { GitHubContext } from "../github/context";
 import { detectMode } from "../modes/detector";
 import { prepareTagMode } from "../modes/tag";
 import { prepareAgentMode } from "../modes/agent";
 import { checkContainsTrigger } from "../github/validation/trigger";
 import { restoreConfigFromBase } from "../github/operations/restore-config";
+import { validateBranchName } from "../github/operations/branch";
 import { collectActionInputsPresence } from "./collect-inputs";
 import { updateCommentLink } from "./update-comment-link";
 import { formatTurnsFromData } from "./format-turns";
@@ -220,8 +227,26 @@ async function run() {
 
     // On PRs, .claude/ and .mcp.json in the checkout are attacker-controlled.
     // Restore them from the base branch before the CLI reads them.
-    if (isEntityContext(context) && context.isPR && baseBranch) {
-      restoreConfigFromBase(baseBranch);
+    //
+    // We read pull_request.base.ref from the payload directly because agent
+    // mode's branchInfo.baseBranch defaults to "main" rather than the PR's
+    // actual target (agent/index.ts). For issue_comment on a PR the payload
+    // lacks base.ref, so we fall back to the mode-provided value — tag mode
+    // fetches it from GraphQL; agent mode on issue_comment is an edge case
+    // that at worst restores from the wrong trusted branch (still secure).
+    if (isEntityContext(context) && context.isPR) {
+      let restoreBase = baseBranch;
+      if (
+        isPullRequestEvent(context) ||
+        isPullRequestReviewEvent(context) ||
+        isPullRequestReviewCommentEvent(context)
+      ) {
+        restoreBase = context.payload.pull_request.base.ref;
+        validateBranchName(restoreBase);
+      }
+      if (restoreBase) {
+        restoreConfigFromBase(restoreBase);
+      }
     }
 
     await setupClaudeCodeSettings(process.env.INPUT_SETTINGS);

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -21,6 +21,7 @@ import { detectMode } from "../modes/detector";
 import { prepareTagMode } from "../modes/tag";
 import { prepareAgentMode } from "../modes/agent";
 import { checkContainsTrigger } from "../github/validation/trigger";
+import { restoreConfigFromBase } from "../github/operations/restore-config";
 import { collectActionInputsPresence } from "./collect-inputs";
 import { updateCommentLink } from "./update-comment-link";
 import { formatTurnsFromData } from "./format-turns";
@@ -216,6 +217,12 @@ async function run() {
     process.env.DETAILED_PERMISSION_MESSAGES = "1";
 
     validateEnvironmentVariables();
+
+    // On PRs, .claude/ and .mcp.json in the checkout are attacker-controlled.
+    // Restore them from the base branch before the CLI reads them.
+    if (isEntityContext(context) && context.isPR && baseBranch) {
+      restoreConfigFromBase(baseBranch);
+    }
 
     await setupClaudeCodeSettings(process.env.INPUT_SETTINGS);
 

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -1,0 +1,65 @@
+import { execFileSync } from "child_process";
+import { rmSync } from "fs";
+
+const SENSITIVE_PATHS = [".claude", ".mcp.json"];
+
+/**
+ * Restores security-sensitive config paths from the PR base branch.
+ *
+ * The CLI's non-interactive mode trusts cwd: it reads `.mcp.json`,
+ * `.claude/settings.json`, and `.claude/settings.local.json` from the working
+ * directory and acts on them before any tool-permission gating — executing
+ * hooks (including SessionStart), setting env vars (NODE_OPTIONS, LD_PRELOAD,
+ * PATH), running apiKeyHelper/awsAuthRefresh shell commands, and auto-approving
+ * MCP servers. When this action checks out a PR head, all of these are
+ * attacker-controlled.
+ *
+ * Rather than enumerate every dangerous key, this replaces the entire `.claude/`
+ * tree and `.mcp.json` with the versions from the PR base branch, which a
+ * maintainer has reviewed and merged. Paths absent on base are deleted.
+ *
+ * Known limitation: if a PR legitimately modifies `.claude/` and the CLI later
+ * commits with `git add -A`, the revert will be included in that commit. This
+ * is a narrow UX tradeoff for closing the RCE surface.
+ *
+ * @param baseBranch - PR base branch name. Must be pre-validated (branch.ts
+ *   calls validateBranchName on it before returning).
+ */
+export function restoreConfigFromBase(baseBranch: string): void {
+  console.log(
+    `Restoring ${SENSITIVE_PATHS.join(", ")} from origin/${baseBranch} (PR head is untrusted)`,
+  );
+
+  // Fetch base first — if this fails we haven't touched the workspace and the
+  // caller sees a clean error.
+  execFileSync("git", ["fetch", "origin", baseBranch, "--depth=1"], {
+    stdio: "inherit",
+  });
+
+  // Delete PR-controlled versions. If the restore below fails for a given path,
+  // that path stays deleted — the safe fallback (no attacker-controlled config).
+  // A bare `git checkout` alone wouldn't remove files the PR added, so nuke first.
+  for (const p of SENSITIVE_PATHS) {
+    rmSync(p, { recursive: true, force: true });
+  }
+
+  for (const p of SENSITIVE_PATHS) {
+    try {
+      execFileSync("git", ["checkout", `origin/${baseBranch}`, "--", p], {
+        stdio: "pipe",
+      });
+    } catch {
+      // Path doesn't exist on base — it stays deleted.
+    }
+  }
+
+  // `git checkout <ref> -- <path>` stages the restored files. Unstage so the
+  // revert doesn't silently leak into commits the CLI makes later.
+  try {
+    execFileSync("git", ["reset", "--", ...SENSITIVE_PATHS], {
+      stdio: "pipe",
+    });
+  } catch {
+    // Nothing was staged, or paths don't exist on HEAD — either is fine.
+  }
+}

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -1,7 +1,21 @@
 import { execFileSync } from "child_process";
 import { rmSync } from "fs";
 
-const SENSITIVE_PATHS = [".claude", ".mcp.json"];
+// Paths that are both PR-controllable and read from cwd at CLI startup.
+//
+// Deliberately excluded from the CLI's broader auto-edit blocklist:
+//   .git/        — not tracked by git; PR commits cannot place files there.
+//                  Restoring it would also undo the PR checkout entirely.
+//   .gitconfig   — git reads ~/.gitconfig and .git/config, never cwd/.gitconfig.
+//   .bashrc etc. — shells source these from $HOME; checkout cannot reach $HOME.
+//   .vscode/.idea— IDE config; nothing in the CLI's startup path reads them.
+const SENSITIVE_PATHS = [
+  ".claude",
+  ".mcp.json",
+  ".claude.json",
+  ".gitmodules",
+  ".ripgreprc",
+];
 
 /**
  * Restores security-sensitive config paths from the PR base branch.


### PR DESCRIPTION
## Problem

The CLI's non-interactive mode trusts the working directory: it reads `.mcp.json`, `.claude/settings.json`, and `.claude/settings.local.json` from cwd and acts on them **before any tool-permission gating**. This includes:

- `hooks` (SessionStart, PreToolUse) — arbitrary shell commands
- `env` — `NODE_OPTIONS`, `LD_PRELOAD`, `PATH`
- `apiKeyHelper` / `awsAuthRefresh` — shell commands for credential fetching
- `.mcp.json` with `enableAllProjectMcpServers` — MCP server init spawns processes

When this action checks out a PR head, all of these files are attacker-controlled. A PR author without write access can achieve RCE in the workflow runner and exfiltrate secrets before the CLI reaches turn 1.

#942 addresses the `.mcp.json` case specifically. This PR addresses the root cause.

## Fix

Before the CLI runs, restore `.claude/` and `.mcp.json` from the PR base branch:

1. `git fetch origin <base> --depth=1`
2. `rm -rf .claude .mcp.json`
3. `git checkout origin/<base> -- .claude .mcp.json` (per path; errors = path absent on base → stays deleted)
4. `git reset -- .claude .mcp.json` (unstage so the revert doesn't leak into CLI commits)

The base branch version is trusted because a maintainer reviewed and merged it. The PR author's delta is discarded. Reviewed config on base still works normally.

| | #942 (file-check) | This PR |
|---|---|---|
| Coverage | `.mcp.json` only | `.claude/` + `.mcp.json` — all startup-executed config |
| TOCTOU | API check races against checkout SHA | Local git, no race |
| Legitimate base config | Disabled when `.mcp.json` touched | Still works — only PR delta neutralized |
| Maintenance | File-pattern list to sync with CLI | One mechanism |

## Scope

- **Only runs on PRs.** Pushes to protected branches, `workflow_dispatch`, etc. are unaffected — workspace is already a trusted ref.
- **`CLAUDE.md` is not covered.** It's prompt injection (gated by tool permissions), not pre-turn-1 RCE.

## Known limitation

If a PR legitimately modifies `.claude/` and the CLI later runs `git add -A`, the revert will be included in that commit. Workaround: merge the config change first with human review, then test. Documented in the function docstring.

## Implementation notes

- `baseBranch` comes from `prData.baseRefName` (GitHub GraphQL) and passes through `validateBranchName()` in `branch.ts` before being returned — blocks option injection (`--upload-pack`), shell metachars, path traversal.
- `execFileSync` with array args throughout — no shell interpolation.
- Fetch happens before `rm`, so fetch failure leaves the workspace untouched.