### PR TITLE
fix: pin bun runtime config and improve log hygiene

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -227,7 +227,10 @@ runs:
       id: run
       shell: bash
       run: |
-        bun run ${GITHUB_ACTION_PATH}/src/entrypoints/run.ts
+        bun --no-env-file \
+          --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
+          --tsconfig-override="${GITHUB_ACTION_PATH}/tsconfig.json" \
+          run ${GITHUB_ACTION_PATH}/src/entrypoints/run.ts
       env:
         # Prepare inputs
         MODE: ${{ inputs.mode }}
@@ -324,7 +327,10 @@ runs:
       if: always() && inputs.ssh_signing_key != ''
       shell: bash
       run: |
-        bun run ${GITHUB_ACTION_PATH}/src/entrypoints/cleanup-ssh-signing.ts
+        bun --no-env-file \
+          --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
+          --tsconfig-override="${GITHUB_ACTION_PATH}/tsconfig.json" \
+          run ${GITHUB_ACTION_PATH}/src/entrypoints/cleanup-ssh-signing.ts
 
     - name: Post buffered inline comments
       if: always() && inputs.classify_inline_comments != 'false'
@@ -336,7 +342,10 @@ runs:
         PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
       run: |
-        bun run ${GITHUB_ACTION_PATH}/src/entrypoints/post-buffered-inline-comments.ts
+        bun --no-env-file \
+          --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
+          --tsconfig-override="${GITHUB_ACTION_PATH}/tsconfig.json" \
+          run ${GITHUB_ACTION_PATH}/src/entrypoints/post-buffered-inline-comments.ts
 
     - name: Revoke app token
       if: always() && inputs.github_token == '' && steps.run.outputs.github_token != '' && steps.run.outputs.skipped_due_to_workflow_validation_mismatch != 'true'

--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -151,7 +151,7 @@ export async function runClaudeWithSdk(
 
   console.log(`Running Claude with prompt from file: ${promptPath}`);
   // Log SDK options without env (which could contain sensitive data)
-  const { env, ...optionsToLog } = sdkOptions;
+  const { env, extraArgs, ...optionsToLog } = sdkOptions;
   console.log("SDK options:", JSON.stringify(optionsToLog, null, 2));
 
   const messages: SDKMessage[] = [];

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -343,9 +343,7 @@ describe("parseSdkOptions", () => {
       const result = parseSdkOptions(options);
 
       expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-haiku");
-      expect(result.sdkOptions.extraArgs?.["prompt"]).toBe(
-        "use color #ff0000",
-      );
+      expect(result.sdkOptions.extraArgs?.["prompt"]).toBe("use color #ff0000");
     });
   });
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+# Intentionally minimal. action.yml pins --config to this file so bun resolves
+# its runtime config from the action directory rather than the workspace.

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -15,6 +15,9 @@ const SENSITIVE_PATHS = [
   ".claude.json",
   ".gitmodules",
   ".ripgreprc",
+  "CLAUDE.md",
+  "CLAUDE.local.md",
+  ".husky",
 ];
 
 /**

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -47,16 +47,19 @@ export function restoreConfigFromBase(baseBranch: string): void {
     `Restoring ${SENSITIVE_PATHS.join(", ")} from origin/${baseBranch} (PR head is untrusted)`,
   );
 
-  // Snapshot the PR's .claude/ tree to .claude-pr/ before deleting it.
-  // This lets review agents inspect what the PR actually changes (CLAUDE.md,
-  // settings, hooks, MCP configs) without those files ever being executed.
-  // The snapshot is taken before the security delete so it captures the
+  // Snapshot every PR-authored sensitive path into .claude-pr/ before deletion
+  // so review agents can inspect what the PR changes without those files ever
+  // being executed. Captured before the security delete so it reflects the
   // PR-authored version.
   rmSync(".claude-pr", { recursive: true, force: true });
-  if (existsSync(".claude")) {
-    cpSync(".claude", ".claude-pr", { recursive: true });
+  for (const p of SENSITIVE_PATHS) {
+    if (existsSync(p)) {
+      cpSync(p, `.claude-pr/${p}`, { recursive: true });
+    }
+  }
+  if (existsSync(".claude-pr")) {
     console.log(
-      "Preserved PR's .claude/ → .claude-pr/ for review agents (not executed)",
+      "Preserved PR's sensitive paths → .claude-pr/ for review agents (not executed)",
     );
   }
 

--- a/src/github/token.ts
+++ b/src/github/token.ts
@@ -148,6 +148,7 @@ export async function setupGitHubToken(): Promise<string> {
     },
   );
   console.log("App token successfully obtained");
+  core.setSecret(appToken);
 
   console.log("Using GITHUB_TOKEN from OIDC");
   return appToken;


### PR DESCRIPTION
- Pin `--config`, `--tsconfig-override`, and `--no-env-file` on the three `bun run` entrypoints so bun resolves runtime config from the action directory instead of the workspace
- Register the OIDC-exchanged app token with `core.setSecret`
- Omit `extraArgs` from the SDK options debug log alongside `env`
- Add `CLAUDE.md`, `CLAUDE.local.md`, and `.husky` to the config-restore list
- Prettier line-wrap in `base-action/test/parse-sdk-options.test.ts` (drift from #1055)

Tests, typecheck, and format all pass.