### PR TITLE
fix: use repo default branch instead of hardcoded 'main' in agent mode

### DIFF
--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -1,4 +1,5 @@
 import { mkdir, writeFile } from "fs/promises";
+import * as github from "@actions/github";
 import { prepareMcpConfig } from "../../mcp/install-mcp-server";
 import { parseAllowedTools } from "./parse-tools";
 import {
@@ -85,15 +86,18 @@ export async function prepareAgentMode({
 
   // Check for branch info from environment variables (useful for auto-fix workflows)
   const claudeBranch = process.env.CLAUDE_BRANCH || undefined;
+  const repoDefaultBranch =
+    (github.context.payload.repository as { default_branch?: string })
+      ?.default_branch || "main";
   const baseBranch =
-    process.env.BASE_BRANCH || context.inputs.baseBranch || "main";
+    process.env.BASE_BRANCH || context.inputs.baseBranch || repoDefaultBranch;
 
   // Detect current branch from GitHub environment
   const currentBranch =
     claudeBranch ||
     process.env.GITHUB_HEAD_REF ||
     process.env.GITHUB_REF_NAME ||
-    "main";
+    repoDefaultBranch;
 
   // Get our GitHub MCP servers config
   const ourMcpConfig = await prepareMcpConfig({


### PR DESCRIPTION
\`restoreConfigFromBase\` (added in v1.0.74 via #1066) fetches config
files from the PR base branch as a security measure. In agent mode,
\`baseBranch\` falls back to \`"main"\` when neither \`BASE_BRANCH\` nor
the action's \`baseBranch\` input is set. On repos whose default branch
is \`master\` (or anything else), this causes \`git fetch origin main\`
to fail, which aborts the entire run.

Read the repo's actual default branch from the event payload
(\`repository.default_branch\`) instead of assuming \`"main"\`. The
payload includes this field on every event type GitHub fires.

Fixes #1080