### PR TITLE
chore: fix prettier formatting in parse-sdk-options.test.ts

### DIFF
--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -343,9 +343,7 @@ describe("parseSdkOptions", () => {
       const result = parseSdkOptions(options);
 
       expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-haiku");
-      expect(result.sdkOptions.extraArgs?.["prompt"]).toBe(
-        "use color #ff0000",
-      );
+      expect(result.sdkOptions.extraArgs?.["prompt"]).toBe("use color #ff0000");
     });
   });
 


### PR DESCRIPTION
Line-wrap drift from #1055.

Note: #1174 also includes this fix, so whichever merges first resolves it.