### PR TITLE
fix: Add code-review plugin example with required --comment flag

### DIFF
--- a/docs/solutions.md
+++ b/docs/solutions.md
@@ -71,6 +71,45 @@ jobs:
 
 **Expected Output:** Claude posts review comments directly to the PR with inline annotations where appropriate.
 
+### Plugin Example (code-review plugin)
+
+The `code-review` plugin from the `claude-code-plugins` marketplace launches multiple parallel agents with confidence-based scoring to filter false positives. It checks for bugs, CLAUDE.md compliance, and historical context via git blame.
+
+```yaml
+name: Claude Code Review (Plugin)
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+```
+
+**Key Configuration:**
+
+- **`--comment` flag is required** — without it, the plugin outputs to terminal only and no PR comments are posted
+- `pull-requests: write` is required for posting review comments
+- The plugin uses `gh` CLI internally (allowed by its command definition)
+
+**Expected Output:** Confidence-scored review comments (threshold ≥80) posted as inline PR comments, or a clean-pass summary if no issues found.
+
 ### Enhanced Example (With Progress Tracking)
 
 Want visual progress tracking for PR reviews? Use `track_progress: true` to get tracking comments like in v0.x:

--- a/examples/pr-review-plugin.yml
+++ b/examples/pr-review-plugin.yml
@@ -1,0 +1,38 @@
+name: Claude Code Review (Plugin)
+
+# Uses the code-review plugin from the claude-code-plugins marketplace.
+# The plugin launches multiple parallel agents with confidence-based scoring
+# to filter false positives. See the plugin README for details:
+# https://github.com/anthropics/claude-code/tree/main/plugins/code-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # Required to post review comments
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+
+          # IMPORTANT: The --comment flag is required for the plugin to post
+          # review comments to the PR. Without it, the review output only goes
+          # to the terminal and no comments will appear on the pull request.
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary

The `code-review` plugin requires the `--comment` flag to post review comments to the PR. Without it, the review completes successfully but output only goes to terminal — no comments are posted. This is a common pitfall because:

1. The workflow generated by `/install-github-app` omits the `--comment` flag
2. The plugin README documents it, but the action repo has no example showing the correct setup
3. Runs complete with `is_error: false` giving no indication that comments were silently skipped

This PR adds:
- **`examples/pr-review-plugin.yml`** — a new example workflow showing the correct plugin-based review setup with `--comment`, proper `pull-requests: write` permissions, and explanatory comments
- **`docs/solutions.md`** — a new "Plugin Example" section under "Automatic PR Code Review" showing the plugin approach alongside the existing custom-prompt examples

## Context

Multiple users have reported this issue:
- #1087 — code-review plugin completes but produces empty result
- anthropics/claude-code#26227 — `/install-github-app` generates broken `claude-code-review.yml`

The root cause in all cases is the missing `--comment` flag in the prompt. The plugin's command file (`commands/code-review.md`, step 7) explicitly gates comment posting on this argument:

> If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.

## Changes

### `examples/pr-review-plugin.yml` (new)
Complete working example with:
- `--comment` flag in the prompt
- `pull-requests: write` permission
- Comments explaining why `--comment` is required

### `docs/solutions.md`
New "Plugin Example" subsection showing the plugin approach with `--comment`, between the existing "Basic Example" and "Enhanced Example" sections.