### PR TITLE
chore: bump setup-bun to v2.2.0 and bun to 1.3.10

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -164,7 +164,7 @@ runs:
   steps:
     - name: Install Bun
       if: inputs.path_to_bun_executable == ''
-      uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # https://github.com/oven-sh/setup-bun/releases/tag/v2.1.2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
       with:
         bun-version: 1.3.6
         token: ${{ inputs.github_token || github.token }}

--- a/action.yml
+++ b/action.yml
@@ -166,7 +166,7 @@ runs:
       if: inputs.path_to_bun_executable == ''
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
       with:
-        bun-version: 1.3.6
+        bun-version: 1.3.10
         token: ${{ inputs.github_token || github.token }}
 
     - name: Setup Custom Bun Path

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -97,7 +97,7 @@ runs:
 
     - name: Install Bun
       if: inputs.path_to_bun_executable == ''
-      uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # https://github.com/oven-sh/setup-bun/releases/tag/v2.1.2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
       with:
         bun-version: 1.3.6
 

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -99,7 +99,7 @@ runs:
       if: inputs.path_to_bun_executable == ''
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
       with:
-        bun-version: 1.3.6
+        bun-version: 1.3.10
 
     - name: Setup Custom Bun Path
       if: inputs.path_to_bun_executable != ''


### PR DESCRIPTION
## Summary
- Bump `oven-sh/setup-bun` from v2.1.2 to v2.2.0 for Node.js 24 support, resolving the Node.js 20 deprecation warning
- Bump `bun-version` from 1.3.6 to 1.3.10

Fixes #1050

## Test plan
- [ ] Verify CI passes with updated setup-bun action
- [ ] Confirm no Node.js 20 deprecation warning in workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)