### PR TITLE
Fix typo: coments -> comments in code comment

### DIFF
--- a/src/create-prompt/types.ts
+++ b/src/create-prompt/types.ts
@@ -38,7 +38,7 @@ type IssueCommentEvent = {
   commentBody: string;
 };
 
-// Not actually a real github event, since issue comments and PR coments are both sent as issue_comment
+// Not actually a real github event, since issue comments and PR comments are both sent as issue_comment
 type PullRequestCommentEvent = {
   eventName: "issue_comment";
   commentId: string;


### PR DESCRIPTION
Small typo fix in a code comment in `src/create-prompt/types.ts`.