### PR TITLE
fix: allow track_progress with pull_request labeled action

### DIFF
--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -67,6 +67,7 @@ export function detectMode(context: GitHubContext): AutoDetectedMode {
       "synchronize",
       "ready_for_review",
       "reopened",
+      "labeled",
     ];
     if (context.eventAction && supportedActions.includes(context.eventAction)) {
       // If prompt is provided, use agent mode (default for automation)
@@ -103,6 +104,7 @@ function validateTrackProgressEvent(context: GitHubContext): void {
       "synchronize",
       "ready_for_review",
       "reopened",
+      "labeled",
     ];
     if (!validActions.includes(context.eventAction)) {
       throw new Error(

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -76,6 +76,20 @@ describe("detectMode with enhanced routing", () => {
       expect(detectMode(context)).toBe("agent");
     });
 
+    it("should use tag mode when track_progress is true for pull_request.labeled", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "labeled",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, trackProgress: true },
+      };
+
+      expect(detectMode(context)).toBe("tag");
+    });
+
     it("should throw error when track_progress is used with unsupported PR action", () => {
       const context: GitHubContext = {
         ...baseContext,


### PR DESCRIPTION
## Problem

`track_progress: true` throws when the workflow fires on `pull_request: [labeled]`:

```
Error: track_progress for pull_request events is only supported for actions:
opened, synchronize, ready_for_review, reopened. Current action: labeled
```

Using labels as an explicit review trigger is a common pattern — users add a label to request a review rather than running on every push. The `labeled` event carries the same PR number and commit SHA as `opened`/`synchronize`, so `track_progress` has everything it needs.

## Changes

`src/modes/detector.ts`:
- Add `"labeled"` to `validActions` in `validateTrackProgressEvent` (removes the throw)
- Add `"labeled"` to `supportedActions` in `detectMode` (ensures tag mode is selected when `track_progress` + `prompt` are set)

`test/modes/detector.test.ts`:
- Add test: `track_progress: true` with `pull_request.labeled` returns `"tag"`

Fixes #1095