### PR TITLE
feat: support ANTHROPIC_AUTH_TOKEN for custom API gateway authentication

### DIFF
--- a/base-action/src/validate-env.ts
+++ b/base-action/src/validate-env.ts
@@ -7,6 +7,7 @@ export function validateEnvironmentVariables() {
   const useVertex = process.env.CLAUDE_CODE_USE_VERTEX === "1";
   const useFoundry = process.env.CLAUDE_CODE_USE_FOUNDRY === "1";
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY;
+  const anthropicAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
   const claudeCodeOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
 
   const errors: string[] = [];
@@ -20,9 +21,9 @@ export function validateEnvironmentVariables() {
   }
 
   if (!useBedrock && !useVertex && !useFoundry) {
-    if (!anthropicApiKey && !claudeCodeOAuthToken) {
+    if (!anthropicApiKey && !anthropicAuthToken && !claudeCodeOAuthToken) {
       errors.push(
-        "Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.",
+        "Either ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.",
       );
     }
   } else if (useBedrock) {

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -1,11 +1,12 @@
 # Cloud Providers
 
-You can authenticate with Claude using any of these four methods:
+You can authenticate with Claude using any of these five methods:
 
 1. Direct Anthropic API (default)
-2. Amazon Bedrock with OIDC authentication
-3. Google Vertex AI with OIDC authentication
-4. Microsoft Foundry with OIDC authentication
+2. Custom API Gateway (Bearer token)
+3. Amazon Bedrock with OIDC authentication
+4. Google Vertex AI with OIDC authentication
+5. Microsoft Foundry with OIDC authentication
 
 For detailed setup instructions for AWS Bedrock and Google Vertex AI, see the [official documentation](https://code.claude.com/docs/en/github-actions#for-aws-bedrock:).
 
@@ -25,6 +26,15 @@ Use provider-specific model names based on your chosen provider:
   with:
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     # ... other inputs
+
+# For custom API gateway with Bearer token
+- uses: anthropics/claude-code-action@v1
+  with:
+    anthropic_api_key: ${{ secrets.GATEWAY_API_KEY }}  # satisfies input validation
+    # ... other inputs
+  env:
+    ANTHROPIC_BASE_URL: https://your-gateway.example.com/anthropic/
+    ANTHROPIC_AUTH_TOKEN: ${{ secrets.GATEWAY_API_KEY }}
 
 # For Amazon Bedrock with OIDC
 - uses: anthropics/claude-code-action@v1
@@ -50,6 +60,36 @@ Use provider-specific model names based on your chosen provider:
       --model claude-sonnet-4-5
     # ... other inputs
 ```
+
+## Custom API Gateway (Bearer Token)
+
+Some organizations route Anthropic API requests through a custom API gateway (e.g. Azure API Management, corporate proxy) that uses `Authorization: Bearer <token>` instead of the standard `x-api-key` header.
+
+Use `ANTHROPIC_AUTH_TOKEN` to send the key as a Bearer token:
+
+```yaml
+- name: Generate GitHub App token
+  id: app-token
+  uses: actions/create-github-app-token@v2
+  with:
+    app-id: ${{ secrets.APP_ID }}
+    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+- uses: anthropics/claude-code-action@v1
+  with:
+    github_token: ${{ steps.app-token.outputs.token }}
+    anthropic_api_key: ${{ secrets.GATEWAY_API_KEY }}  # satisfies input validation
+    claude_args: |
+      --model claude-sonnet-4-6
+  env:
+    ANTHROPIC_BASE_URL: https://your-gateway.example.com/anthropic/
+    ANTHROPIC_AUTH_TOKEN: ${{ secrets.GATEWAY_API_KEY }}
+```
+
+**How it works:**
+- `ANTHROPIC_BASE_URL` points to your gateway endpoint
+- `ANTHROPIC_AUTH_TOKEN` sends the key as `Authorization: Bearer <token>` (used by the Anthropic SDK when set)
+- `ANTHROPIC_API_KEY` input is still required to pass action validation (can use the same key)
 
 ## OIDC Authentication for Cloud Providers
 


### PR DESCRIPTION
## Problem

Organizations that route Anthropic API requests through a **custom API gateway** (e.g. Azure API Management, corporate proxy) use `Authorization: Bearer <token>` header for authentication — not the standard `x-api-key` header used by `ANTHROPIC_API_KEY`.

Currently, setting `ANTHROPIC_AUTH_TOKEN` as an env variable (which the Anthropic SDK uses for Bearer token auth) still fails validation with:

```
Environment variable validation failed:
  - Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required when using direct Anthropic API.
```

This forces users to pass `anthropic_api_key` just to satisfy the validation check, even though the actual authentication happens via `ANTHROPIC_AUTH_TOKEN`.

## Solution

Add `ANTHROPIC_AUTH_TOKEN` as a valid authentication option in `validateEnvironmentVariables()`.

### Changes

- **`base-action/src/validate-env.ts`**: Accept `ANTHROPIC_AUTH_TOKEN` alongside `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` for direct API validation
- **`docs/cloud-providers.md`**: Add new "Custom API Gateway" section with Bearer token example

## Usage

```yaml
- uses: anthropics/claude-code-action@v1
  with:
    github_token: ${{ steps.app-token.outputs.token }}
  env:
    ANTHROPIC_BASE_URL: https://your-gateway.example.com/anthropic/
    ANTHROPIC_AUTH_TOKEN: ${{ secrets.GATEWAY_API_KEY }}
```

## Why This Matters

This is a common pattern for enterprise users who:
- Have corporate API proxies that require Bearer token auth
- Use API management platforms (Azure APIM, AWS API Gateway) in front of Anthropic
- Need `Authorization: Bearer` instead of `x-api-key` header format

The Anthropic Python SDK already supports this via the `auth_token` parameter. This PR ensures the GitHub Action validates consistently with how the underlying SDK works.