### PR TITLE
fix: merge project permissions.allow into tag mode --allowedTools

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -246,6 +246,34 @@ async function run() {
       }
       if (restoreBase) {
         restoreConfigFromBase(restoreBase);
+
+        // After restore, .claude/settings.json is the trusted base-branch version.
+        // For tag mode, merge its permissions.allow entries into claudeArgs so that
+        // project-approved tools (e.g. Bash(pnpm test:*)) are not silently denied.
+        // PR #1002 hardened tag mode with an explicit --allowedTools allowlist, which
+        // inadvertently stopped respecting project settings entirely.
+        if (modeName === "tag") {
+          try {
+            const settingsPath = ".claude/settings.json";
+            if (existsSync(settingsPath)) {
+              const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+              const projectAllow: unknown = settings?.permissions?.allow;
+              if (Array.isArray(projectAllow) && projectAllow.length > 0) {
+                const projectTools = projectAllow.filter(
+                  (t): t is string => typeof t === "string" && t.length > 0,
+                );
+                if (projectTools.length > 0) {
+                  prepareResult.claudeArgs += ` --allowedTools "${projectTools.join(",")}"`;
+                  console.log(
+                    `Merged ${projectTools.length} project permission(s) from .claude/settings.json into tag mode tools`,
+                  );
+                }
+              }
+            }
+          } catch {
+            // Malformed settings.json — proceed with hardcoded tool list only.
+          }
+        }
       }
     }
 

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -246,34 +246,38 @@ async function run() {
       }
       if (restoreBase) {
         restoreConfigFromBase(restoreBase);
+      }
+    }
 
-        // After restore, .claude/settings.json is the trusted base-branch version.
-        // For tag mode, merge its permissions.allow entries into claudeArgs so that
-        // project-approved tools (e.g. Bash(pnpm test:*)) are not silently denied.
-        // PR #1002 hardened tag mode with an explicit --allowedTools allowlist, which
-        // inadvertently stopped respecting project settings entirely.
-        if (modeName === "tag") {
-          try {
-            const settingsPath = ".claude/settings.json";
-            if (existsSync(settingsPath)) {
-              const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
-              const projectAllow: unknown = settings?.permissions?.allow;
-              if (Array.isArray(projectAllow) && projectAllow.length > 0) {
-                const projectTools = projectAllow.filter(
-                  (t): t is string => typeof t === "string" && t.length > 0,
-                );
-                if (projectTools.length > 0) {
-                  prepareResult.claudeArgs += ` --allowedTools "${projectTools.join(",")}"`;
-                  console.log(
-                    `Merged ${projectTools.length} project permission(s) from .claude/settings.json into tag mode tools`,
-                  );
-                }
-              }
+    // For tag mode, merge project permissions.allow into the allowed tool list.
+    // .claude/settings.json is trusted at this point in both cases:
+    //   - PR events: restoreConfigFromBase replaced it with the base-branch version above.
+    //   - Issue events: the checkout is from the default branch (no untrusted PR code).
+    // PR #1002 added an explicit --allowedTools list for security, which inadvertently
+    // stopped the CLI from respecting project settings. This restores that behavior.
+    if (modeName === "tag") {
+      try {
+        const settingsPath = ".claude/settings.json";
+        if (existsSync(settingsPath)) {
+          const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+          const projectAllow: unknown = settings?.permissions?.allow;
+          if (Array.isArray(projectAllow)) {
+            const projectTools = projectAllow.filter(
+              // Exclude entries that contain `"` — they would escape out of the
+              // double-quoted --allowedTools shell argument and corrupt the args string.
+              (t): t is string =>
+                typeof t === "string" && t.length > 0 && !t.includes('"'),
+            );
+            if (projectTools.length > 0) {
+              prepareResult.claudeArgs += ` --allowedTools "${projectTools.join(",")}"`;
+              console.log(
+                `Merged ${projectTools.length} project permission(s) from .claude/settings.json into tag mode tools`,
+              );
             }
-          } catch {
-            // Malformed settings.json — proceed with hardcoded tool list only.
           }
         }
+      } catch {
+        // Malformed settings.json — proceed with hardcoded tool list only.
       }
     }
 


### PR DESCRIPTION
Fixes #1063.

## Problem

PR #1002 (\"Harden tag mode tool permissions against prompt injection\") added an explicit `--allowedTools` list to tag mode. In `acceptEdits` mode with no prompt handler, anything not in that list hits \"ask\" → immediately denied. This regression broke project `.claude/settings.json` `permissions.allow` entries — tools like `Bash(pnpm test:*)` that maintainers explicitly approved are silently denied.

## Fix

`restoreConfigFromBase()` already runs in `run.ts` before the CLI starts, replacing `.claude/` with the trusted base-branch version. After that restore, read the project's trusted `permissions.allow` entries and append them to `claudeArgs` as an additional `--allowedTools` flag.

This restores the pre-#1002 behavior of respecting project settings while keeping the hardening intact — the entries come from the base branch (maintainer-reviewed), not the PR head.

## Security

No new trust surface. The project `permissions.allow` entries are read from the base-branch version of `.claude/settings.json` (already trusted by the existing restore logic), not from the PR-authored version.