### PR TITLE
fix: force process exit after run() completion to prevent hanging

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -343,5 +343,16 @@ async function run() {
 }
 
 if (import.meta.main) {
-  run();
+  // Workaround: The Claude Agent SDK does not fully clean up child process
+  // streams after the session ends, leaving references in the event loop that
+  // prevent the process from exiting naturally. Force exit once run() settles.
+  // See: https://github.com/anthropics/claude-code-action/issues/865
+  run()
+    .then(() => {
+      process.exit(process.exitCode ?? 0);
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
 }


### PR DESCRIPTION
## Summary

Fixes #865

The action hangs indefinitely after Claude completes its work, running until `timeout-minutes` kills the job. This happens because the Claude Agent SDK does not fully clean up child process streams (stdout/stderr) after the session ends, leaving references in the event loop that prevent the Bun process from exiting naturally.

## Root Cause

`run()` in `src/entrypoints/run.ts` is an async function invoked without awaiting or chaining, so even after the Promise resolves, the process stays alive waiting for the event loop to drain. The SDK's `ProcessTransport.close()` sends SIGTERM to the child process but does not destroy the associated stdio streams, keeping the event loop occupied.

## Fix

Explicitly call `process.exit()` once `run()` settles, using `process.exitCode` to preserve the exit code set by `core.setFailed()`. This is consistent with how `post-buffered-inline-comments.ts` handles its entrypoint.

This is a workaround — the root fix belongs in `@anthropic-ai/claude-agent-sdk`, which should fully release child process stream references during cleanup.

## Changes
- `src/entrypoints/run.ts`: chain `.then()` / `.catch()` on `run()` to call `process.exit()` after completion

## Reproduction

1. Use `claude-code-action@v1` in `workflow_dispatch` or `repository_dispatch` mode (agent mode)
2. Claude completes work successfully (PR created, Jira comment posted, etc.)
3. Process hangs with zero log output until job timeout

Observed in our workflow: Claude finished in ~3 minutes, then hung for ~27 minutes until the 30-minute `timeout-minutes` killed the job. Full logs confirmed `run()` completed (final "Done" summary at `08:31:45`), but the process didn't exit until `08:58:01`.

## Additional Evidence

Reproduced again on 2026-04-10 in a `repository_dispatch` workflow (no MCP servers):

| Time (UTC) | Event |
|---|---|
| ~01:03 | Job starts |
| 01:06:27 | Last log entry — WebFetch tool result received (~3 min of active work) |
| 01:06:27–01:33:37 | **27-minute gap with zero log output** |
| 01:33:37 | `##[error]The operation was canceled.` (30-min `timeout-minutes` hit) |

Orphan processes at cleanup: `pid (2156) (bun)`, `pid (2227) (bun)`