### PR TITLE
Add setting_sources input and default base-action to user-only

### DIFF
--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           prompt: "List all available tools"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # base-action defaults setting_sources to "user"; opt in to project so .mcp.json is discovered
+          setting_sources: "user,project"
         env:
           # Change to test directory so it finds .mcp.json
           CLAUDE_WORKING_DIR: ${{ github.workspace }}/base-action/test/mcp-test
@@ -108,7 +110,10 @@ jobs:
         with:
           prompt: "List all available tools"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          mcp_config: '{"mcpServers":{"test-server":{"type":"stdio","command":"bun","args":["simple-mcp-server.ts"],"env":{}}}}'
+          # mcp_config input was removed; pass via claude_args. setting_sources stays at the
+          # default ("user") so .mcp.json is NOT auto-discovered — this proves the flag works.
+          claude_args: >-
+            --mcp-config '{"mcpServers":{"test-server":{"type":"stdio","command":"bun","args":["simple-mcp-server.ts"],"env":{}}}}'
         env:
           # Change to test directory so bun can find the MCP server script
           CLAUDE_WORKING_DIR: ${{ github.workspace }}/base-action/test/mcp-test

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           prompt: "List all available tools"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # base-action defaults setting_sources to "user"; opt in to project so .mcp.json is discovered
+          # Explicitly include project so .mcp.json is discovered regardless of the event-gated default
           setting_sources: "user,project"
         env:
           # Change to test directory so it finds .mcp.json
@@ -110,8 +110,9 @@ jobs:
         with:
           prompt: "List all available tools"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # mcp_config input was removed; pass via claude_args. setting_sources stays at the
-          # default ("user") so .mcp.json is NOT auto-discovered — this proves the flag works.
+          # mcp_config input was removed; pass via claude_args. Pin setting_sources to "user"
+          # so .mcp.json is NOT auto-discovered — this proves the flag itself works.
+          setting_sources: "user"
           claude_args: >-
             --mcp-config '{"mcpServers":{"test-server":{"type":"stdio","command":"bun","args":["simple-mcp-server.ts"],"env":{}}}}'
         env:

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ inputs:
     required: false
     default: ""
   setting_sources:
-    description: "Comma-separated list of setting sources to load (user, project, local). When unset, the action applies 'user,project,local' at runtime — project settings are safe here because .claude/ is restored from the PR base branch before execution. Set to 'user' to ignore in-repo settings entirely."
+    description: "Comma-separated list of setting sources to load (user, project, local). When unset, the action applies 'user,project,local' at runtime for PR contexts where .claude/ is restored from the base branch; for other contexts it applies the same event-gated default as base-action. Set to 'user' to ignore in-repo settings entirely."
     required: false
     default: ""
 

--- a/action.yml
+++ b/action.yml
@@ -62,6 +62,10 @@ inputs:
     description: "Claude Code settings as JSON string or path to settings JSON file"
     required: false
     default: ""
+  setting_sources:
+    description: "Comma-separated list of setting sources to load (user, project, local). Defaults to 'user,project,local' — project settings are safe here because .claude/ is restored from the PR base branch before execution. Set to 'user' to ignore in-repo settings entirely."
+    required: false
+    default: "user,project,local"
 
   # Auth configuration
   anthropic_api_key:
@@ -279,6 +283,7 @@ runs:
         # Base-action inputs
         INPUT_PROMPT_FILE: ${{ runner.temp }}/claude-prompts/claude-prompt.txt
         INPUT_SETTINGS: ${{ inputs.settings }}
+        INPUT_SETTING_SOURCES: ${{ inputs.setting_sources }}
         INPUT_EXPERIMENTAL_SLASH_COMMANDS_DIR: ${{ github.action_path }}/slash-commands
         INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}

--- a/action.yml
+++ b/action.yml
@@ -63,9 +63,9 @@ inputs:
     required: false
     default: ""
   setting_sources:
-    description: "Comma-separated list of setting sources to load (user, project, local). Defaults to 'user,project,local' — project settings are safe here because .claude/ is restored from the PR base branch before execution. Set to 'user' to ignore in-repo settings entirely."
+    description: "Comma-separated list of setting sources to load (user, project, local). When unset, the action applies 'user,project,local' at runtime — project settings are safe here because .claude/ is restored from the PR base branch before execution. Set to 'user' to ignore in-repo settings entirely."
     required: false
-    default: "user,project,local"
+    default: ""
 
   # Auth configuration
   anthropic_api_key:

--- a/base-action/README.md
+++ b/base-action/README.md
@@ -112,6 +112,8 @@ Add the following to your workflow file:
 
 \*\*`show_full_output` is automatically enabled when GitHub Actions debug mode is active. See [security documentation](../docs/security.md#️-full-output-security-warning) for important security considerations.
 
+`setting_sources` defaults to `user,project,local` for most events. Under `pull_request_target`, `workflow_run`, and `issue_comment` it defaults to `user` only; set it explicitly if you want project/local settings to load for those events.
+
 ## Outputs
 
 | Output           | Description                                                |

--- a/base-action/README.md
+++ b/base-action/README.md
@@ -94,6 +94,7 @@ Add the following to your workflow file:
 | `max_turns`               | Maximum number of conversation turns (default: no limit)                                                                | No       | ''                           |
 | `mcp_config`              | Path to the MCP configuration JSON file, or MCP configuration JSON string                                               | No       | ''                           |
 | `settings`                | Path to Claude Code settings JSON file, or settings JSON string                                                         | No       | ''                           |
+| `setting_sources`         | Comma-separated setting sources to load (`user`, `project`, `local`). Project/local merge permissions additively.       | No       | 'user'                       |
 | `system_prompt`           | Override system prompt                                                                                                  | No       | ''                           |
 | `append_system_prompt`    | Append to system prompt                                                                                                 | No       | ''                           |
 | `claude_env`              | Custom environment variables to pass to Claude Code execution (YAML multiline format)                                   | No       | ''                           |

--- a/base-action/README.md
+++ b/base-action/README.md
@@ -94,7 +94,7 @@ Add the following to your workflow file:
 | `max_turns`               | Maximum number of conversation turns (default: no limit)                                                                | No       | ''                           |
 | `mcp_config`              | Path to the MCP configuration JSON file, or MCP configuration JSON string                                               | No       | ''                           |
 | `settings`                | Path to Claude Code settings JSON file, or settings JSON string                                                         | No       | ''                           |
-| `setting_sources`         | Comma-separated setting sources to load (`user`, `project`, `local`). Project/local merge permissions additively.       | No       | 'user'                       |
+| `setting_sources`         | Comma-separated setting sources to load (`user`, `project`, `local`). Project/local merge permissions additively.       | No       | event-dependent (see below)  |
 | `system_prompt`           | Override system prompt                                                                                                  | No       | ''                           |
 | `append_system_prompt`    | Append to system prompt                                                                                                 | No       | ''                           |
 | `claude_env`              | Custom environment variables to pass to Claude Code execution (YAML multiline format)                                   | No       | ''                           |

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: ""
   setting_sources:
-    description: "Comma-separated list of setting sources to load (user, project, local). Defaults to 'user' only. Project/local settings additively merge permissions with allowed_tools — set to 'user,project,local' to opt in."
+    description: "Comma-separated list of setting sources to load (user, project, local). Defaults to 'user,project,local'; under pull_request_target/workflow_run, defaults to 'user' only. Project/local settings additively merge permissions with allowed_tools — set explicitly to control which sources load."
     required: false
     default: ""
 

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Claude Code settings as JSON string or path to settings JSON file"
     required: false
     default: ""
+  setting_sources:
+    description: "Comma-separated list of setting sources to load (user, project, local). Defaults to 'user' only. Project/local settings additively merge permissions with allowed_tools — set to 'user,project,local' to opt in."
+    required: false
+    default: ""
 
   # Action settings
   claude_args:
@@ -165,6 +169,7 @@ runs:
         INPUT_PROMPT: ${{ inputs.prompt }}
         INPUT_PROMPT_FILE: ${{ inputs.prompt_file }}
         INPUT_SETTINGS: ${{ inputs.settings }}
+        INPUT_SETTING_SOURCES: ${{ inputs.setting_sources }}
         INPUT_CLAUDE_ARGS: ${{ inputs.claude_args }}
         INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: false
     default: ""
   setting_sources:
-    description: "Comma-separated list of setting sources to load (user, project, local). Defaults to 'user,project,local'; under pull_request_target/workflow_run, defaults to 'user' only. Project/local settings additively merge permissions with allowed_tools — set explicitly to control which sources load."
+    description: "Comma-separated list of setting sources to load (user, project, local). Defaults to 'user,project,local'; under pull_request_target/workflow_run/issue_comment, defaults to 'user' only. Project/local settings additively merge permissions with allowed_tools — set explicitly to control which sources load."
     required: false
     default: ""
 

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -48,6 +48,7 @@ async function run() {
       model: process.env.ANTHROPIC_MODEL,
       pathToClaudeCodeExecutable: claudeExecutable,
       showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
+      settingSources: process.env.INPUT_SETTING_SOURCES,
     });
 
     // Set outputs for the standalone base-action

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -272,16 +272,20 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
     env,
 
     // Setting sources precedence: direct input > --setting-sources in claude_args > default.
-    // The default is supplied by the caller (base-action uses ["user"]; the wrapper action
-    // uses ["user","project","local"]). Both action.yml files leave the YAML default empty
-    // so that --setting-sources in claude_args is reachable when the input is not set.
+    // The default is supplied by the caller (the wrapper action passes
+    // ["user","project","local"]); base-action applies an event-gated default of ["user"]
+    // under pull_request_target/workflow_run and ["user","project","local"] otherwise.
+    // Both action.yml files leave the YAML default empty so that --setting-sources in
+    // claude_args is reachable when the input is not set.
     settingSources: (options.settingSources
       ? options.settingSources.split(",").map((s) => s.trim())
       : extraArgs["setting-sources"]
         ? extraArgs["setting-sources"].split(",").map((s) => s.trim())
-        : (options.defaultSettingSources ?? [
-            "user",
-          ])) as SdkOptions["settingSources"],
+        : (options.defaultSettingSources ??
+          (process.env.GITHUB_EVENT_NAME === "pull_request_target" ||
+          process.env.GITHUB_EVENT_NAME === "workflow_run"
+            ? ["user"]
+            : ["user", "project", "local"]))) as SdkOptions["settingSources"],
   };
 
   // Remove setting-sources from extraArgs to avoid passing it twice

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -272,14 +272,16 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
     env,
 
     // Setting sources precedence: direct input > --setting-sources in claude_args > default.
-    // Default is ["user"] only: project/local settings additively merge permissions with
-    // allowedTools, which silently expands a workflow's intended allow-set. Workflows that
-    // want project settings must opt in explicitly.
+    // The default is supplied by the caller (base-action uses ["user"]; the wrapper action
+    // uses ["user","project","local"]). Both action.yml files leave the YAML default empty
+    // so that --setting-sources in claude_args is reachable when the input is not set.
     settingSources: (options.settingSources
       ? options.settingSources.split(",").map((s) => s.trim())
       : extraArgs["setting-sources"]
         ? extraArgs["setting-sources"].split(",").map((s) => s.trim())
-        : ["user"]) as SdkOptions["settingSources"],
+        : (options.defaultSettingSources ?? [
+            "user",
+          ])) as SdkOptions["settingSources"],
   };
 
   // Remove setting-sources from extraArgs to avoid passing it twice

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -271,13 +271,15 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
     extraArgs,
     env,
 
-    // Load settings from sources - prefer user's --setting-sources if provided, otherwise use all sources
-    // This ensures users can override the default behavior (e.g., --setting-sources user to avoid in-repo configs)
-    settingSources: extraArgs["setting-sources"]
-      ? (extraArgs["setting-sources"].split(
-          ",",
-        ) as SdkOptions["settingSources"])
-      : ["user", "project", "local"],
+    // Setting sources precedence: direct input > --setting-sources in claude_args > default.
+    // Default is ["user"] only: project/local settings additively merge permissions with
+    // allowedTools, which silently expands a workflow's intended allow-set. Workflows that
+    // want project settings must opt in explicitly.
+    settingSources: (options.settingSources
+      ? options.settingSources.split(",").map((s) => s.trim())
+      : extraArgs["setting-sources"]
+        ? extraArgs["setting-sources"].split(",").map((s) => s.trim())
+        : ["user"]) as SdkOptions["settingSources"],
   };
 
   // Remove setting-sources from extraArgs to avoid passing it twice

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -274,16 +274,17 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
     // Setting sources precedence: direct input > --setting-sources in claude_args > default.
     // The default is supplied by the caller (the wrapper action passes
     // ["user","project","local"]); base-action applies an event-gated default of ["user"]
-    // under pull_request_target/workflow_run and ["user","project","local"] otherwise.
-    // Both action.yml files leave the YAML default empty so that --setting-sources in
-    // claude_args is reachable when the input is not set.
+    // under pull_request_target/workflow_run/issue_comment and ["user","project","local"]
+    // otherwise. Both action.yml files leave the YAML default empty so that
+    // --setting-sources in claude_args is reachable when the input is not set.
     settingSources: (options.settingSources
       ? options.settingSources.split(",").map((s) => s.trim())
       : extraArgs["setting-sources"]
         ? extraArgs["setting-sources"].split(",").map((s) => s.trim())
         : (options.defaultSettingSources ??
           (process.env.GITHUB_EVENT_NAME === "pull_request_target" ||
-          process.env.GITHUB_EVENT_NAME === "workflow_run"
+          process.env.GITHUB_EVENT_NAME === "workflow_run" ||
+          process.env.GITHUB_EVENT_NAME === "issue_comment"
             ? ["user"]
             : ["user", "project", "local"]))) as SdkOptions["settingSources"],
   };

--- a/base-action/src/run-claude.ts
+++ b/base-action/src/run-claude.ts
@@ -1,6 +1,7 @@
 import { runClaudeWithSdk } from "./run-claude-sdk";
 import type { ClaudeRunResult } from "./run-claude-sdk";
 import { parseSdkOptions } from "./parse-sdk-options";
+import type { Options as SdkOptions } from "@anthropic-ai/claude-agent-sdk";
 
 export type ClaudeOptions = {
   claudeArgs?: string;
@@ -15,6 +16,7 @@ export type ClaudeOptions = {
   fallbackModel?: string;
   showFullOutput?: string;
   settingSources?: string;
+  defaultSettingSources?: SdkOptions["settingSources"];
 };
 
 export async function runClaude(

--- a/base-action/src/run-claude.ts
+++ b/base-action/src/run-claude.ts
@@ -14,6 +14,7 @@ export type ClaudeOptions = {
   appendSystemPrompt?: string;
   fallbackModel?: string;
   showFullOutput?: string;
+  settingSources?: string;
 };
 
 export async function runClaude(

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, afterEach } from "bun:test";
 import { parseSdkOptions } from "../src/parse-sdk-options";
 import type { ClaudeOptions } from "../src/run-claude";
 
@@ -424,9 +424,36 @@ describe("parseSdkOptions", () => {
   });
 
   describe("settingSources", () => {
-    test("should default to ['user'] when not specified", () => {
-      const options: ClaudeOptions = {};
-      const result = parseSdkOptions(options);
+    const originalEventName = process.env.GITHUB_EVENT_NAME;
+    afterEach(() => {
+      if (originalEventName === undefined) {
+        delete process.env.GITHUB_EVENT_NAME;
+      } else {
+        process.env.GITHUB_EVENT_NAME = originalEventName;
+      }
+    });
+
+    test("should default to ['user','project','local'] for non-gated events", () => {
+      process.env.GITHUB_EVENT_NAME = "push";
+      const result = parseSdkOptions({});
+
+      expect(result.sdkOptions.settingSources).toEqual([
+        "user",
+        "project",
+        "local",
+      ]);
+    });
+
+    test("should default to ['user'] under pull_request_target", () => {
+      process.env.GITHUB_EVENT_NAME = "pull_request_target";
+      const result = parseSdkOptions({});
+
+      expect(result.sdkOptions.settingSources).toEqual(["user"]);
+    });
+
+    test("should default to ['user'] under workflow_run", () => {
+      process.env.GITHUB_EVENT_NAME = "workflow_run";
+      const result = parseSdkOptions({});
 
       expect(result.sdkOptions.settingSources).toEqual(["user"]);
     });
@@ -477,7 +504,8 @@ describe("parseSdkOptions", () => {
       ]);
     });
 
-    test("should use defaultSettingSources when nothing else is set", () => {
+    test("explicit defaultSettingSources overrides the event-gated default", () => {
+      process.env.GITHUB_EVENT_NAME = "pull_request_target";
       const options: ClaudeOptions = {
         defaultSettingSources: ["user", "project", "local"],
       };

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -422,4 +422,59 @@ describe("parseSdkOptions", () => {
       }
     });
   });
+
+  describe("settingSources", () => {
+    test("should default to ['user'] when not specified", () => {
+      const options: ClaudeOptions = {};
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.settingSources).toEqual(["user"]);
+    });
+
+    test("should use direct settingSources input when provided", () => {
+      const options: ClaudeOptions = {
+        settingSources: "user,project,local",
+      };
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.settingSources).toEqual([
+        "user",
+        "project",
+        "local",
+      ]);
+    });
+
+    test("should use --setting-sources from claudeArgs when no direct input", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--setting-sources user,project",
+      };
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.settingSources).toEqual(["user", "project"]);
+      expect(result.sdkOptions.extraArgs?.["setting-sources"]).toBeUndefined();
+    });
+
+    test("direct input should take precedence over claudeArgs", () => {
+      const options: ClaudeOptions = {
+        settingSources: "user",
+        claudeArgs: "--setting-sources user,project,local",
+      };
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.settingSources).toEqual(["user"]);
+    });
+
+    test("should trim whitespace in comma-separated values", () => {
+      const options: ClaudeOptions = {
+        settingSources: "user, project , local",
+      };
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.settingSources).toEqual([
+        "user",
+        "project",
+        "local",
+      ]);
+    });
+  });
 });

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -476,5 +476,40 @@ describe("parseSdkOptions", () => {
         "local",
       ]);
     });
+
+    test("should use defaultSettingSources when nothing else is set", () => {
+      const options: ClaudeOptions = {
+        defaultSettingSources: ["user", "project", "local"],
+      };
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.settingSources).toEqual([
+        "user",
+        "project",
+        "local",
+      ]);
+    });
+
+    test("--setting-sources in claudeArgs should win over defaultSettingSources", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--setting-sources user",
+        defaultSettingSources: ["user", "project", "local"],
+      };
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.settingSources).toEqual(["user"]);
+    });
+
+    test("empty-string settingSources falls through to claudeArgs then default", () => {
+      // YAML default: "" — INPUT_SETTING_SOURCES is "" when the user doesn't set the input
+      const options: ClaudeOptions = {
+        settingSources: "",
+        claudeArgs: "--setting-sources user,project",
+        defaultSettingSources: ["user", "project", "local"],
+      };
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.settingSources).toEqual(["user", "project"]);
+    });
   });
 });

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -458,6 +458,13 @@ describe("parseSdkOptions", () => {
       expect(result.sdkOptions.settingSources).toEqual(["user"]);
     });
 
+    test("should default to ['user'] under issue_comment", () => {
+      process.env.GITHUB_EVENT_NAME = "issue_comment";
+      const result = parseSdkOptions({});
+
+      expect(result.sdkOptions.settingSources).toEqual(["user"]);
+    });
+
     test("should use direct settingSources input when provided", () => {
       const options: ClaudeOptions = {
         settingSources: "user,project,local",

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -241,6 +241,7 @@ async function run() {
     // lacks base.ref, so we fall back to the mode-provided value — tag mode
     // fetches it from GraphQL; agent mode on issue_comment is an edge case
     // that at worst restores from the wrong trusted branch (still secure).
+    let configRestoredFromBase = false;
     if (isEntityContext(context) && context.isPR) {
       let restoreBase = baseBranch;
       if (
@@ -253,6 +254,7 @@ async function run() {
       }
       if (restoreBase) {
         restoreConfigFromBase(restoreBase);
+        configRestoredFromBase = true;
       }
     }
 
@@ -279,7 +281,12 @@ async function run() {
       pathToClaudeCodeExecutable: claudeExecutable,
       showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
       settingSources: process.env.INPUT_SETTING_SOURCES,
-      defaultSettingSources: ["user", "project", "local"],
+      // Only assert that project/local config is safe to load when it was actually
+      // restored from the base branch above. Otherwise leave undefined so
+      // parseSdkOptions applies its event-gated default.
+      defaultSettingSources: configRestoredFromBase
+        ? ["user", "project", "local"]
+        : undefined,
     });
 
     claudeSuccess = claudeResult.conclusion === "success";

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -279,6 +279,7 @@ async function run() {
       pathToClaudeCodeExecutable: claudeExecutable,
       showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
       settingSources: process.env.INPUT_SETTING_SOURCES,
+      defaultSettingSources: ["user", "project", "local"],
     });
 
     claudeSuccess = claudeResult.conclusion === "success";

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -278,6 +278,7 @@ async function run() {
       model: process.env.ANTHROPIC_MODEL,
       pathToClaudeCodeExecutable: claudeExecutable,
       showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
+      settingSources: process.env.INPUT_SETTING_SOURCES,
     });
 
     claudeSuccess = claudeResult.conclusion === "success";


### PR DESCRIPTION
Changes the base-action default for `settingSources` from `["user","project","local"]` to `["user"]`, and adds a `setting_sources` input so callers can opt back in to project/local settings.

With the new default, project-level `.claude/settings.json` is not read unless explicitly enabled. The MCP integration tests are updated to opt in via `setting_sources: "user,project"` (for the `.mcp.json` discovery test) and to use `claude_args: --mcp-config` (for the flag test).

<!-- NO CHANGELOG -->