### PR TITLE
feat: add npmrc_config input for enterprise npm registry

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -142,6 +142,10 @@ inputs:
     description: "Show full JSON output from Claude Code. WARNING: This outputs ALL Claude messages including tool execution results which may contain secrets, API keys, or other sensitive information. These logs are publicly visible in GitHub Actions. Only enable for debugging in non-sensitive environments."
     required: false
     default: "false"
+  npmrc_config:
+    description: "Content to write to ~/.npmrc before installing dependencies. Useful for configuring private npm registries in air-gapped or enterprise environments."
+    required: false
+    default: ""
   plugins:
     description: "Newline-separated list of Claude Code plugin names to install (e.g., 'code-review@claude-code-plugins\nfeature-dev@claude-code-plugins')"
     required: false
@@ -280,6 +284,7 @@ runs:
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
         DISPLAY_REPORT: ${{ inputs.display_report }}
+        INPUT_NPMRC_CONFIG: ${{ inputs.npmrc_config }}
         INPUT_PLUGINS: ${{ inputs.plugins }}
         INPUT_PLUGIN_MARKETPLACES: ${{ inputs.plugin_marketplaces }}
         PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -219,6 +219,13 @@ async function run() {
     baseBranch = prepareResult.branchInfo.baseBranch;
     prepareCompleted = true;
 
+    // Write .npmrc if configured (for air-gapped / enterprise environments)
+    if (process.env.INPUT_NPMRC_CONFIG) {
+      const npmrcPath = `${process.env.HOME}/.npmrc`;
+      await appendFile(npmrcPath, `\n${process.env.INPUT_NPMRC_CONFIG}\n`);
+      console.log("Wrote custom .npmrc configuration");
+    }
+
     // Phase 2: Install Claude Code CLI
     await installClaudeCode();
 


### PR DESCRIPTION
## Summary
- Adds `npmrc_config` action input for configuring private npm registries in air-gapped/enterprise environments
- Writes provided content to `~/.npmrc` before the Claude Code install step
- Uses `appendFile` to avoid clobbering any existing `.npmrc` content

## Relates to
Relates to #1188

## Changes
- `action.yml` — new `npmrc_config` input + `INPUT_NPMRC_CONFIG` env mapping
- `src/entrypoints/run.ts` — writes `.npmrc` before `installClaudeCode()` when input is set

## Test plan
- [ ] Verify action runs without `npmrc_config` (no behavior change)
- [ ] Verify with `npmrc_config` set — check `~/.npmrc` contains the content before install step
- [ ] Verify air-gapped environment can resolve packages via internal registry