### PR TITLE
fix: respect user-provided enableAllProjectMcpServers value

### DIFF
--- a/base-action/src/setup-claude-code-settings.ts
+++ b/base-action/src/setup-claude-code-settings.ts
@@ -59,9 +59,11 @@ export async function setupClaudeCodeSettings(
     console.log(`Merged settings with input settings`);
   }
 
-  // Always set enableAllProjectMcpServers to true
-  settings.enableAllProjectMcpServers = true;
-  console.log(`Updated settings with enableAllProjectMcpServers: true`);
+  // Default enableAllProjectMcpServers to true if not explicitly set by the user
+  settings.enableAllProjectMcpServers ??= true;
+  console.log(
+    `Using enableAllProjectMcpServers: ${settings.enableAllProjectMcpServers}`,
+  );
 
   await $`echo ${JSON.stringify(settings, null, 2)} > ${settingsPath}`.quiet();
   console.log(`Settings saved successfully`);

--- a/base-action/test/setup-claude-code-settings.test.ts
+++ b/base-action/test/setup-claude-code-settings.test.ts
@@ -79,9 +79,24 @@ describe("setupClaudeCodeSettings", () => {
     expect(settings.permissions).toEqual(testSettings.permissions);
   });
 
-  test("should override enableAllProjectMcpServers even if false in input", async () => {
+  test("should respect explicit false for enableAllProjectMcpServers", async () => {
     const inputSettings = JSON.stringify({
       enableAllProjectMcpServers: false,
+      model: "test-model",
+    });
+
+    await setupClaudeCodeSettings(inputSettings, testHomeDir);
+
+    const settingsContent = await readFile(settingsPath, "utf-8");
+    const settings = JSON.parse(settingsContent);
+
+    expect(settings.enableAllProjectMcpServers).toBe(false);
+    expect(settings.model).toBe("test-model");
+  });
+
+  test("should respect explicit true for enableAllProjectMcpServers", async () => {
+    const inputSettings = JSON.stringify({
+      enableAllProjectMcpServers: true,
       model: "test-model",
     });
 


### PR DESCRIPTION
Fixes #1042

## Root cause

`setupClaudeCodeSettings` unconditionally overwrites `enableAllProjectMcpServers` to `true` after merging the user's settings input, making it impossible to opt out of project MCP server loading:

```typescript
// Always set enableAllProjectMcpServers to true
settings.enableAllProjectMcpServers = true;
```

## Impact

Users with a `.mcp.json` containing local-path MCP servers (e.g., servers that require AWS credentials not available in CI) cannot suppress project MCP loading. Every action run generates permission denial errors for tools that were never meant to run in CI.

## Fix

Replace the unconditional override with a nullish default so an explicit `false` (or `true`) from the user is preserved. Only absent values fall back to `true`:

```typescript
settings.enableAllProjectMcpServers ??= true;
```

This matches the nullish-coalescing pattern already used elsewhere in the file (`homeDir ?? homedir()`).

## Tests

- Updated `"should override enableAllProjectMcpServers even if false in input"` → now verifies `false` is **respected**, not overridden
- Added `"should respect explicit true for enableAllProjectMcpServers"` to cover the explicit-`true` case
- All 665 existing tests pass