### PR TITLE
fix: wire max_turns input through to SDK in run.ts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,10 @@ inputs:
     required: false
     default: "false"
 
+  max_turns:
+    description: "Maximum number of agentic turns for Claude to use"
+    required: false
+    default: ""
   claude_args:
     description: "Additional arguments to pass directly to Claude CLI"
     required: false
@@ -268,6 +272,7 @@ runs:
         INPUT_EXPERIMENTAL_SLASH_COMMANDS_DIR: ${{ github.action_path }}/slash-commands
         INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
+        INPUT_MAX_TURNS: ${{ inputs.max_turns }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
         DISPLAY_REPORT: ${{ inputs.display_report }}
         INPUT_PLUGINS: ${{ inputs.plugins }}

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -268,6 +268,7 @@ async function run() {
     const claudeResult: ClaudeRunResult = await runClaude(promptConfig.path, {
       claudeArgs: prepareResult.claudeArgs,
       appendSystemPrompt: process.env.APPEND_SYSTEM_PROMPT,
+      maxTurns: process.env.INPUT_MAX_TURNS,
       model: process.env.ANTHROPIC_MODEL,
       pathToClaudeCodeExecutable:
         process.env.INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE,


### PR DESCRIPTION
## Summary

`run.ts` never passes `maxTurns` to `runClaude()`, so the SDK omits `--max-turns` from the CLI args and the CLI defaults to 10 turns. The base-action entrypoint already wires this correctly — `run.ts` was just missing it.

- Added `max_turns` input to `action.yml`
- Passed `INPUT_MAX_TURNS` through the composite step env block
- Added `maxTurns` to the `runClaude()` call in `run.ts`

Note: `--max-turns` via `claude_args` does work correctly (the SDK passes `extraArgs` through to the CLI). This fix adds the dedicated `max_turns` input for discoverability and consistency with the base-action.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` passes (664/664)
- [x] `bun run format:check` passes
- [ ] Verify in a live workflow: `max_turns: 50` allows Claude beyond 10 turns

Fixes #1177