### PR TITLE
Fix workflow template permissions and surface 403 errors

### DIFF
--- a/examples/pr-review-filtered-authors.yml
+++ b/examples/pr-review-filtered-authors.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout repository

--- a/examples/pr-review-filtered-paths.yml
+++ b/examples/pr-review-filtered-paths.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout repository

--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -12,6 +12,13 @@
 import { readFileSync } from "fs";
 import { createOctokit } from "../github/api/client";
 
+class PermissionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PermissionError";
+  }
+}
+
 const BUFFER_PATH = "/tmp/inline-comments-buffer.jsonl";
 
 type BufferedComment = {
@@ -135,10 +142,19 @@ async function postComment(
   try {
     await octokit.rest.pulls.createReviewComment(params);
     return true;
-  } catch (e) {
-    console.log(
-      `  failed ${c.path}:${c.line}: ${e instanceof Error ? e.message : String(e)}`,
-    );
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    const status =
+      e && typeof e === "object" && "status" in e
+        ? (e as { status: number }).status
+        : undefined;
+    console.log(`  failed ${c.path}:${c.line}: ${message}`);
+    if (status === 403) {
+      throw new PermissionError(
+        `Permission denied posting inline comment on ${c.path}:${c.line}. ` +
+          "Ensure your workflow has 'pull-requests: write' permission.",
+      );
+    }
     return false;
   }
 }

--- a/src/mcp/github-comment-server.ts
+++ b/src/mcp/github-comment-server.ts
@@ -76,11 +76,19 @@ server.tool(
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
+      const status =
+        error && typeof error === "object" && "status" in error
+          ? (error as { status: number }).status
+          : undefined;
+      const helpMessage =
+        status === 403
+          ? " Permission denied. Ensure your workflow has 'pull-requests: write' and 'issues: write' permissions."
+          : "";
       return {
         content: [
           {
             type: "text",
-            text: `Error: ${errorMessage}`,
+            text: `Error: ${errorMessage}${helpMessage}`,
           },
         ],
         error: errorMessage,

--- a/src/mcp/github-inline-comment-server.ts
+++ b/src/mcp/github-inline-comment-server.ts
@@ -205,7 +205,15 @@ server.tool(
 
       // Provide more helpful error messages for common issues
       let helpMessage = "";
-      if (errorMessage.includes("Validation Failed")) {
+      const status =
+        error && typeof error === "object" && "status" in error
+          ? (error as { status: number }).status
+          : undefined;
+      if (status === 403) {
+        helpMessage =
+          "\n\nPermission denied. Ensure your workflow has 'pull-requests: write' permission. " +
+          "The current permission level does not allow posting review comments.";
+      } else if (errorMessage.includes("Validation Failed")) {
         helpMessage =
           "\n\nThis usually means the line number doesn't exist in the diff or the file path is incorrect. Make sure you're commenting on lines that are part of the PR's changes.";
       } else if (errorMessage.includes("Not Found")) {


### PR DESCRIPTION
## Summary

Fixes #1121. Two related bugs:

- **Wrong permissions in example workflows**: `pr-review-filtered-authors.yml` and `pr-review-filtered-paths.yml` had `pull-requests: read` instead of `write`. Users copying these templates get silent failures when Claude tries to post review comments. The other example workflows already had the correct `write` permission.

- **Silent 403 failures**: When the GitHub API returns a 403 (permission denied), the error was caught and logged but the action exited successfully (code 0). Now throws a `PermissionError` with a clear message pointing users to the required workflow permissions. Also surfaces 403 help text in the MCP comment servers so Claude can self-diagnose the issue.

## Test plan

- [ ] Copy `pr-review-filtered-authors.yml` into a test repo — verify Claude can post review comments
- [ ] Run action with `pull-requests: read` — verify it fails with a clear permission error instead of exiting 0
- [ ] Verify other example workflows are unaffected