### PR TITLE
Fix use_sticky_comment in agent mode

### DIFF
--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -6,6 +6,8 @@ import {
   setupSshSigning,
 } from "../../github/operations/git-config";
 import { checkHumanActor } from "../../github/validation/actor";
+import { createInitialComment } from "../../github/operations/comments/create-initial";
+import { isEntityContext } from "../../github/context";
 import type { GitHubContext } from "../../github/context";
 import type { Octokits } from "../../github/api/client";
 
@@ -95,6 +97,15 @@ export async function prepareAgentMode({
     process.env.GITHUB_REF_NAME ||
     "main";
 
+  // Create initial comment for sticky comment support in agent mode
+  let claudeCommentId: string | undefined;
+  let commentId: number | undefined;
+  if (context.inputs.useStickyComment && isEntityContext(context)) {
+    const commentData = await createInitialComment(octokit.rest, context);
+    commentId = commentData.id;
+    claudeCommentId = commentId.toString();
+  }
+
   // Get our GitHub MCP servers config
   const ourMcpConfig = await prepareMcpConfig({
     githubToken,
@@ -102,7 +113,7 @@ export async function prepareAgentMode({
     repo: context.repository.repo,
     branch: currentBranch,
     baseBranch: baseBranch,
-    claudeCommentId: undefined, // No tracking comment in agent mode
+    claudeCommentId,
     allowedTools,
     mode: "agent",
     context,
@@ -122,7 +133,7 @@ export async function prepareAgentMode({
   claudeArgs = `${claudeArgs} ${userClaudeArgs}`.trim();
 
   return {
-    commentId: undefined,
+    commentId,
     branchInfo: {
       baseBranch: baseBranch,
       currentBranch: baseBranch, // Use base branch as current when creating new branch


### PR DESCRIPTION
## Summary

Fixes #1108. `use_sticky_comment` was broken in agent mode because `prepareAgentMode` hardcoded `claudeCommentId` to `undefined`, skipping the `createInitialComment()` call that tag mode performs.

Now calls `createInitialComment(octokit.rest, context)` when `useStickyComment` is enabled and the context is an entity (PR or issue), matching the existing tag mode pattern. Automation contexts (workflow_dispatch, schedule) where there is no entity to comment on are unaffected — both IDs remain `undefined`.

## Test plan

- [ ] Run agent mode with `use_sticky_comment: true` on a PR event — verify a single comment is created and updated
- [ ] Run agent mode with `use_sticky_comment: false` — verify no change in behavior
- [ ] Run agent mode on a `workflow_dispatch` event — verify no comment is created (no entity context)
- [ ] Run tag mode with `use_sticky_comment: true` — verify existing behavior is unchanged