### PR TITLE
Remove redundant git status/diff/log from tag mode allowlist

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -56,9 +56,6 @@ export function buildAllowedToolsString(
       "Bash(git add:*)",
       "Bash(git commit:*)",
       `Bash(${GIT_PUSH_WRAPPER}:*)`,
-      "Bash(git status:*)",
-      "Bash(git diff:*)",
-      "Bash(git log:*)",
       "Bash(git rm:*)",
     );
   }

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -139,9 +139,6 @@ export async function prepareTagMode({
       "Bash(git add:*)",
       "Bash(git commit:*)",
       `Bash(${gitPushWrapper}:*)`,
-      "Bash(git status:*)",
-      "Bash(git diff:*)",
-      "Bash(git log:*)",
       "Bash(git rm:*)",
     );
   } else {

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -1017,9 +1017,6 @@ describe("buildAllowedToolsString", () => {
     expect(result).toContain("Bash(git add:*)");
     expect(result).toContain("Bash(git commit:*)");
     expect(result).toContain("scripts/git-push.sh:*)");
-    expect(result).toContain("Bash(git status:*)");
-    expect(result).toContain("Bash(git diff:*)");
-    expect(result).toContain("Bash(git log:*)");
     expect(result).toContain("Bash(git rm:*)");
 
     // Comment tool from minimal server should be included


### PR DESCRIPTION
These three entries are redundant — `git status`, `git diff`, and `git log` are already auto-allowed by the Claude Code CLI's built-in read-only command allowlist. Removing the explicit entries lets the CLI's flag validation apply (the read-only path validates flags, the explicit-allow path doesn't).

No behavior change for the git operations the prompt actually instructs Claude to use (`git status`, `git diff origin/<base>...HEAD`, `git log origin/<base>..HEAD`) — those all pass the read-only validator.