### PR TITLE
fix: snapshot PR's .claude/ to .claude-pr/ before security restore

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { rmSync } from "fs";
+import { cpSync, existsSync, rmSync } from "fs";
 
 // Paths that are both PR-controllable and read from cwd at CLI startup.
 //
@@ -43,6 +43,19 @@ export function restoreConfigFromBase(baseBranch: string): void {
   console.log(
     `Restoring ${SENSITIVE_PATHS.join(", ")} from origin/${baseBranch} (PR head is untrusted)`,
   );
+
+  // Snapshot the PR's .claude/ tree to .claude-pr/ before deleting it.
+  // This lets review agents inspect what the PR actually changes (CLAUDE.md,
+  // settings, hooks, MCP configs) without those files ever being executed.
+  // The snapshot is taken before the security delete so it captures the
+  // PR-authored version.
+  rmSync(".claude-pr", { recursive: true, force: true });
+  if (existsSync(".claude")) {
+    cpSync(".claude", ".claude-pr", { recursive: true });
+    console.log(
+      "Preserved PR's .claude/ → .claude-pr/ for review agents (not executed)",
+    );
+  }
 
   // Delete PR-controlled versions BEFORE fetching so the attacker-controlled
   // .gitmodules is absent during the network operation. If git reads .gitmodules


### PR DESCRIPTION
Fixes #1134.

## Problem

When a PR modifies files under `.claude/`, `restoreConfigFromBase()` overwrites them with the base branch version before the CLI runs. This is correct for execution safety — but it means review agents never see what the PR actually changes.

Two concrete breakages:
1. A PR adding hooks, MCP configs, or agent specs to `.claude/` is never inspected — it merges without review.
2. A review agent checking `.claude/CLAUDE.md` for accuracy reads the base branch version and keeps flagging issues the PR already fixed.

## Fix

Before deleting the PR-controlled `.claude/` tree, copy it to `.claude-pr/`. Review agents can read `.claude-pr/` to inspect the PR's changes without those files ever being executed by the CLI.

The snapshot is taken before the security delete, so it captures the full PR-authored version. The existing restore logic is unchanged.

## Security

No execution surface is added. `.claude-pr/` is never read by the CLI at startup — only `.claude/` is. The snapshot is data-only; hooks, MCP servers, and permission settings still run from the base branch version.