### PR TITLE
Add `list_inline_comments` tool to inline comment MCP server

### DIFF
--- a/docs/solutions.md
+++ b/docs/solutions.md
@@ -585,7 +585,9 @@ prompt: |
 ### Common Tool Permissions
 
 - **PR Comments**: `Bash(gh pr comment:*)`
-- **Inline Comments**: `mcp__github_inline_comment__create_inline_comment` — pass `confirmed: true` to post immediately. When omitted, the comment is buffered and classified after the session ends (real review comments post, test/probe comments are filtered). This prevents subagent test comments from reaching PRs. To disable classification entirely, set `classify_inline_comments: 'false'` on the action.
+- **Inline Comments**:
+  - `mcp__github_inline_comment__create_inline_comment` — pass `confirmed: true` to post immediately. When omitted, the comment is buffered and classified after the session ends (real review comments post, test/probe comments are filtered). This prevents subagent test comments from reaching PRs. To disable classification entirely, set `classify_inline_comments: 'false'` on the action.
+  - `mcp__github_inline_comment__list_inline_comments` — list inline (review) comments on the current PR. Optionally filter by `user_login` (e.g. `claude[bot]`) and use `limit` to cap results (e.g. `limit: 1` to check if any matching comments exist).
 - **File Operations**: `Read,Write,Edit`
 - **Git Operations**: `Bash(git:*)`
 

--- a/src/mcp/github-inline-comment-server.ts
+++ b/src/mcp/github-inline-comment-server.ts
@@ -227,6 +227,123 @@ server.tool(
   },
 );
 
+server.tool(
+  "list_inline_comments",
+  "List inline (review) comments on the current PR, optionally filtered by user login",
+  {
+    user_login: z
+      .string()
+      .optional()
+      .describe(
+        "Filter comments by this GitHub user login (e.g. 'claude[bot]'). If omitted, returns all inline comments.",
+      ),
+    limit: z
+      .number()
+      .positive()
+      .optional()
+      .describe(
+        "Maximum number of comments to return. Use limit=1 to efficiently check whether any matching comments exist.",
+      ),
+  },
+  async ({ user_login, limit }) => {
+    try {
+      const githubToken = process.env.GITHUB_TOKEN;
+
+      if (!githubToken) {
+        throw new Error("GITHUB_TOKEN environment variable is required");
+      }
+
+      const owner = REPO_OWNER;
+      const repo = REPO_NAME;
+      const pull_number = parseInt(PR_NUMBER, 10);
+
+      const octokit = createOctokit(githubToken).rest;
+
+      // Paginate through review comments (stops early when limit is reached)
+      const comments: Array<{
+        id: number;
+        user_login: string;
+        path: string;
+        line: number | null;
+        body: string;
+        in_reply_to_id?: number;
+        created_at: string;
+      }> = [];
+
+      let page = 1;
+      const per_page = 100;
+
+      pagination: while (true) {
+        const response = await octokit.pulls.listReviewComments({
+          owner,
+          repo,
+          pull_number,
+          per_page,
+          page,
+        });
+
+        for (const comment of response.data) {
+          if (user_login && comment.user?.login !== user_login) {
+            continue;
+          }
+
+          comments.push({
+            id: comment.id,
+            user_login: comment.user?.login ?? "",
+            path: comment.path,
+            line: comment.line ?? comment.original_line ?? null,
+            body: comment.body,
+            ...(comment.in_reply_to_id && {
+              in_reply_to_id: comment.in_reply_to_id,
+            }),
+            created_at: comment.created_at,
+          });
+
+          if (limit && comments.length >= limit) {
+            break pagination;
+          }
+        }
+
+        if (response.data.length < per_page) {
+          break;
+        }
+        page++;
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                success: true,
+                count: comments.length,
+                comments,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error listing inline comments: ${errorMessage}`,
+          },
+        ],
+        error: errorMessage,
+        isError: true,
+      };
+    }
+  },
+);
+
 async function runServer() {
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -175,6 +175,27 @@ describe("prepareMcpConfig", () => {
     expect(parsed.mcpServers.github_inline_comment.env.PR_NUMBER).toBe("456");
   });
 
+  test("should include inline comment server for PRs when list_inline_comments tool is allowed", async () => {
+    const result = await prepareMcpConfig({
+      githubToken: "test-token",
+      owner: "test-owner",
+      repo: "test-repo",
+      branch: "test-branch",
+      baseBranch: "main",
+      allowedTools: ["mcp__github_inline_comment__list_inline_comments"],
+      mode: "tag",
+      context: mockPRContext,
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.mcpServers).toBeDefined();
+    expect(parsed.mcpServers.github_inline_comment).toBeDefined();
+    expect(parsed.mcpServers.github_inline_comment.env.GITHUB_TOKEN).toBe(
+      "test-token",
+    );
+    expect(parsed.mcpServers.github_inline_comment.env.PR_NUMBER).toBe("456");
+  });
+
   test("should include comment server when no GitHub tools are allowed and signing disabled", async () => {
     const result = await prepareMcpConfig({
       githubToken: "test-token",


### PR DESCRIPTION
Adds a new MCP tool to list PR review comments, with optional `user_login` filter and `limit` parameter for early exit. This lets Claude read prior inline comments without shelling out to `gh api`.