### PR TITLE
fix: reject control characters in PATH_TO_CLAUDE_CODE_EXECUTABLE

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -49,6 +49,13 @@ async function installClaudeCode(): Promise<void> {
   if (customExecutable) {
     console.log(`Using custom Claude Code executable: ${customExecutable}`);
     const claudeDir = dirname(customExecutable);
+    // Reject paths containing control characters — an embedded newline in claudeDir
+    // would inject an additional directory into GITHUB_PATH for all subsequent steps.
+    if (/[\x00-\x1f\x7f]/.test(claudeDir)) {
+      throw new Error(
+        `PATH_TO_CLAUDE_CODE_EXECUTABLE contains invalid control characters: ${JSON.stringify(claudeDir)}`,
+      );
+    }
     // Add to PATH by appending to GITHUB_PATH
     const githubPath = process.env.GITHUB_PATH;
     if (githubPath) {


### PR DESCRIPTION
## Problem

`PATH_TO_CLAUDE_CODE_EXECUTABLE` is passed through `dirname()` and written directly to the `GITHUB_PATH` file without sanitizing control characters:

```typescript
const claudeDir = dirname(customExecutable);
await appendFile(githubPath, `${claudeDir}\n`);
```

`GITHUB_PATH` is newline-delimited — each line becomes a directory added to `PATH` for subsequent steps. If `customExecutable` contains an embedded newline (e.g. set from an untrusted workflow input), `dirname()` passes it through and `appendFile` writes two lines, injecting an attacker-controlled directory into the runner PATH for all subsequent job steps.

## Fix

Add a fail-closed guard before the `appendFile` call that throws if `claudeDir` contains any control characters (`\x00–\x1f`, `\x7f`):

```typescript
if (/[\x00-\x1f\x7f]/.test(claudeDir)) {
  throw new Error(
    `PATH_TO_CLAUDE_CODE_EXECUTABLE contains invalid control characters: ${JSON.stringify(claudeDir)}`,
  );
}
```

**Fail-closed rather than silently stripping:** a path with embedded control characters is almost certainly a misconfiguration or injection attempt. Throwing loudly is better than quietly sanitizing and continuing — the latter hides the problem.

All 653 existing tests continue to pass.

Fixes #1160
