### PR TITLE
chore: update setup-bun from v2.1.2 to v2.2.0 (Node.js 24)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -173,7 +173,7 @@ runs:
   steps:
     - name: Install Bun
       if: inputs.path_to_bun_executable == ''
-      uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # https://github.com/oven-sh/setup-bun/releases/tag/v2.1.2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
       with:
         bun-version: 1.3.6
         token: ${{ inputs.github_token || github.token }}

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -97,7 +97,7 @@ runs:
 
     - name: Install Bun
       if: inputs.path_to_bun_executable == ''
-      uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # https://github.com/oven-sh/setup-bun/releases/tag/v2.1.2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
       with:
         bun-version: 1.3.6
 


### PR DESCRIPTION
Closes #1050

## Summary

`oven-sh/setup-bun` v2.2.0 was released 2026-03-14 with the action runtime updated from Node.js 20 to Node.js 24 ([oven-sh/setup-bun#176](https://github.com/oven-sh/setup-bun/pull/176)).

Both action files currently pin v2.1.2 (SHA `3d267786...`), which produces a deprecation warning on every workflow run:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Changes

- `action.yml`: `3d267786...` → `0c5077e5...` (v2.2.0)
- `base-action/action.yml`: same

No functional changes — v2.2.0 is a GitHub Actions runtime update only. The Bun runtime version is still controlled by the `bun-version` input and is unchanged.

## Test plan

- [x] Full `bun test` suite passes (664/664)
- [x] No other files reference the old SHA