### PR TITLE
fix: prevent restoreConfigFromBase from hanging on repos with submodules

### DIFF
--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -23,13 +23,19 @@ export function ensureProperlyEncodedUrl(url: string): string | null {
     // First, try to parse the URL to see if it's already properly encoded
     new URL(url);
     if (url.includes(" ")) {
-      const [baseUrl, queryString] = url.split("?");
+      const qIndex = url.indexOf("?");
+      const baseUrl = qIndex >= 0 ? url.slice(0, qIndex) : url;
+      const queryString = qIndex >= 0 ? url.slice(qIndex + 1) : "";
       if (queryString) {
         // Parse query parameters and re-encode them properly
         const params = new URLSearchParams();
         const pairs = queryString.split("&");
         for (const pair of pairs) {
-          const [key, value = ""] = pair.split("=");
+          // Split only at the first '=' to preserve '=' in values
+          // e.g. "body=a=b" → key="body", value="a=b"
+          const eqIndex = pair.indexOf("=");
+          const key = eqIndex >= 0 ? pair.slice(0, eqIndex) : pair;
+          const value = eqIndex >= 0 ? pair.slice(eqIndex + 1) : "";
           if (key) {
             // Decode first in case it's partially encoded, then encode properly
             params.set(key, decodeURIComponent(value));

--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -54,9 +54,10 @@ export function ensureProperlyEncodedUrl(url: string): string | null {
       let fixedUrl = url.replace(/ /g, "%20");
 
       // Ensure colons in parameter values are encoded (but not in http:// or after domain)
-      const urlParts = fixedUrl.split("?");
-      if (urlParts.length > 1 && urlParts[1]) {
-        const [baseUrl, queryString] = urlParts;
+      const qIdx = fixedUrl.indexOf("?");
+      if (qIdx >= 0 && fixedUrl.length > qIdx + 1) {
+        const baseUrl = fixedUrl.slice(0, qIdx);
+        const queryString = fixedUrl.slice(qIdx + 1);
         // Encode colons in the query string that aren't already encoded
         const fixedQuery = queryString.replace(/([^%]|^):(?!%2F%2F)/g, "$1%3A");
         fixedUrl = `${baseUrl}?${fixedQuery}`;

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -23,7 +23,7 @@ const GIT_TIMEOUT_MS = 60_000;
 
 // Environment overrides that prevent git from hanging on credential prompts or
 // recursing into submodules. Applied to every git subprocess in this module.
-const SAFE_GIT_ENV: Record<string, string> = {
+const SAFE_GIT_ENV: NodeJS.ProcessEnv = {
   ...process.env,
   // Prevent git from opening an interactive credential prompt (would block the
   // runner forever in a non-interactive CI environment).
@@ -33,7 +33,7 @@ const SAFE_GIT_ENV: Record<string, string> = {
   // can cause git to fetch/update submodules, which may hang indefinitely
   // if the submodule URLs require authentication not available to the runner.
   GIT_SUBMODULE_UPDATE_COMMAND: "true",
-} as Record<string, string>;
+};
 
 /**
  * Restores security-sensitive config paths from the PR base branch.

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -17,6 +17,24 @@ const SENSITIVE_PATHS = [
   ".ripgreprc",
 ];
 
+// Timeout for individual git operations (60 seconds). Prevents indefinite hangs
+// when git triggers submodule operations or credential prompts.
+const GIT_TIMEOUT_MS = 60_000;
+
+// Environment overrides that prevent git from hanging on credential prompts or
+// recursing into submodules. Applied to every git subprocess in this module.
+const SAFE_GIT_ENV: Record<string, string> = {
+  ...process.env,
+  // Prevent git from opening an interactive credential prompt (would block the
+  // runner forever in a non-interactive CI environment).
+  GIT_TERMINAL_PROMPT: "0",
+  // Prevent automatic submodule operations that can be triggered when
+  // .gitmodules is checked out. Without this, `git checkout -- .gitmodules`
+  // can cause git to fetch/update submodules, which may hang indefinitely
+  // if the submodule URLs require authentication not available to the runner.
+  GIT_SUBMODULE_UPDATE_COMMAND: "true",
+} as Record<string, string>;
+
 /**
  * Restores security-sensitive config paths from the PR base branch.
  *
@@ -45,10 +63,17 @@ export function restoreConfigFromBase(baseBranch: string): void {
   );
 
   // Fetch base first — if this fails we haven't touched the workspace and the
-  // caller sees a clean error.
-  execFileSync("git", ["fetch", "origin", baseBranch, "--depth=1"], {
-    stdio: "inherit",
-  });
+  // caller sees a clean error. --no-recurse-submodules prevents git from
+  // fetching submodule objects referenced by .gitmodules on the base branch.
+  execFileSync(
+    "git",
+    ["fetch", "origin", baseBranch, "--depth=1", "--no-recurse-submodules"],
+    {
+      stdio: "inherit",
+      timeout: GIT_TIMEOUT_MS,
+      env: SAFE_GIT_ENV,
+    },
+  );
 
   // Delete PR-controlled versions. If the restore below fails for a given path,
   // that path stays deleted — the safe fallback (no attacker-controlled config).
@@ -59,9 +84,15 @@ export function restoreConfigFromBase(baseBranch: string): void {
 
   for (const p of SENSITIVE_PATHS) {
     try {
-      execFileSync("git", ["checkout", `origin/${baseBranch}`, "--", p], {
-        stdio: "pipe",
-      });
+      execFileSync(
+        "git",
+        ["checkout", `origin/${baseBranch}`, "--", p],
+        {
+          stdio: "pipe",
+          timeout: GIT_TIMEOUT_MS,
+          env: SAFE_GIT_ENV,
+        },
+      );
     } catch {
       // Path doesn't exist on base — it stays deleted.
     }
@@ -72,6 +103,8 @@ export function restoreConfigFromBase(baseBranch: string): void {
   try {
     execFileSync("git", ["reset", "--", ...SENSITIVE_PATHS], {
       stdio: "pipe",
+      timeout: GIT_TIMEOUT_MS,
+      env: SAFE_GIT_ENV,
     });
   } catch {
     // Nothing was staged, or paths don't exist on HEAD — either is fine.

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { execFileSync } from "child_process";
+import { rmSync } from "fs";
+
+// Mock child_process and fs before importing the module under test
+mock.module("child_process", () => ({
+  execFileSync: mock(() => undefined),
+}));
+
+mock.module("fs", () => ({
+  rmSync: mock(() => undefined),
+}));
+
+// Import after mocking
+import { restoreConfigFromBase } from "../src/github/operations/restore-config";
+
+const mockedExecFileSync = execFileSync as unknown as ReturnType<typeof mock>;
+const mockedRmSync = rmSync as unknown as ReturnType<typeof mock>;
+
+describe("restoreConfigFromBase", () => {
+  beforeEach(() => {
+    mockedExecFileSync.mockClear();
+    mockedRmSync.mockClear();
+  });
+
+  it("passes --no-recurse-submodules to git fetch", () => {
+    restoreConfigFromBase("main");
+
+    // First call should be git fetch with --no-recurse-submodules
+    const fetchCall = (mockedExecFileSync as any).mock.calls[0];
+    expect(fetchCall[0]).toBe("git");
+    expect(fetchCall[1]).toContain("fetch");
+    expect(fetchCall[1]).toContain("--no-recurse-submodules");
+  });
+
+  it("sets GIT_TERMINAL_PROMPT=0 to prevent credential hangs", () => {
+    restoreConfigFromBase("main");
+
+    // All git calls should have GIT_TERMINAL_PROMPT=0 in env
+    for (const call of (mockedExecFileSync as any).mock.calls) {
+      const options = call[2];
+      expect(options.env.GIT_TERMINAL_PROMPT).toBe("0");
+    }
+  });
+
+  it("sets a timeout on all git operations", () => {
+    restoreConfigFromBase("main");
+
+    for (const call of (mockedExecFileSync as any).mock.calls) {
+      const options = call[2];
+      expect(options.timeout).toBeGreaterThan(0);
+    }
+  });
+
+  it("deletes sensitive paths before restoring them", () => {
+    restoreConfigFromBase("main");
+
+    // rmSync should be called for each sensitive path
+    const rmCalls = (mockedRmSync as any).mock.calls;
+    expect(rmCalls.length).toBeGreaterThanOrEqual(5);
+
+    const deletedPaths = rmCalls.map((c: any) => c[0]);
+    expect(deletedPaths).toContain(".claude");
+    expect(deletedPaths).toContain(".mcp.json");
+    expect(deletedPaths).toContain(".gitmodules");
+  });
+
+  it("uses the provided baseBranch in git commands", () => {
+    restoreConfigFromBase("release/5.1.0");
+
+    const fetchCall = (mockedExecFileSync as any).mock.calls[0];
+    expect(fetchCall[1]).toContain("release/5.1.0");
+  });
+
+  it("continues if a path does not exist on the base branch", () => {
+    let callCount = 0;
+    (mockedExecFileSync as any).mockImplementation(
+      (_cmd: string, args: string[]) => {
+        callCount++;
+        // Fail on the first checkout (simulating .claude not existing on base)
+        if (args[0] === "checkout" && callCount === 2) {
+          throw new Error("pathspec '.claude' did not match any file(s)");
+        }
+      },
+    );
+
+    // Should not throw
+    expect(() => restoreConfigFromBase("main")).not.toThrow();
+  });
+});

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -1,21 +1,21 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
-import { execFileSync } from "child_process";
-import { rmSync } from "fs";
 
-// Mock child_process and fs before importing the module under test
+// Create mock functions first, then register them with mock.module
+const mockedExecFileSync = mock(() => undefined);
+const mockedRmSync = mock(() => undefined);
+
 mock.module("child_process", () => ({
-  execFileSync: mock(() => undefined),
+  execFileSync: mockedExecFileSync,
 }));
 
 mock.module("fs", () => ({
-  rmSync: mock(() => undefined),
+  rmSync: mockedRmSync,
 }));
 
-// Import after mocking
-import { restoreConfigFromBase } from "../src/github/operations/restore-config";
-
-const mockedExecFileSync = execFileSync as unknown as ReturnType<typeof mock>;
-const mockedRmSync = rmSync as unknown as ReturnType<typeof mock>;
+// Dynamic import after mocking to guarantee bindings point to mocks
+const { restoreConfigFromBase } = await import(
+  "../src/github/operations/restore-config"
+);
 
 describe("restoreConfigFromBase", () => {
   beforeEach(() => {

--- a/test/url-encoding.test.ts
+++ b/test/url-encoding.test.ts
@@ -73,4 +73,36 @@ describe("ensureProperlyEncodedUrl", () => {
     const url = "https://[invalid:url:format]/path";
     expect(ensureProperlyEncodedUrl(url)).toBe(null);
   });
+
+  it("should preserve equals signs in query parameter values", () => {
+    const url =
+      "https://github.com/owner/repo/compare/main...branch?title=fix this&body=data=value";
+    const result = ensureProperlyEncodedUrl(url);
+    expect(result).toContain("body=data%3Dvalue");
+  });
+
+  it("should preserve multiple equals signs in query parameter values", () => {
+    const url =
+      "https://github.com/owner/repo/compare/main...branch?title=fix this&body=base64data==";
+    const result = ensureProperlyEncodedUrl(url);
+    expect(result).toContain("body=base64data%3D%3D");
+  });
+
+  it("should handle query parameter with equals but no spaces (passthrough)", () => {
+    const url =
+      "https://github.com/owner/repo/compare/main...branch?title=test&body=a=b=c";
+    // No spaces in URL, so it should pass through unchanged
+    expect(ensureProperlyEncodedUrl(url)).toBe(url);
+  });
+
+  it("should not split base URL at question marks in query string", () => {
+    const url =
+      "https://github.com/owner/repo/compare/main...branch?title=fix this?&body=test";
+    const result = ensureProperlyEncodedUrl(url);
+    // The base URL should end at the first '?', not split at subsequent ones
+    expect(result).toStartWith(
+      "https://github.com/owner/repo/compare/main...branch?",
+    );
+    expect(result).toContain("title=fix+this%3F");
+  });
 });


### PR DESCRIPTION
## Summary

- Fix `restoreConfigFromBase` hanging indefinitely on repositories with `.gitmodules` (submodules) by adding `--no-recurse-submodules`, `GIT_TERMINAL_PROMPT=0`, and a 60-second timeout to all git operations
- Fix `ensureProperlyEncodedUrl` silently truncating query parameter values that contain `=` signs (e.g. `body=a=b` became `body=a`)

Fixes #1088

## Details

### `restoreConfigFromBase` hang (fixes #1088)

When a repository contains `.gitmodules`, git operations in `restoreConfigFromBase` can trigger recursive submodule fetching or credential prompts, causing the action to hang for hours with no output.

Changes to `src/github/operations/restore-config.ts`:
- Add `--no-recurse-submodules` to `git fetch` to prevent submodule object fetching
- Set `GIT_TERMINAL_PROMPT=0` on all git subprocesses to prevent interactive credential prompts in CI
- Set `GIT_SUBMODULE_UPDATE_COMMAND=true` to no-op any automatic submodule updates triggered by `.gitmodules` checkout
- Add 60-second `timeout` to all `execFileSync` calls as a safety net

### `ensureProperlyEncodedUrl` value truncation

`pair.split("=")` with array destructuring `[key, value]` only captures the first two segments. For a query parameter like `body=a=b`, this produces `key="body"`, `value="a"` — silently dropping `=b`. Fixed by splitting only at the first `=` using `indexOf`.

Also fixed `url.split("?")` to use `indexOf` to correctly handle `?` characters appearing in query parameter values.

## Test plan

- [x] New test file `test/restore-config.test.ts` (6 tests): verifies `--no-recurse-submodules`, `GIT_TERMINAL_PROMPT=0`, timeout, and error handling
- [x] New tests in `test/url-encoding.test.ts` (4 tests): verifies `=` preservation in query values, multiple `=` signs, and `?` in query values
- [x] All existing tests pass (13 pre-existing failures are unrelated missing-dependency issues in local env)