### PR TITLE
fix: write execution file in finally block so rate limit errors are parseable

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -156,6 +156,7 @@ export async function runClaudeWithSdk(
 
   const messages: SDKMessage[] = [];
   let resultMessage: SDKResultMessage | undefined;
+  let sdkError: unknown;
 
   try {
     for await (const message of query({ prompt, options: sdkOptions })) {
@@ -171,21 +172,29 @@ export async function runClaudeWithSdk(
       }
     }
   } catch (error) {
+    sdkError = error;
     console.error("SDK execution error:", error);
-    throw new Error(`SDK execution error: ${error}`);
   }
 
   const result: ClaudeRunResult = {
     conclusion: "failure",
   };
 
-  // Write execution file
-  try {
-    await writeFile(EXECUTION_FILE, JSON.stringify(messages, null, 2));
-    console.log(`Log saved to ${EXECUTION_FILE}`);
-    result.executionFile = EXECUTION_FILE;
-  } catch (error) {
-    core.warning(`Failed to write execution file: ${error}`);
+  // Write execution file — always, even after SDK errors, so callers can
+  // inspect messages (e.g. to distinguish rate limits from other failures).
+  if (messages.length > 0) {
+    try {
+      await writeFile(EXECUTION_FILE, JSON.stringify(messages, null, 2));
+      console.log(`Log saved to ${EXECUTION_FILE}`);
+      result.executionFile = EXECUTION_FILE;
+    } catch (error) {
+      core.warning(`Failed to write execution file: ${error}`);
+    }
+  }
+
+  // Re-throw SDK error after writing execution file
+  if (sdkError) {
+    throw new Error(`SDK execution error: ${sdkError}`);
   }
 
   // Extract session_id from system.init message


### PR DESCRIPTION
Fixes #1040

## Problem

When the Claude Code SDK throws (e.g. rate limit, crash), the execution file is never written because the `catch` block in `run-claude-sdk.ts` re-throws immediately, making the `writeFile` call on the subsequent lines unreachable.

This means workflows using `continue-on-error: true` cannot inspect the collected messages to distinguish rate limits from other failures — both surface as exit code 1 with a generic SDK stack trace, and the `execution_file` output is empty.

## Solution

Instead of re-throwing immediately in the `catch` block, the SDK error is stored in a variable. The execution file write proceeds (guarded by `messages.length > 0` to avoid writing empty files), and only then is the error re-thrown.

This ensures:
- The `execution_file` output is always populated when messages were collected, regardless of whether the SDK completed successfully
- Callers can parse the execution file to detect `rate_limit_event` messages vs other failures
- The error is still propagated with the same message format
- No behavioral change for the success path

## Changes

- `base-action/src/run-claude-sdk.ts`: Store SDK error instead of immediately re-throwing; write execution file before propagating the error

## Testing

- All 653 existing tests pass
- TypeScript type checking passes
- Prettier formatting passes