### PR TITLE
security: reject PATH_TO_CLAUDE_CODE_EXECUTABLE with control characters

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -47,6 +47,11 @@ import type { ClaudeRunResult } from "../../base-action/src/run-claude-sdk";
 async function installClaudeCode(): Promise<void> {
   const customExecutable = process.env.PATH_TO_CLAUDE_CODE_EXECUTABLE;
   if (customExecutable) {
+    if (/[\x00-\x1f\x7f]/.test(customExecutable)) {
+      throw new Error(
+        "PATH_TO_CLAUDE_CODE_EXECUTABLE contains control characters (e.g. newlines), which is not allowed",
+      );
+    }
     console.log(`Using custom Claude Code executable: ${customExecutable}`);
     const claudeDir = dirname(customExecutable);
     // Add to PATH by appending to GITHUB_PATH


### PR DESCRIPTION
## Summary

`installClaudeCode()` in `run.ts` passes `PATH_TO_CLAUDE_CODE_EXECUTABLE` through `dirname()` and writes the result to `GITHUB_PATH` via `appendFile`. Node's `dirname()` preserves embedded newlines, so a value like `/usr/bin/claude\n/attacker/path` writes two lines to `GITHUB_PATH` — injecting an attacker-controlled directory into `PATH` for all subsequent workflow steps.

This adds a fail-closed validation: if the path contains any control characters (0x00-0x1f, 0x7f), the action throws immediately before any use of the value. A path with control characters is always misconfigured or malicious, so failing loudly is better than silent stripping (which could produce a valid-looking but wrong path).

**Note:** `action.yml` has a similar pattern at line 193-194 for `path_to_bun_executable` via shell `dirname` + `echo >>`. Bash `dirname` strips trailing newlines (POSIX behavior), partially mitigating the shell path, but it could be hardened in a follow-up.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` passes (664/664)
- [x] `bun run format:check` passes
- [x] Verified Node `dirname()` preserves embedded newlines: `dirname("/usr/bin/claude\n/evil/path")` → `"/usr/bin/claude\n/evil"`

Fixes #1160