### PR TITLE
fix: restore ripgrep execute bits after bun install --production

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -194,6 +194,10 @@ runs:
       run: |
         cd ${GITHUB_ACTION_PATH}
         bun install --production
+        # bun install --production strips execute bits from vendored binaries (bun issue #1140).
+        # Restore +x on the ripgrep binaries so the Claude Agent SDK can exec them.
+        find "${GITHUB_ACTION_PATH}/node_modules/@anthropic-ai/claude-agent-sdk/vendor/ripgrep" \
+          -name "rg" -type f -exec chmod +x {} \;
 
     - name: Install subprocess isolation dependencies
       # Install subprocess isolation dependencies when processing content from non-write users.


### PR DESCRIPTION
## Problem

After `bun install --production`, the `rg` binaries vendored by `@anthropic-ai/claude-agent-sdk` lose their execute bits, causing EACCES when the SDK tries to spawn ripgrep.

Affected binaries:
```
node_modules/@anthropic-ai/claude-agent-sdk/vendor/ripgrep/
  x64-linux/rg
  arm64-linux/rg
  x64-darwin/rg
  arm64-darwin/rg
  x64-win32/rg.exe
  arm64-win32/rg.exe
```

## Root cause

This is a known bun bug: `bun install --production` strips execute bits from vendored binaries in `node_modules`. The npm package ships the binaries with correct permissions (`0777` in bun's cache) but the `--production` install strips them.

The SDK has no `postinstall` script to restore them, so the action gets unexecutable `rg` binaries on every run.

## Fix

Add a targeted `find`+`chmod +x` immediately after `bun install --production` in the Install Dependencies step:

```bash
find "${GITHUB_ACTION_PATH}/node_modules/@anthropic-ai/claude-agent-sdk/vendor/ripgrep" \
  -name "rg" -type f -exec chmod +x {} \;
```

Design decisions:
- **`-type f`** — excludes symlinks, safe against symlink attacks without extra guards
- **`-name "rg"`** — naturally excludes `.exe` on Windows (`find` returns nothing, `chmod` never called — correct and safe on all platforms)
- **No `|| true`** — fails loudly if the binary path is missing, so an SDK packaging change is immediately visible rather than silently broken
- **No audio-capture chmod** — `.node` native addon files are loaded via `dlopen`, not `execve` — they don't need execute bits

Single file, 4 lines added.

Fixes #1140
