### PR TITLE
fix: remove .husky from SENSITIVE_PATHS

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -17,7 +17,6 @@ const SENSITIVE_PATHS = [
   ".ripgreprc",
   "CLAUDE.md",
   "CLAUDE.local.md",
-  ".husky",
 ];
 
 /**


### PR DESCRIPTION
Removes `.husky` from the `SENSITIVE_PATHS` list in `src/github/operations/restore-config.ts`. This fixes a regression from #1174 where repos that commit `.husky` files would have their git hook setup broken because the directory was being restored/reset.

Fixes #1203

Generated with [Claude Code](https://claude.ai/code)