### PR TITLE
fix: prevent hang in restoreConfigFromBase on repos with .gitmodules

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -44,19 +44,29 @@ export function restoreConfigFromBase(baseBranch: string): void {
     `Restoring ${SENSITIVE_PATHS.join(", ")} from origin/${baseBranch} (PR head is untrusted)`,
   );
 
-  // Fetch base first — if this fails we haven't touched the workspace and the
-  // caller sees a clean error.
-  execFileSync("git", ["fetch", "origin", baseBranch, "--depth=1"], {
-    stdio: "inherit",
-    env: process.env,
-  });
-
-  // Delete PR-controlled versions. If the restore below fails for a given path,
-  // that path stays deleted — the safe fallback (no attacker-controlled config).
-  // A bare `git checkout` alone wouldn't remove files the PR added, so nuke first.
+  // Delete PR-controlled versions BEFORE fetching so the attacker-controlled
+  // .gitmodules is absent during the network operation. If git reads .gitmodules
+  // during fetch (fetch.recurseSubmodules=on-demand, the git default), it will
+  // attempt to fetch submodule objects and block on credential prompts in CI —
+  // causing an indefinite hang. Deleting first closes that window.
+  //
+  // If the restore below fails for a given path, that path stays deleted —
+  // the safe fallback (no attacker-controlled config). A bare `git checkout`
+  // alone wouldn't remove files the PR added, so nuke first.
   for (const p of SENSITIVE_PATHS) {
     rmSync(p, { recursive: true, force: true });
   }
+
+  // --no-recurse-submodules: explicitly suppress submodule fetching regardless of
+  // fetch.recurseSubmodules config. Defense-in-depth alongside the delete above.
+  execFileSync(
+    "git",
+    ["fetch", "origin", baseBranch, "--depth=1", "--no-recurse-submodules"],
+    {
+      stdio: "inherit",
+      env: process.env,
+    },
+  );
 
   for (const p of SENSITIVE_PATHS) {
     try {


### PR DESCRIPTION
## Problem

`restoreConfigFromBase` hangs indefinitely (users report ~4 hours) on repositories that have a `.gitmodules` file in the PR head. Fixes #1088.

**Root cause:** `git fetch origin <base> --depth=1` reads `.gitmodules` from the working tree when `fetch.recurseSubmodules=on-demand` is set (the git default). The PR head's `.gitmodules` is attacker-controlled and present in the working directory at the time of the fetch. Git attempts to fetch submodule objects, which blocks waiting for credentials that never arrive in CI.

## Fix

Two changes, both defence-in-depth:

**1. Delete `SENSITIVE_PATHS` before fetching** (order swap)

The attacker-controlled `.gitmodules` is removed before the `git fetch` call. Git never sees a submodule config to follow, regardless of runner git settings.

**2. Pass `--no-recurse-submodules` to `git fetch`**

Explicitly suppresses submodule fetching independent of any `fetch.recurseSubmodules` config on the runner.

The original order (fetch-then-delete) had a brief window where `.gitmodules` from the PR head could influence the fetch. The reorder also tightens the security property: if the subsequent `git checkout` fails for a path, the attacker-controlled file is already gone rather than present during the network operation.

## Testing

`bun test` — 653 pass, 0 fail. No logic changes to the restore flow; the fix is purely ordering + flag.
