### PR TITLE
fix: use lstat instead of stat to detect symlinks in getFileMode

### DIFF
--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -3,7 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { readFile, stat } from "fs/promises";
+import { readFile, lstat } from "fs/promises";
 import { resolve } from "path";
 import { constants } from "fs";
 import fetch from "node-fetch";
@@ -167,7 +167,7 @@ async function getOrCreateBranchRef(
 // Get the appropriate Git file mode for a file
 async function getFileMode(filePath: string): Promise<string> {
   try {
-    const fileStat = await stat(filePath);
+    const fileStat = await lstat(filePath);
     if (fileStat.isFile()) {
       // Check if execute bit is set for user
       if (fileStat.mode & constants.S_IXUSR) {


### PR DESCRIPTION
## Summary

Replace `stat()` with `lstat()` in `getFileMode()` so symlinks are correctly detected and committed with Git mode `120000`.

## Bug

`src/mcp/github-file-ops-server.ts:170` uses `stat()`, which follows symlinks and reports the target file's type. `isSymbolicLink()` on a `stat()` result always returns `false`.

```typescript
const fileStat = await stat(filePath);   // follows symlink → sees target
// ...
} else if (fileStat.isSymbolicLink()) {  // always false with stat()
    return "120000";
}
```

Symlinks are committed as regular files (mode `100644`) instead of symlinks (mode `120000`).

## Fix

`stat()` → `lstat()`. `lstat()` does not follow symlinks, so `isSymbolicLink()` correctly returns `true`.

## Verified with Node.js

```
stat('/tmp/test-symlink').isSymbolicLink():  false  ← follows symlink
lstat('/tmp/test-symlink').isSymbolicLink(): true   ← sees symlink itself
```

## Test plan

- [x] `tsc --noEmit` passes
- [x] Tested with real symlink: `stat()` returns false, `lstat()` returns true
- [x] Regular files and directories unaffected (`lstat()` behaves identically to `stat()` for non-symlinks)