### PR TITLE
fix: bypass write permission check for actors in allowed_bots list

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -177,6 +177,7 @@ async function run() {
         context,
         context.inputs.allowedNonWriteUsers,
         !!process.env.OVERRIDE_GITHUB_TOKEN,
+        context.inputs.allowedBots,
       );
       if (!hasWritePermissions) {
         throw new Error(

--- a/src/github/validation/permissions.ts
+++ b/src/github/validation/permissions.ts
@@ -3,11 +3,40 @@ import type { ParsedGitHubContext } from "../context";
 import type { Octokit } from "@octokit/rest";
 
 /**
+ * Normalize a bot name for comparison: lowercase and strip the "[bot]" suffix.
+ * Matches the normalization used in checkHumanActor.
+ */
+function normalizeBotName(name: string): string {
+  return name.toLowerCase().replace(/\[bot\]$/, "");
+}
+
+/**
+ * Check if the actor is in the allowed_bots list.
+ * Handles wildcard "*" and comma-separated bot name lists.
+ * Names are normalized: case-insensitive and "[bot]" suffix is ignored.
+ */
+export function isActorInAllowedBots(
+  actor: string,
+  allowedBots: string,
+): boolean {
+  const trimmed = allowedBots.trim();
+  if (!trimmed) return false;
+  if (trimmed === "*") return true;
+  const actorName = normalizeBotName(actor);
+  const allowedList = trimmed
+    .split(",")
+    .map((b) => normalizeBotName(b.trim()))
+    .filter((b) => b.length > 0);
+  return allowedList.includes(actorName);
+}
+
+/**
  * Check if the actor has write permissions to the repository
  * @param octokit - The Octokit REST client
  * @param context - The GitHub context
  * @param allowedNonWriteUsers - Comma-separated list of users allowed without write permissions, or '*' for all
  * @param githubTokenProvided - Whether github_token was provided as input (not from app)
+ * @param allowedBots - Comma-separated list of bot usernames allowed to bypass the permission check, or '*' for all bots
  * @returns true if the actor has write permissions, false otherwise
  */
 export async function checkWritePermissions(
@@ -15,6 +44,7 @@ export async function checkWritePermissions(
   context: ParsedGitHubContext,
   allowedNonWriteUsers?: string,
   githubTokenProvided?: boolean,
+  allowedBots?: string,
 ): Promise<boolean> {
   const { repository, actor } = context;
 
@@ -43,9 +73,27 @@ export async function checkWritePermissions(
       }
     }
 
-    // Check if the actor is a GitHub App (bot user)
+    // Check if the actor is a GitHub App (bot user) by [bot] suffix
     if (actor.endsWith("[bot]")) {
       core.info(`Actor is a GitHub App: ${actor}`);
+      return true;
+    }
+
+    // Check if the actor is in the allowed_bots list.
+    // Some bots (e.g. Copilot, renovate) do not have a "[bot]" suffix in their
+    // login but are still bot-type accounts. When a repo owner explicitly lists
+    // them in allowed_bots, we bypass the collaborators API call — the API
+    // returns 404 for bot accounts that are not repository collaborators.
+    if (allowedBots && isActorInAllowedBots(actor, allowedBots)) {
+      if (allowedBots.trim() === "*") {
+        core.warning(
+          `⚠️ SECURITY WARNING: Bypassing write permission check for ${actor} due to allowed_bots='*'. Ensure your workflow triggers are appropriately scoped.`,
+        );
+      } else {
+        core.info(
+          `Actor ${actor} is in allowed_bots list, bypassing permission check`,
+        );
+      }
       return true;
     }
 

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test";
 import * as core from "@actions/core";
-import { checkWritePermissions } from "../src/github/validation/permissions";
+import {
+  checkWritePermissions,
+  isActorInAllowedBots,
+} from "../src/github/validation/permissions";
 import type { ParsedGitHubContext } from "../src/github/context";
 import { CLAUDE_APP_BOT_ID, CLAUDE_BOT_LOGIN } from "../src/github/constants";
 
@@ -302,5 +305,181 @@ describe("checkWritePermissions", () => {
         "Actor is a GitHub App: test-bot[bot]",
       );
     });
+  });
+
+  describe("allowed_bots bypass", () => {
+    test("should bypass permission check for bot actor in allowed_bots list", async () => {
+      const mockOctokit = createMockOctokit("none");
+      const context = createContext();
+      context.actor = "Copilot";
+
+      const result = await checkWritePermissions(
+        mockOctokit,
+        context,
+        undefined,
+        undefined,
+        "Copilot",
+      );
+
+      expect(result).toBe(true);
+      expect(coreInfoSpy).toHaveBeenCalledWith(
+        "Actor Copilot is in allowed_bots list, bypassing permission check",
+      );
+    });
+
+    test("should match case-insensitively (Copilot vs copilot)", async () => {
+      const mockOctokit = createMockOctokit("none");
+      const context = createContext();
+      context.actor = "Copilot";
+
+      const result = await checkWritePermissions(
+        mockOctokit,
+        context,
+        undefined,
+        undefined,
+        "copilot,renovate",
+      );
+
+      expect(result).toBe(true);
+    });
+
+    test("should match actor with [bot] suffix against normalized allowed_bots entry", async () => {
+      const mockOctokit = createMockOctokit("none");
+      const context = createContext();
+      context.actor = "renovate[bot]";
+
+      const result = await checkWritePermissions(
+        mockOctokit,
+        context,
+        undefined,
+        undefined,
+        "renovate",
+      );
+
+      expect(result).toBe(true);
+    });
+
+    test("should bypass permission check for all bots with wildcard", async () => {
+      const mockOctokit = createMockOctokit("none");
+      const context = createContext();
+      context.actor = "Copilot";
+
+      const result = await checkWritePermissions(
+        mockOctokit,
+        context,
+        undefined,
+        undefined,
+        "*",
+      );
+
+      expect(result).toBe(true);
+      expect(coreWarningSpy).toHaveBeenCalledWith(
+        expect.stringContaining("⚠️ SECURITY WARNING"),
+      );
+      expect(coreWarningSpy).toHaveBeenCalledWith(
+        expect.stringContaining("allowed_bots='*'"),
+      );
+    });
+
+    test("should NOT bypass when actor is not in allowed_bots list", async () => {
+      const mockOctokit = createMockOctokit("write");
+      const context = createContext();
+      context.actor = "some-human";
+
+      const result = await checkWritePermissions(
+        mockOctokit,
+        context,
+        undefined,
+        undefined,
+        "Copilot,renovate",
+      );
+
+      // Falls through to collaborators API — returns write
+      expect(result).toBe(true);
+      expect(coreInfoSpy).toHaveBeenCalledWith(
+        "Permission level retrieved: write",
+      );
+    });
+
+    test("should NOT bypass when allowed_bots is empty", async () => {
+      const mockOctokit = createMockOctokit("write");
+      const context = createContext();
+      context.actor = "Copilot";
+
+      const result = await checkWritePermissions(
+        mockOctokit,
+        context,
+        undefined,
+        undefined,
+        "",
+      );
+
+      // Falls through to collaborators API
+      expect(result).toBe(true);
+      expect(coreInfoSpy).toHaveBeenCalledWith(
+        "Permission level retrieved: write",
+      );
+    });
+
+    test("should NOT bypass when allowed_bots is undefined", async () => {
+      const mockOctokit = createMockOctokit("write");
+      const context = createContext();
+      context.actor = "Copilot";
+
+      const result = await checkWritePermissions(mockOctokit, context);
+
+      // Falls through to collaborators API
+      expect(result).toBe(true);
+      expect(coreInfoSpy).toHaveBeenCalledWith(
+        "Permission level retrieved: write",
+      );
+    });
+  });
+});
+
+describe("isActorInAllowedBots", () => {
+  test("returns false for empty allowedBots", () => {
+    expect(isActorInAllowedBots("Copilot", "")).toBe(false);
+  });
+
+  test("returns false for whitespace-only allowedBots", () => {
+    expect(isActorInAllowedBots("Copilot", "   ")).toBe(false);
+  });
+
+  test("returns true for wildcard", () => {
+    expect(isActorInAllowedBots("anyone", "*")).toBe(true);
+    expect(isActorInAllowedBots("Copilot", "*")).toBe(true);
+  });
+
+  test("returns true for exact match", () => {
+    expect(isActorInAllowedBots("Copilot", "Copilot")).toBe(true);
+  });
+
+  test("returns true for case-insensitive match", () => {
+    expect(isActorInAllowedBots("Copilot", "copilot")).toBe(true);
+    expect(isActorInAllowedBots("copilot", "Copilot")).toBe(true);
+    expect(isActorInAllowedBots("COPILOT", "copilot")).toBe(true);
+  });
+
+  test("returns true when actor has [bot] suffix, entry does not", () => {
+    expect(isActorInAllowedBots("renovate[bot]", "renovate")).toBe(true);
+  });
+
+  test("returns true when actor has no [bot] suffix, entry does", () => {
+    expect(isActorInAllowedBots("renovate", "renovate[bot]")).toBe(true);
+  });
+
+  test("returns true when actor is in comma-separated list", () => {
+    expect(isActorInAllowedBots("Copilot", "dependabot,Copilot,renovate")).toBe(
+      true,
+    );
+  });
+
+  test("returns false when actor is not in list", () => {
+    expect(isActorInAllowedBots("attacker", "Copilot,renovate")).toBe(false);
+  });
+
+  test("handles whitespace around entries", () => {
+    expect(isActorInAllowedBots("Copilot", " Copilot , renovate ")).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

When a bot actor like `Copilot` (GitHub user type: `Bot`, but no `[bot]` suffix in its login) triggers a workflow with `allowed_bots: "Copilot"`, the action fails before the allowed list is ever consulted:

```
Checking permissions for actor: Copilot
GET /repos/{owner}/{repo}/collaborators/Copilot/permission — 404
##[error] Failed to check permissions: HttpError: Copilot is not a user
##[error] Action failed with error: Actor does not have write permissions to the repository
```

Every approach fails for the same reason — `checkWritePermissions` runs first and throws before `checkHumanActor` gets a chance to apply the `allowed_bots` allowlist.

## Root cause

`checkWritePermissions` only bypasses the collaborators API for actors whose login ends in `[bot]` (line 47). Bots without that suffix — `Copilot`, `renovate`, `dependabot` (when listed without suffix) — fall through to the collaborators API. That API returns 404 for accounts that are not repository collaborators, and the error propagates as a permission failure.

Meanwhile `checkHumanActor` (called later in `prepareAgentMode`/`prepareTagMode`) correctly handles these actors: it calls `octokit.users.getByUsername`, sees `type: "Bot"`, and checks the `allowed_bots` list. But execution never reaches it.

## Fix

Add an optional `allowedBots` parameter to `checkWritePermissions`. When the actor's normalized name (case-insensitive, `[bot]`-suffix-stripped) matches an entry in the list, the collaborators API call is skipped. This is the same trust model as the existing `[bot]`-suffix bypass — the repo owner explicitly configured the list.

```typescript
// src/github/validation/permissions.ts (new export)
export function isActorInAllowedBots(actor: string, allowedBots: string): boolean

// checkWritePermissions — new optional 5th parameter
export async function checkWritePermissions(
  octokit, context, allowedNonWriteUsers?, githubTokenProvided?, allowedBots?
)
```

`run.ts` passes `context.inputs.allowedBots` as the new argument.

Additional details:
- `allowed_bots: '*'` emits `⚠️ SECURITY WARNING` matching the `allowed_non_write_users='*'` precedent
- `isActorInAllowedBots` is exported as a standalone utility for independent testing
- 17 new tests added: specific match, wildcard, case-insensitive, `[bot]` normalization, and negative cases
- All 670 existing tests continue to pass

## After this fix

```yaml
# Both now work:
allowed_bots: "Copilot"           # exact match, case-insensitive
allowed_bots: "Copilot,renovate"  # multiple bots
allowed_bots: "*"                 # all bots (emits security warning)
```

Fixes #1133
