### PR TITLE
fix: dereference symlinks when snapshotting sensitive paths to .claude-pr/

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -54,7 +54,7 @@ export function restoreConfigFromBase(baseBranch: string): void {
   rmSync(".claude-pr", { recursive: true, force: true });
   for (const p of SENSITIVE_PATHS) {
     if (existsSync(p)) {
-      cpSync(p, `.claude-pr/${p}`, { recursive: true });
+      cpSync(p, `.claude-pr/${p}`, { recursive: true, dereference: true });
     }
   }
   if (existsSync(".claude-pr")) {


### PR DESCRIPTION
## Summary
- Adds `dereference: true` to the `cpSync` call that snapshots PR-authored sensitive paths into `.claude-pr/`
- Fixes `ENOENT: no such file or directory, symlink` crash when a sensitive path (e.g. `CLAUDE.md`) is a symlink

## Problem
`cpSync` defaults to `dereference: false`, which means it tries to recreate symlinks at the destination rather than copying file contents. When a sensitive path like `CLAUDE.md` is a symlink (e.g. `CLAUDE.md -> AGENTS.md`), the copy fails because `cpSync` calls `symlink()` without ensuring the parent `.claude-pr/` directory exists first.

**Error:**
```
Restoring .claude, .mcp.json, .claude.json, .gitmodules, .ripgreprc, CLAUDE.md, CLAUDE.local.md, .husky from origin/main (PR head is untrusted)
ENOENT: no such file or directory, symlink
```

## Fix
Adding `dereference: true` follows symlinks and copies the actual file contents instead of recreating the symlink. This is also the correct semantic behavior — review agents need to inspect the real content, not a symlink that may not resolve correctly from `.claude-pr/`.

## Test plan
- [x] Verify the action works on a repo where `CLAUDE.md` is a symlink to another file
- [x] Verify the action still works on repos with regular (non-symlink) sensitive paths