### PR TITLE
fix: respect explicit mode input instead of always auto-detecting

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -153,9 +153,20 @@ async function run() {
     // Phase 1: Prepare
     const actionInputsPresent = collectActionInputsPresence();
     context = parseGitHubContext();
-    const modeName = detectMode(context);
+    // Respect explicit mode input; fall back to auto-detection
+    const explicitMode = process.env.MODE as
+      | "agent"
+      | "tag"
+      | ""
+      | undefined;
+    const modeName =
+      explicitMode === "agent" || explicitMode === "tag"
+        ? explicitMode
+        : detectMode(context);
     console.log(
-      `Auto-detected mode: ${modeName} for event: ${context.eventName}`,
+      explicitMode
+        ? `Explicit mode: ${modeName} (from mode input)`
+        : `Auto-detected mode: ${modeName} for event: ${context.eventName}`,
     );
 
     try {
@@ -191,13 +202,17 @@ async function run() {
     }
 
     // Check trigger conditions
-    const containsTrigger =
-      modeName === "tag"
+    // When mode is explicitly set via input, the user opted in — skip trigger detection
+    const containsTrigger = explicitMode
+      ? true
+      : modeName === "tag"
         ? isEntityContext(context) && checkContainsTrigger(context)
         : !!context.inputs?.prompt;
     console.log(`Mode: ${modeName}`);
     console.log(`Context prompt: ${context.inputs?.prompt || "NO PROMPT"}`);
-    console.log(`Trigger result: ${containsTrigger}`);
+    console.log(
+      `Trigger result: ${containsTrigger}${explicitMode ? " (explicit mode — trigger bypassed)" : ""}`,
+    );
 
     if (!containsTrigger) {
       console.log("No trigger found, skipping remaining steps");


### PR DESCRIPTION
## Summary

When users set `mode: agent` in their workflow, the action ignores it and exits with "No trigger found, skipping." This PR makes the explicit `mode` input actually work.

Fixes #1197

## Root cause

1. `action.yml:246` sets `MODE=${{ inputs.mode }}` as an env var
2. `detectMode()` in `src/modes/detector.ts` never reads `process.env.MODE` — it only auto-detects from event context
3. Trigger check (`run.ts:194-197`) requires `context.inputs.prompt` to be truthy for agent mode, but users using `direct_prompt` have an empty `prompt` → `containsTrigger = false` → skip

`process.env.MODE` is set but never read anywhere in the codebase.

## Fix

Two changes in `src/entrypoints/run.ts`:

1. **Check `process.env.MODE` before calling `detectMode()`** — if explicitly `"agent"` or `"tag"`, use it directly instead of auto-detecting
2. **Bypass trigger detection when mode is explicit** — the user opted in by setting `mode`, so no trigger check is needed

## What changes

| Scenario | Before | After |
|----------|--------|-------|
| `mode: agent` + `direct_prompt` | "No trigger found, skipping" | Runs Claude |
| `mode: agent` + `prompt` | "No trigger found, skipping" (if no entity context) | Runs Claude |
| `mode: tag` (explicit) | Auto-detected as tag (worked by coincidence) | Explicitly tag |
| No `mode` set | Auto-detect | Auto-detect (unchanged) |

## Test plan

- [x] TypeScript compiles with zero errors (`npx tsc --noEmit`)
- [x] Traced the full code path: `action.yml:246` → `process.env.MODE` → `run.ts:156` → `detectMode()` confirms MODE is never read
- [x] Confirmed `base-action/src/index.ts` already handles mode correctly (this fix aligns `run.ts` with that behavior)