### PR TITLE
Use env vars for workflow_run context values in example workflows

### DIFF
--- a/examples/ci-failure-auto-fix.yml
+++ b/examples/ci-failure-auto-fix.yml
@@ -35,10 +35,14 @@ jobs:
 
       - name: Create fix branch
         id: branch
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          BRANCH_NAME="claude-auto-fix-ci-${{ github.event.workflow_run.head_branch }}-${{ github.run_id }}"
+          SAFE_BRANCH=$(printf '%s' "$HEAD_BRANCH" | tr -cd 'a-zA-Z0-9/_.-')
+          BRANCH_NAME="claude-auto-fix-ci-${SAFE_BRANCH}-${RUN_ID}"
           git checkout -b "$BRANCH_NAME"
-          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Get CI failure details
         id: failure_details

--- a/examples/ci-failure-auto-fix.yml
+++ b/examples/ci-failure-auto-fix.yml
@@ -1,5 +1,21 @@
 name: Auto Fix CI Failures
 
+# ⚠️ SECURITY NOTE
+#
+# This workflow checks out the PR branch and runs build/test commands
+# (npm, bun, etc.) against it with elevated permissions (contents:write,
+# id-token:write). This means code from the PR branch executes in a
+# trusted context with access to secrets and the ability to push to the
+# repository.
+#
+# Only use this workflow in repositories where everyone with write access
+# is fully trusted with these permissions. Do not use this in repositories
+# that accept contributions from untrusted or semi-trusted collaborators.
+#
+# The pull_requests[0] check below limits this to same-repo PRs (fork PRs
+# are excluded), but anyone who can push a branch to this repository can
+# control what code runs here.
+
 on:
   workflow_run:
     workflows: ["CI"]

--- a/examples/test-failure-analysis.yml
+++ b/examples/test-failure-analysis.yml
@@ -53,6 +53,8 @@ jobs:
           fromJSON(steps.detect.outputs.structured_output).confidence >= 0.7
         env:
           GH_TOKEN: ${{ github.token }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           OUTPUT='${{ steps.detect.outputs.structured_output }}'
           CONFIDENCE=$(echo "$OUTPUT" | jq -r '.confidence')
@@ -63,8 +65,7 @@ jobs:
           echo ""
           echo "Triggering automatic retry..."
 
-          gh workflow run "${{ github.event.workflow_run.name }}" \
-            --ref "${{ github.event.workflow_run.head_branch }}"
+          gh workflow run "$WORKFLOW_NAME" --ref "$HEAD_BRANCH"
 
       # Low confidence flaky detection - skip retry
       - name: Low confidence detection
@@ -83,13 +84,14 @@ jobs:
         if: github.event.workflow_run.event == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           OUTPUT='${{ steps.detect.outputs.structured_output }}'
           IS_FLAKY=$(echo "$OUTPUT" | jq -r '.is_flaky')
           CONFIDENCE=$(echo "$OUTPUT" | jq -r '.confidence')
           SUMMARY=$(echo "$OUTPUT" | jq -r '.summary')
 
-          pr_number=$(gh pr list --head "${{ github.event.workflow_run.head_branch }}" --json number --jq '.[0].number')
+          pr_number=$(gh pr list --head "$HEAD_BRANCH" --json number --jq '.[0].number')
 
           if [ -n "$pr_number" ]; then
             if [ "$IS_FLAKY" = "true" ]; then


### PR DESCRIPTION
Updates the `workflow_run`-triggered example workflows to follow GitHub Actions best practices by passing `github.event.workflow_run.*` context values through `env:` blocks rather than interpolating them directly into `run:` shell scripts.

## Changes

**`examples/ci-failure-auto-fix.yml`**
- Pass `head_branch` and `run_id` via `env:` instead of inline `${{ }}` interpolation in the `run:` block
- Sanitize the branch name to alphanumeric characters, slashes, dots, dashes, and underscores before using it to construct a new branch name
- Quote `$GITHUB_OUTPUT`

**`examples/test-failure-analysis.yml`**
- Pass `head_branch` and `workflow_run.name` via `env:` in the retry and comment steps

## Why

Branch names can contain characters like `$`, `(`, `)`, backticks, and `;` that have special meaning in shell contexts. Passing these values through environment variables ensures they're treated as literal strings when referenced in shell scripts, which is the pattern recommended by GitHub's security hardening guide for Actions.