### PR TITLE
fix: forward MCP_TIMEOUT, MCP_TOOL_TIMEOUT, MAX_MCP_OUTPUT_TOKENS to action step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -305,6 +305,15 @@ runs:
         ANTHROPIC_DEFAULT_HAIKU_MODEL: ${{ env.ANTHROPIC_DEFAULT_HAIKU_MODEL }}
         ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ env.ANTHROPIC_DEFAULT_OPUS_MODEL }}
 
+        # MCP configuration — these env vars are read directly from process.env by the
+        # Claude CLI subprocess. They must be listed explicitly here because this step's
+        # env: block shadows the calling workflow's job-level env vars (GitHub Actions
+        # composite action behavior). Set these in your workflow's job-level env: or via
+        # a prior step that writes to $GITHUB_ENV.
+        MCP_TIMEOUT: ${{ env.MCP_TIMEOUT }}
+        MCP_TOOL_TIMEOUT: ${{ env.MCP_TOOL_TIMEOUT }}
+        MAX_MCP_OUTPUT_TOKENS: ${{ env.MAX_MCP_OUTPUT_TOKENS }}
+
         # Telemetry configuration
         CLAUDE_CODE_ENABLE_TELEMETRY: ${{ env.CLAUDE_CODE_ENABLE_TELEMETRY }}
         OTEL_METRICS_EXPORTER: ${{ env.OTEL_METRICS_EXPORTER }}


### PR DESCRIPTION
## Problem

`MCP_TIMEOUT` (and related vars) set in a calling workflow never reach the Claude CLI subprocess, causing npx-based MCP servers to always hit the default 30-second timeout.

Every approach users try silently fails:

| Method | Why it fails |
|---|---|
| Step-level `env: MCP_TIMEOUT: 120000` on calling workflow step | Composite action steps do not inherit the caller's step-level env |
| `echo "MCP_TIMEOUT=120000" >> "$GITHUB_ENV"` in a prior step | Sets job-level env, but the step's explicit `env:` block shadows it — missing a `${{ env.MCP_TIMEOUT }}` line |
| `settings` input `{"env": {"MCP_TIMEOUT": ...}}` | Writes to `~/.claude/settings.json`, not to `process.env` — wrong path entirely |

## Root cause

The "Run Claude Code Action" step in `action.yml` uses an explicit `env:` block (~50 vars). In GitHub Actions composite actions, a step with its own `env:` block does not automatically inherit the calling workflow's job-level environment — it only gets what's explicitly listed. `MCP_TIMEOUT`, `MCP_TOOL_TIMEOUT`, and `MAX_MCP_OUTPUT_TOKENS` were not in the list.

Once any of these vars IS in the step's process environment, the existing forwarding chain is already correct: `parse-sdk-options.ts:211` spreads `{ ...process.env }` into `sdkOptions.env`, the SDK passes that env to the CLI subprocess, and the CLI reads the values directly.

## Fix

Add explicit `${{ env.VAR }}` passthrough lines for all three MCP config vars — the same pattern already used for `OTEL_*`, `AWS_*`, and GCP configuration in lines 271–317.

```yaml
MCP_TIMEOUT: ${{ env.MCP_TIMEOUT }}
MCP_TOOL_TIMEOUT: ${{ env.MCP_TOOL_TIMEOUT }}
MAX_MCP_OUTPUT_TOKENS: ${{ env.MAX_MCP_OUTPUT_TOKENS }}
```

No TypeScript changes needed. Single file, 9 lines added (3 vars + 6 lines of comment).

## After this fix

```yaml
# job-level env (recommended)
env:
  MCP_TIMEOUT: "120000"

# or GITHUB_ENV in a prior step
- run: echo "MCP_TIMEOUT=120000" >> "$GITHUB_ENV"
```

Both approaches now work correctly.

All three vars fixed together — fixing only `MCP_TIMEOUT` while leaving `MCP_TOOL_TIMEOUT` and `MAX_MCP_OUTPUT_TOKENS` broken would generate follow-up issues.

Fixes #1152
