### PR TITLE
fix: propagate curl exit code through pipe with set -o pipefail

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -60,7 +60,16 @@ async function installClaudeCode(): Promise<void> {
   }
 
   const claudeCodeVersion = "2.1.92";
+  const VERSION_RE = /^\d+\.\d+\.\d+$/;
+  if (!VERSION_RE.test(claudeCodeVersion)) {
+    throw new Error(
+      `Invalid claudeCodeVersion format: ${claudeCodeVersion}`,
+    );
+  }
   console.log(`Installing Claude Code v${claudeCodeVersion}...`);
+
+  const homeBin = `${process.env.HOME}/.local/bin`;
+  const claudeBinary = `${homeBin}/claude`;
 
   for (let attempt = 1; attempt <= 3; attempt++) {
     console.log(`Installation attempt ${attempt}...`);
@@ -70,7 +79,7 @@ async function installClaudeCode(): Promise<void> {
           "bash",
           [
             "-c",
-            `curl -fsSL https://claude.ai/install.sh | bash -s -- ${claudeCodeVersion}`,
+            `set -o pipefail; curl -fsSL https://claude.ai/install.sh | bash -s -- ${claudeCodeVersion}`,
           ],
           { stdio: "inherit" },
         );
@@ -81,8 +90,13 @@ async function installClaudeCode(): Promise<void> {
         child.on("error", reject);
       });
       console.log("Claude Code installed successfully");
+      // Verify the binary actually landed where expected
+      if (!existsSync(claudeBinary)) {
+        throw new Error(
+          `Install exited successfully but Claude binary not found at ${claudeBinary}. The install script may have changed its output location.`,
+        );
+      }
       // Add to PATH
-      const homeBin = `${process.env.HOME}/.local/bin`;
       const githubPath = process.env.GITHUB_PATH;
       if (githubPath) {
         await appendFile(githubPath, `${homeBin}\n`);
@@ -95,7 +109,10 @@ async function installClaudeCode(): Promise<void> {
           `Failed to install Claude Code after 3 attempts: ${error}`,
         );
       }
-      console.log("Installation failed, retrying...");
+      console.log(
+        `Installation attempt ${attempt} failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      console.log("Retrying...");
       await new Promise((resolve) => setTimeout(resolve, 5000));
     }
   }


### PR DESCRIPTION
## Problem

`installClaudeCode()` runs a bash command that pipes the install script output.

Because of POSIX pipe semantics, the exit code of this pipeline is the exit code of the last command (`bash`), not `curl`. When curl returns HTTP 429 (rate-limited) or 403 (auth error), it exits non-zero — but `bash` receives an empty or partial script and exits 0. The caller sees success, the retry loop never fires, and Claude Code is not actually installed.

## Fix

Four targeted changes to `installClaudeCode()` in `src/entrypoints/run.ts`:

1. **`set -o pipefail`** — prefixed to the bash command so any non-zero exit anywhere in the pipeline propagates to the process exit code. Curl 429/403 now correctly fails the install attempt.

2. **Version regex guard** — validate `claudeCodeVersion` against `/^\d+\.\d+\.\d+$/` before interpolating into the shell command. The version is currently hardcoded so injection is not possible today, but this guards against future refactors that make it configurable.

3. **Post-install binary check** — after a successful spawn exit, verify `existsSync(homeBin + '/claude')`. Even with pipefail, a network drop mid-transfer after bash has started could produce a truncated script that exits 0. The binary check catches that.

4. **Better retry logging** — log the actual error on failed attempts (not just `"Installation failed, retrying..."`), so CI logs show what actually went wrong.

## Changes

- `homeBin` hoisted above the loop (was inside the success block; now shared with the binary check and PATH append)
- No temp files, no new imports (`existsSync` already imported at line 9)

Fixes #1136
