### PR TITLE
feat: batch inline comments into a single PR review submission

### DIFF
--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -143,6 +143,71 @@ async function postComment(
   }
 }
 
+/**
+ * Submit all comments as a single GitHub Pull Request Review. This produces
+ * one notification instead of N separate notifications for each comment.
+ * Falls back to posting individual comments if the batch review fails (e.g.
+ * when a comment targets an invalid path or line).
+ */
+async function postCommentsAsReview(
+  octokit: ReturnType<typeof createOctokit>["rest"],
+  owner: string,
+  repo: string,
+  pull_number: number,
+  headSha: string,
+  comments: BufferedComment[],
+): Promise<number> {
+  const reviewComments = comments.map((c) => {
+    const comment: {
+      path: string;
+      body: string;
+      side?: "LEFT" | "RIGHT";
+      line?: number;
+      start_line?: number;
+      start_side?: "LEFT" | "RIGHT";
+    } = {
+      path: c.path,
+      body: c.body,
+      side: c.side || "RIGHT",
+    };
+    if (c.startLine) {
+      comment.start_line = c.startLine;
+      comment.start_side = c.side || "RIGHT";
+      comment.line = c.line;
+    } else {
+      comment.line = c.line;
+    }
+    return comment;
+  });
+
+  try {
+    await octokit.rest.pulls.createReview({
+      owner,
+      repo,
+      pull_number,
+      commit_id: headSha,
+      event: "COMMENT",
+      comments: reviewComments,
+    });
+    console.log(
+      `  submitted ${comments.length} comment(s) as a single PR review`,
+    );
+    return comments.length;
+  } catch (e) {
+    console.log(
+      `  batch review failed (${e instanceof Error ? e.message : String(e)}), falling back to individual comments`,
+    );
+    let posted = 0;
+    for (const c of comments) {
+      if (await postComment(octokit, owner, repo, pull_number, headSha, c)) {
+        console.log(`  posted ${c.path}:${c.line}`);
+        posted++;
+      }
+    }
+    return posted;
+  }
+}
+
 async function main() {
   let raw: string;
   try {
@@ -217,13 +282,18 @@ async function main() {
   const headSha = pr.data.head.sha;
 
   console.log(`Posting ${toPost.length} classified-as-real comment(s)`);
-  let posted = 0;
-  for (const c of toPost) {
-    if (await postComment(octokit, owner, repo, pull_number, headSha, c)) {
-      console.log(`  posted ${c.path}:${c.line}`);
-      posted++;
-    }
-  }
+
+  // Batch all comments into a single PR review submission. This produces
+  // one notification and a cohesive review in GitHub's timeline instead of
+  // separate per-comment notifications.
+  const posted = await postCommentsAsReview(
+    octokit,
+    owner,
+    repo,
+    pull_number,
+    headSha,
+    toPost,
+  );
   console.log(`Posted ${posted}/${toPost.length}`);
 }
 


### PR DESCRIPTION
Fixes #1049

## Problem

The post-processing step posts each buffered inline comment as an individual `createReviewComment` API call. For a review with N inline comments, this generates N separate email notifications and N disconnected entries in the PR timeline — noisy and hard to review as a whole.

## Solution

Replace the individual comment loop with a single `createReview()` API call that submits all inline comments together as one cohesive PR review with `event: "COMMENT"`. This:

- Produces **one notification** instead of N
- Creates a single review entry in GitHub's "Reviews" tab
- Matches the experience of a human reviewer submitting a batch review
- Is fully backward-compatible: if the batch call fails (e.g. one comment targets an invalid path/line), it falls back to posting comments individually

## Changes

- `src/entrypoints/post-buffered-inline-comments.ts`: Added `postCommentsAsReview()` that maps buffered comments to the `pulls.createReview` API format and submits them as a single review. The existing `postComment()` function is retained as the fallback path.

## Testing

- All 653 existing tests pass
- TypeScript type checking passes
- Prettier formatting passes
- The `postComment()` fallback ensures no regressions — if batch submission fails for any reason, comments are posted individually as before