### PR TITLE
fix: throw HttpError for non-retryable HTTP failures in updateRef

### DIFF
--- a/src/entrypoints/prepare.ts
+++ b/src/entrypoints/prepare.ts
@@ -6,7 +6,7 @@
  */
 
 import * as core from "@actions/core";
-import { setupGitHubToken } from "../github/token";
+import { setupGitHubToken, WorkflowValidationSkipError } from "../github/token";
 import { checkWritePermissions } from "../github/validation/permissions";
 import { createOctokit } from "../github/api/client";
 import { parseGitHubContext, isEntityContext } from "../github/context";
@@ -30,10 +30,20 @@ async function run() {
     );
 
     // Setup GitHub token
-    const githubToken = await setupGitHubToken();
+    let githubToken: string;
+    try {
+      githubToken = await setupGitHubToken();
+    } catch (error) {
+      if (error instanceof WorkflowValidationSkipError) {
+        core.setOutput("skipped_due_to_workflow_validation_mismatch", "true");
+        console.log("Exiting due to workflow validation skip");
+        return;
+      }
+      throw error;
+    }
     const octokit = createOctokit(githubToken);
 
-    // Step 3: Check write permissions (only for entity contexts)
+    // Check write permissions (only for entity contexts)
     if (isEntityContext(context)) {
       // Check if github_token was provided as input (not from app)
       const githubTokenProvided = !!process.env.OVERRIDE_GITHUB_TOKEN;

--- a/src/github/token.ts
+++ b/src/github/token.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env bun
 
 import * as core from "@actions/core";
+import type { NonRetryable } from "../utils/errors";
 import { retryWithBackoff } from "../utils/retry";
 
-export class WorkflowValidationSkipError extends Error {
+export class WorkflowValidationSkipError extends Error implements NonRetryable {
+  readonly retryable = false as const;
+
   constructor(message: string) {
     super(message);
     this.name = "WorkflowValidationSkipError";

--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -404,8 +404,9 @@ server.tool(
               `Failed to update reference: ${updateRefResponse.status} - ${errorText}`,
             );
 
-            // For non-403 errors, fail immediately without retry
-            console.error("Non-retryable error:", updateRefResponse.status);
+            // Note: this error is still retried by retryWithBackoff. To make
+            // specific HTTP status codes non-retryable, see issue #1156.
+            console.error("Update ref error:", updateRefResponse.status);
             throw error;
           }
         },
@@ -620,8 +621,9 @@ server.tool(
               `Failed to update reference: ${updateRefResponse.status} - ${errorText}`,
             );
 
-            // For non-403 errors, fail immediately without retry
-            console.error("Non-retryable error:", updateRefResponse.status);
+            // Note: this error is still retried by retryWithBackoff. To make
+            // specific HTTP status codes non-retryable, see issue #1156.
+            console.error("Update ref error:", updateRefResponse.status);
             throw error;
           }
         },

--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -8,6 +8,7 @@ import { resolve } from "path";
 import { constants } from "fs";
 import fetch from "node-fetch";
 import { GITHUB_API_URL } from "../github/api/config";
+import { HttpError } from "../utils/errors";
 import { retryWithBackoff } from "../utils/retry";
 import { validatePathWithinRepo } from "./path-validation";
 
@@ -399,15 +400,12 @@ server.tool(
               throw permissionError;
             }
 
-            // For other errors, use the original message
-            const error = new Error(
+            // All other non-2xx errors are deterministic failures — do not retry.
+            console.error("Update ref error:", updateRefResponse.status);
+            throw new HttpError(
+              updateRefResponse.status,
               `Failed to update reference: ${updateRefResponse.status} - ${errorText}`,
             );
-
-            // Note: this error is still retried by retryWithBackoff. To make
-            // specific HTTP status codes non-retryable, see issue #1156.
-            console.error("Update ref error:", updateRefResponse.status);
-            throw error;
           }
         },
         {
@@ -616,15 +614,12 @@ server.tool(
               throw permissionError;
             }
 
-            // For other errors, use the original message
-            const error = new Error(
+            // All other non-2xx errors are deterministic failures — do not retry.
+            console.error("Update ref error:", updateRefResponse.status);
+            throw new HttpError(
+              updateRefResponse.status,
               `Failed to update reference: ${updateRefResponse.status} - ${errorText}`,
             );
-
-            // Note: this error is still retried by retryWithBackoff. To make
-            // specific HTTP status codes non-retryable, see issue #1156.
-            console.error("Update ref error:", updateRefResponse.status);
-            throw error;
           }
         },
         {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,28 @@
+/**
+ * Marker interface for errors that should not be retried.
+ *
+ * Implement this on error classes that represent deterministic failures
+ * where retrying cannot produce a different outcome (e.g., auth errors,
+ * validation failures, resource-not-found errors).
+ *
+ * @example
+ * class ValidationError extends Error implements NonRetryable {
+ *   readonly retryable = false as const;
+ * }
+ */
+export interface NonRetryable {
+  readonly retryable: false;
+}
+
+/**
+ * Type guard that returns true if the error declares itself non-retryable
+ * via the {@link NonRetryable} marker interface.
+ */
+export function isNonRetryable(error: unknown): error is NonRetryable {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "retryable" in (error as object) &&
+    (error as NonRetryable).retryable === false
+  );
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -15,6 +15,25 @@ export interface NonRetryable {
 }
 
 /**
+ * An HTTP error carrying the response status code.
+ *
+ * Implements {@link NonRetryable} — errors with deterministic HTTP status codes
+ * (e.g. 400, 404, 422) should not be retried. Callers that want to retry specific
+ * status codes (e.g. 403, 429) should throw a plain `Error` for those cases instead.
+ */
+export class HttpError extends Error implements NonRetryable {
+  readonly retryable = false as const;
+
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
+
+/**
  * Type guard that returns true if the error declares itself non-retryable
  * via the {@link NonRetryable} marker interface.
  */

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,8 +1,16 @@
+import { isNonRetryable } from "./errors";
+
 export type RetryOptions = {
   maxAttempts?: number;
   initialDelayMs?: number;
   maxDelayMs?: number;
   backoffFactor?: number;
+  /**
+   * Return false to abort retries immediately for this error.
+   * Defaults to skipping retries for any error that implements the
+   * {@link NonRetryable} marker interface (i.e. has `retryable: false`).
+   */
+  shouldRetry?: (error: Error) => boolean;
 };
 
 export async function retryWithBackoff<T>(
@@ -14,7 +22,14 @@ export async function retryWithBackoff<T>(
     initialDelayMs = 5000,
     maxDelayMs = 20000,
     backoffFactor = 2,
+    shouldRetry,
   } = options;
+
+  if (maxAttempts < 1) {
+    throw new Error("maxAttempts must be >= 1");
+  }
+
+  const effectiveShouldRetry = shouldRetry ?? ((e: Error) => !isNonRetryable(e));
 
   let delayMs = initialDelayMs;
   let lastError: Error | undefined;
@@ -28,6 +43,12 @@ export async function retryWithBackoff<T>(
       console.error(`Attempt ${attempt} failed:`, lastError.message);
 
       if (attempt < maxAttempts) {
+        if (!effectiveShouldRetry(lastError)) {
+          console.error(
+            `Non-retryable error (${lastError.name}), aborting retries`,
+          );
+          break;
+        }
         console.log(`Retrying in ${delayMs / 1000} seconds...`);
         await new Promise((resolve) => setTimeout(resolve, delayMs));
         delayMs = Math.min(delayMs * backoffFactor, maxDelayMs);

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test";
 import { retryWithBackoff } from "../src/utils/retry";
-import { isNonRetryable } from "../src/utils/errors";
+import { HttpError, isNonRetryable } from "../src/utils/errors";
 import type { NonRetryable } from "../src/utils/errors";
 import { WorkflowValidationSkipError } from "../src/github/token";
 
@@ -183,7 +183,50 @@ describe("retryWithBackoff", () => {
     });
   });
 
-  describe("WorkflowValidationSkipError integration", () => {
+  describe("HttpError", () => {
+  test("has retryable=false", () => {
+    const err = new HttpError(404, "not found");
+    expect(err.retryable).toBe(false);
+    expect(isNonRetryable(err)).toBe(true);
+  });
+
+  test("exposes status code", () => {
+    const err = new HttpError(422, "unprocessable");
+    expect(err.status).toBe(422);
+    expect(err.message).toBe("unprocessable");
+    expect(err.name).toBe("HttpError");
+  });
+
+  test("is not retried by retryWithBackoff", async () => {
+    let calls = 0;
+    await expect(
+      retryWithBackoff(
+        async () => {
+          calls++;
+          throw new HttpError(404, "branch not found");
+        },
+        { maxAttempts: 3, initialDelayMs: 0, maxDelayMs: 0 },
+      ),
+    ).rejects.toBeInstanceOf(HttpError);
+    expect(calls).toBe(1);
+  });
+
+  test("plain Error from same operation IS retried (403 stays retryable)", async () => {
+    let calls = 0;
+    await expect(
+      retryWithBackoff(
+        async () => {
+          calls++;
+          throw new Error("403 permission denied");
+        },
+        { maxAttempts: 3, initialDelayMs: 0, maxDelayMs: 0 },
+      ),
+    ).rejects.toThrow("403 permission denied");
+    expect(calls).toBe(3);
+  });
+});
+
+describe("WorkflowValidationSkipError integration", () => {
     test("WorkflowValidationSkipError is not retried (implements NonRetryable)", async () => {
       let calls = 0;
       await expect(

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test";
+import { retryWithBackoff } from "../src/utils/retry";
+import { isNonRetryable } from "../src/utils/errors";
+import type { NonRetryable } from "../src/utils/errors";
+import { WorkflowValidationSkipError } from "../src/github/token";
+
+// Silence console output during tests
+let consoleLogSpy: ReturnType<typeof spyOn>;
+let consoleErrorSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+  consoleErrorSpy = spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleLogSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+});
+
+// Helper: create an operation that fails N times then succeeds
+function failThenSucceed(failCount: number, successValue = "ok") {
+  let calls = 0;
+  return async () => {
+    calls++;
+    if (calls <= failCount) throw new Error(`Attempt ${calls} failed`);
+    return successValue;
+  };
+}
+
+describe("isNonRetryable", () => {
+  test("returns false for a plain Error", () => {
+    expect(isNonRetryable(new Error("oops"))).toBe(false);
+  });
+
+  test("returns false for null", () => {
+    expect(isNonRetryable(null)).toBe(false);
+  });
+
+  test("returns false for a string", () => {
+    expect(isNonRetryable("error string")).toBe(false);
+  });
+
+  test("returns true for an object with retryable: false", () => {
+    expect(isNonRetryable({ retryable: false })).toBe(true);
+  });
+
+  test("returns false for an object with retryable: true", () => {
+    expect(isNonRetryable({ retryable: true })).toBe(false);
+  });
+});
+
+describe("retryWithBackoff", () => {
+  describe("baseline: retries transient errors", () => {
+    test("retries a plain Error up to maxAttempts", async () => {
+      const operation = failThenSucceed(2);
+      const result = await retryWithBackoff(operation, {
+        maxAttempts: 3,
+        initialDelayMs: 0,
+        maxDelayMs: 0,
+      });
+      expect(result).toBe("ok");
+    });
+
+    test("throws after exhausting all attempts", async () => {
+      const operation = failThenSucceed(99);
+      await expect(
+        retryWithBackoff(operation, {
+          maxAttempts: 3,
+          initialDelayMs: 0,
+          maxDelayMs: 0,
+        }),
+      ).rejects.toThrow("Attempt 3 failed");
+    });
+
+    test("succeeds on first attempt without retrying", async () => {
+      let calls = 0;
+      const result = await retryWithBackoff(async () => {
+        calls++;
+        return "success";
+      });
+      expect(result).toBe("success");
+      expect(calls).toBe(1);
+    });
+  });
+
+  describe("NonRetryable default: skips retry for retryable=false errors", () => {
+    test("does not retry an error with retryable=false", async () => {
+      class MyNonRetryableError extends Error implements NonRetryable {
+        readonly retryable = false as const;
+      }
+      let calls = 0;
+      await expect(
+        retryWithBackoff(
+          async () => {
+            calls++;
+            throw new MyNonRetryableError("deterministic failure");
+          },
+          { maxAttempts: 3, initialDelayMs: 0, maxDelayMs: 0 },
+        ),
+      ).rejects.toThrow("deterministic failure");
+      expect(calls).toBe(1);
+    });
+
+    test("does not log 'aborting retries' on the final attempt of a retryable error", async () => {
+      await expect(
+        retryWithBackoff(failThenSucceed(99), {
+          maxAttempts: 2,
+          initialDelayMs: 0,
+          maxDelayMs: 0,
+        }),
+      ).rejects.toThrow();
+      const abortingCalls = (consoleErrorSpy.mock.calls as string[][]).filter(
+        (args) => typeof args[0] === "string" && args[0].includes("aborting retries"),
+      );
+      expect(abortingCalls).toHaveLength(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("maxAttempts=0 throws immediately", async () => {
+      await expect(
+        retryWithBackoff(async () => "ok", { maxAttempts: 0 }),
+      ).rejects.toThrow("maxAttempts must be >= 1");
+    });
+
+    test("wraps non-Error thrown values into Error", async () => {
+      await expect(
+        retryWithBackoff(
+          async () => {
+            throw "a plain string error";
+          },
+          { maxAttempts: 1 },
+        ),
+      ).rejects.toThrow("a plain string error");
+    });
+
+    test("shouldRetry is called with the thrown error object", async () => {
+      const targetError = new Error("specific error");
+      const shouldRetry = spyOn({ shouldRetry: () => false }, "shouldRetry");
+      shouldRetry.mockImplementation(() => false);
+      await expect(
+        retryWithBackoff(
+          async () => {
+            throw targetError;
+          },
+          { maxAttempts: 3, initialDelayMs: 0, maxDelayMs: 0, shouldRetry },
+        ),
+      ).rejects.toThrow("specific error");
+      expect(shouldRetry).toHaveBeenCalledWith(targetError);
+    });
+  });
+
+  describe("explicit shouldRetry option", () => {
+    test("shouldRetry=()=>false stops retries immediately", async () => {
+      let calls = 0;
+      await expect(
+        retryWithBackoff(
+          async () => {
+            calls++;
+            throw new Error("always fails");
+          },
+          {
+            maxAttempts: 3,
+            initialDelayMs: 0,
+            maxDelayMs: 0,
+            shouldRetry: () => false,
+          },
+        ),
+      ).rejects.toThrow("always fails");
+      expect(calls).toBe(1);
+    });
+
+    test("shouldRetry=()=>true retries up to maxAttempts", async () => {
+      const operation = failThenSucceed(2);
+      const result = await retryWithBackoff(operation, {
+        maxAttempts: 3,
+        initialDelayMs: 0,
+        maxDelayMs: 0,
+        shouldRetry: () => true,
+      });
+      expect(result).toBe("ok");
+    });
+  });
+
+  describe("WorkflowValidationSkipError integration", () => {
+    test("WorkflowValidationSkipError is not retried (implements NonRetryable)", async () => {
+      let calls = 0;
+      await expect(
+        retryWithBackoff(
+          async () => {
+            calls++;
+            throw new WorkflowValidationSkipError("workflow not found");
+          },
+          { maxAttempts: 3, initialDelayMs: 0, maxDelayMs: 0 },
+        ),
+      ).rejects.toBeInstanceOf(WorkflowValidationSkipError);
+      expect(calls).toBe(1);
+    });
+
+    test("WorkflowValidationSkipError has retryable=false", () => {
+      const err = new WorkflowValidationSkipError("test");
+      expect(err.retryable).toBe(false);
+      expect(isNonRetryable(err)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1156. Two `updateRef` call sites in `github-file-ops-server.ts` threw plain `Error` for all non-2xx HTTP responses, so `retryWithBackoff` retried deterministic failures like 404 (branch not found), 422 (validation failed), and 409 (conflict) — wasting up to 10 seconds per failure.

## What changed

Adds `HttpError` to `src/utils/errors.ts`:

```typescript
export class HttpError extends Error implements NonRetryable {
  readonly retryable = false as const;
  constructor(public readonly status: number, message: string) { ... }
}
```

Both `updateRef` call sites now throw `HttpError` for non-403 non-2xx responses. Since `HttpError` implements `NonRetryable`, `retryWithBackoff` skips retries automatically — no `shouldRetry` option needed at the call sites.

**403 intentionally keeps throwing plain `Error`** — the existing comment documents these as intermittent transient GitHub API issues that succeed on retry.

## Dependency

This PR builds on #1157 (which introduces `NonRetryable` and updates `retryWithBackoff`). It should be merged after #1157. The diff on top of `main` once #1157 lands is exactly this commit.

## Tests

4 new tests in `test/retry.test.ts`:
- `HttpError` has `retryable=false` and `isNonRetryable` returns true
- `HttpError` exposes `status` and `name`
- `HttpError` is not retried by `retryWithBackoff`
- Plain `Error` (simulating 403) IS still retried

All 674 tests pass.