### PR TITLE
Pass env to execFileSync git calls

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -118,7 +118,7 @@ export function validateBranchName(branchName: string): void {
  * @param args - Git command arguments (e.g., ["checkout", "branch-name"])
  */
 function execGit(args: string[]): void {
-  execFileSync("git", args, { stdio: "inherit" });
+  execFileSync("git", args, { stdio: "inherit", env: process.env });
 }
 
 export type BranchInfo = {

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -48,6 +48,7 @@ export function restoreConfigFromBase(baseBranch: string): void {
   // caller sees a clean error.
   execFileSync("git", ["fetch", "origin", baseBranch, "--depth=1"], {
     stdio: "inherit",
+    env: process.env,
   });
 
   // Delete PR-controlled versions. If the restore below fails for a given path,


### PR DESCRIPTION
Bun's `execFileSync` without an explicit `env` option spawns with the process startup environment, dropping runtime `process.env` mutations. The credential helper reads `$GH_TOKEN` which is set at runtime, so `git fetch` in the restore-config path failed with empty password.

Fixes #1139