### PR TITLE
fix: allow # in branch names for PR checkout and base restore

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -28,7 +28,7 @@ function extractFirstLabel(githubData: FetchDataResult): string | undefined {
  *
  * Valid branch names:
  * - Start with alphanumeric character (not dash, to prevent option injection)
- * - Contain only alphanumeric, forward slash, hyphen, underscore, or period
+ * - Contain only alphanumeric, forward slash, hyphen, underscore, period, or hash (#)
  * - Do not start or end with a period
  * - Do not end with a slash
  * - Do not contain '..' (path traversal)
@@ -58,12 +58,14 @@ export function validateBranchName(branchName: string): void {
     );
   }
 
-  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/period
-  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$/;
+  // Strict whitelist pattern: alphanumeric start, then alphanumeric/slash/hyphen/underscore/period/hash.
+  // # is valid per git-check-ref-format and commonly used in branch names like "fix/#123-description".
+  // All git calls use execFileSync (not shell interpolation), so # carries no injection risk.
+  const validPattern = /^[a-zA-Z0-9][a-zA-Z0-9/_.#-]*$/;
 
   if (!validPattern.test(branchName)) {
     throw new Error(
-      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, or periods.`,
+      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character and contain only alphanumeric characters, forward slashes, hyphens, underscores, periods, or hashes (#).`,
     );
   }
 

--- a/test/validate-branch-name.test.ts
+++ b/test/validate-branch-name.test.ts
@@ -36,6 +36,13 @@ describe("validateBranchName", () => {
       expect(() => validateBranchName("refs/heads/main")).not.toThrow();
       expect(() => validateBranchName("bugfix/JIRA-1234")).not.toThrow();
     });
+
+    it("should accept branch names containing # (git-valid, common in issue-linked branches)", () => {
+      // Reported in #1137: branches like "put-back-arm64-#2" were rejected
+      expect(() => validateBranchName("put-back-arm64-#2")).not.toThrow();
+      expect(() => validateBranchName("feature/#123-description")).not.toThrow();
+      expect(() => validateBranchName("fix/issue-#42")).not.toThrow();
+    });
   });
 
   describe("command injection attempts", () => {


### PR DESCRIPTION
## Problem

`validateBranchName` rejects `#`, causing the action to fail on PRs from branches like `put-back-arm64-#2`:

```
##[error] Invalid branch name: "put-back-arm64-#2". Branch names must start with an
alphanumeric character and contain only alphanumeric characters, forward slashes,
hyphens, underscores, or periods.
```

There is no workaround — the branch already exists in git, and GitHub provided its name through the event payload. Fixes #1137.

## Root cause

The whitelist regex `/^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$/` excludes `#`. The validation exists to prevent command injection, but every git call in the action uses `execFileSync`, which bypasses the shell entirely (arguments go directly to the kernel via `execve`). There is no shell to interpret `#`, so the strict whitelist was blocking valid names with no security benefit.

`#` is explicitly permitted by `git-check-ref-format`.

## Fix

Add `#` to the whitelist: `/^[a-zA-Z0-9][a-zA-Z0-9/_.#-]*$/`. Update the JSDoc and error message to match.

## Testing

- 3 new test cases covering `#` in mid-name and path-segment positions
- All existing rejection cases still pass
- `bun test`: 654 pass, 0 fail
