### PR TITLE
fix: remove PR action allowlist from track_progress validation

### DIFF
--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -67,7 +67,6 @@ export function detectMode(context: GitHubContext): AutoDetectedMode {
       "synchronize",
       "ready_for_review",
       "reopened",
-      "labeled",
     ];
     if (context.eventAction && supportedActions.includes(context.eventAction)) {
       // If prompt is provided, use agent mode (default for automation)
@@ -97,20 +96,4 @@ function validateTrackProgressEvent(context: GitHubContext): void {
     );
   }
 
-  // Additionally validate PR actions
-  if (context.eventName === "pull_request" && context.eventAction) {
-    const validActions = [
-      "opened",
-      "synchronize",
-      "ready_for_review",
-      "reopened",
-      "labeled",
-    ];
-    if (!validActions.includes(context.eventAction)) {
-      throw new Error(
-        `track_progress for pull_request events is only supported for actions: ` +
-          `${validActions.join(", ")}. Current action: ${context.eventAction}`,
-      );
-    }
-  }
 }

--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -67,6 +67,7 @@ export function detectMode(context: GitHubContext): AutoDetectedMode {
       "synchronize",
       "ready_for_review",
       "reopened",
+      "labeled",
     ];
     if (context.eventAction && supportedActions.includes(context.eventAction)) {
       // If prompt is provided, use agent mode (default for automation)
@@ -103,6 +104,7 @@ function validateTrackProgressEvent(context: GitHubContext): void {
       "synchronize",
       "ready_for_review",
       "reopened",
+      "labeled",
     ];
     if (!validActions.includes(context.eventAction)) {
       throw new Error(

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -76,6 +76,20 @@ describe("detectMode with enhanced routing", () => {
       expect(detectMode(context)).toBe("agent");
     });
 
+    it("should use tag mode when track_progress is true for pull_request.labeled", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "labeled",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, trackProgress: true },
+      };
+
+      expect(detectMode(context)).toBe("tag");
+    });
+
     it("should throw error when track_progress is used with unsupported PR action", () => {
       const context: GitHubContext = {
         ...baseContext,

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -90,7 +90,7 @@ describe("detectMode with enhanced routing", () => {
       expect(detectMode(context)).toBe("tag");
     });
 
-    it("should throw error when track_progress is used with unsupported PR action", () => {
+    it("should use tag mode when track_progress is true for pull_request.closed", () => {
       const context: GitHubContext = {
         ...baseContext,
         eventName: "pull_request",
@@ -101,9 +101,7 @@ describe("detectMode with enhanced routing", () => {
         inputs: { ...baseContext.inputs, trackProgress: true },
       };
 
-      expect(() => detectMode(context)).toThrow(
-        /track_progress for pull_request events is only supported for actions/,
-      );
+      expect(detectMode(context)).toBe("tag");
     });
   });
 


### PR DESCRIPTION
## Problem

`track_progress: true` throws on `pull_request: [labeled]` (and any other non-listed action like `unlabeled`, `edited`, `assigned`):

```
Error: track_progress for pull_request events is only supported for actions:
opened, synchronize, ready_for_review, reopened. Current action: labeled
```

## Root cause

`validateTrackProgressEvent` had a secondary check that restricted `pull_request` events to a hardcoded action list. But `track_progress` only needs `pull_request.number` to post progress comments — which every `pull_request` action provides. The action-level restriction was over-engineered and had no protective purpose.

## Fix

Remove the `// Additionally validate PR actions` block entirely. The event-type check (`pull_request` is valid, `workflow_dispatch` throws) is the correct gate.

Extending the list would have been a patch that breaks again for the next unlisted action. Removing it is the correct fix.

## Changes

- `src/modes/detector.ts`: delete the 14-line PR action validation block
- `test/modes/detector.test.ts`: update old "unsupported action" test (now `closed` returns "tag"); add test for `labeled`

All 16 detector tests pass.

Fixes #1095