### PR TITLE
fix: create sticky comment in agent mode when useStickyComment is enabled

### DIFF
--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -6,6 +6,8 @@ import {
   setupSshSigning,
 } from "../../github/operations/git-config";
 import { checkHumanActor } from "../../github/validation/actor";
+import { createInitialComment } from "../../github/operations/comments/create-initial";
+import { isEntityContext } from "../../github/context";
 import type { GitHubContext } from "../../github/context";
 import type { Octokits } from "../../github/api/client";
 
@@ -95,6 +97,13 @@ export async function prepareAgentMode({
     process.env.GITHUB_REF_NAME ||
     "main";
 
+  // Create sticky comment if enabled and context is entity-based (PR/issue)
+  let commentId: number | undefined;
+  if (context.inputs.useStickyComment && isEntityContext(context)) {
+    const commentData = await createInitialComment(octokit.rest, context);
+    commentId = commentData.id;
+  }
+
   // Get our GitHub MCP servers config
   const ourMcpConfig = await prepareMcpConfig({
     githubToken,
@@ -102,7 +111,7 @@ export async function prepareAgentMode({
     repo: context.repository.repo,
     branch: currentBranch,
     baseBranch: baseBranch,
-    claudeCommentId: undefined, // No tracking comment in agent mode
+    claudeCommentId: commentId?.toString(),
     allowedTools,
     mode: "agent",
     context,
@@ -122,7 +131,7 @@ export async function prepareAgentMode({
   claudeArgs = `${claudeArgs} ${userClaudeArgs}`.trim();
 
   return {
-    commentId: undefined,
+    commentId,
     branchInfo: {
       baseBranch: baseBranch,
       currentBranch: baseBranch, // Use base branch as current when creating new branch

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -8,9 +8,10 @@ import {
   mock,
 } from "bun:test";
 import { prepareAgentMode } from "../../src/modes/agent";
-import { createMockAutomationContext } from "../mockContext";
+import { createMockAutomationContext, createMockContext } from "../mockContext";
 import * as core from "@actions/core";
 import * as gitConfig from "../../src/github/operations/git-config";
+import * as createInitialCommentModule from "../../src/github/operations/comments/create-initial";
 
 describe("Agent Mode", () => {
   let exportVariableSpy: any;
@@ -202,5 +203,77 @@ describe("Agent Mode", () => {
     // should not include any MCP config
     // Should be empty or just whitespace when no MCP servers are included
     expect(result.claudeArgs).not.toContain("--mcp-config");
+  });
+
+  test("prepare creates sticky comment when useStickyComment is true and context is entity-based", async () => {
+    const createInitialCommentSpy = spyOn(
+      createInitialCommentModule,
+      "createInitialComment",
+    ).mockImplementation(async () => ({ id: 12345 }) as any);
+
+    const entityContext = createMockContext({
+      eventName: "pull_request",
+      entityNumber: 456,
+      isPR: true,
+      inputs: { useStickyComment: true, prompt: "Fix the bug" },
+    });
+
+    const mockOctokit = {
+      rest: {
+        users: {
+          getByUsername: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345, type: "User" },
+            }),
+          ),
+        },
+      },
+    } as any;
+
+    const result = await prepareAgentMode({
+      context: entityContext,
+      octokit: mockOctokit,
+      githubToken: "test-token",
+    });
+
+    expect(createInitialCommentSpy).toHaveBeenCalledTimes(1);
+    expect(result.commentId).toBe(12345);
+
+    createInitialCommentSpy.mockRestore();
+  });
+
+  test("prepare skips sticky comment when useStickyComment is true but context is automation", async () => {
+    const createInitialCommentSpy = spyOn(
+      createInitialCommentModule,
+      "createInitialComment",
+    ).mockImplementation(async () => ({ id: 99999 }) as any);
+
+    const automationContext = createMockAutomationContext({
+      eventName: "workflow_dispatch",
+      inputs: { useStickyComment: true },
+    });
+
+    const mockOctokit = {
+      rest: {
+        users: {
+          getByUsername: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345, type: "User" },
+            }),
+          ),
+        },
+      },
+    } as any;
+
+    const result = await prepareAgentMode({
+      context: automationContext,
+      octokit: mockOctokit,
+      githubToken: "test-token",
+    });
+
+    expect(createInitialCommentSpy).not.toHaveBeenCalled();
+    expect(result.commentId).toBeUndefined();
+
+    createInitialCommentSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Fixes #1108

## Summary

- In agent mode, `claudeCommentId` was hardcoded to `undefined` in `prepareAgentMode`, so the MCP comment server never received `CLAUDE_COMMENT_ID` even when `use_sticky_comment` was enabled.
- Added the same `createInitialComment` call that tag mode uses: when `useStickyComment` is `true` and the context is entity-based (PR/issue), it creates the initial comment and passes the ID to `prepareMcpConfig`.
- Automation contexts (`workflow_dispatch`, `schedule`) with no entity skip comment creation gracefully.

## Test plan

- Added tests verifying `createInitialComment` is called when `useStickyComment=true` with entity context, and that the returned `commentId` is passed through to the result and MCP config.
- Added tests verifying `createInitialComment` is NOT called for automation contexts or when `useStickyComment=false`.
- `bun test` (654 pass), `bun run typecheck`, `bun run format:check` all pass.