### PR TITLE
Add Deno CI workflow for linting and testing

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,42 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will install Deno then run `deno lint` and `deno test`.
+# For more information see: https://github.com/denoland/setup-deno
+
+name: Deno
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        # uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31  # v1.1.2
+        with:
+          deno-version: v1.x
+
+      # Uncomment this step to verify the use of 'deno fmt' on each commit.
+      # - name: Verify formatting
+      #   run: deno fmt --check
+
+      - name: Run linter
+        run: deno lint
+
+      - name: Run tests
+        run: deno test -A


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically run Deno linting and tests on every push to main and pull request.

## Key Changes
- Added `.github/workflows/deno.yml` workflow file that:
  - Runs on pushes and pull requests to the `main` branch
  - Sets up Deno v1.x runtime environment
  - Executes `deno lint` to check code style and quality
  - Executes `deno test -A` to run the test suite with all permissions
  - Uses the pinned version of `denoland/setup-deno@v1.1.2` for reproducibility

## Notable Details
- The workflow includes a commented-out step for `deno fmt --check` that can be enabled to enforce code formatting
- Minimal permissions are set (read-only access to repository contents)
- Runs on Ubuntu latest for consistency

https://claude.ai/code/session_01Rh6dNYe4PcLk19k5bS3nB9