### PR TITLE
fix: support fork PRs by fetching via refs/pull/N/head

### DIFF
--- a/src/github/api/queries/github.ts
+++ b/src/github/api/queries/github.ts
@@ -12,6 +12,7 @@ export const PR_QUERY = `
         baseRefName
         headRefName
         headRefOid
+        isCrossRepository
         createdAt
         updatedAt
         lastEditedAt

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -168,7 +168,20 @@ export async function setupBranch(
 
       // Execute git commands to checkout PR branch (dynamic depth based on PR size)
       // Using execFileSync instead of shell template literals for security
-      execGit(["fetch", "origin", `--depth=${fetchDepth}`, branchName]);
+      // For fork PRs, the branch doesn't exist on origin - use refs/pull/N/head instead
+      if (prData.isCrossRepository) {
+        console.log(
+          `Fork PR detected, fetching via refs/pull/${entityNumber}/head`,
+        );
+        execGit([
+          "fetch",
+          "origin",
+          `--depth=${fetchDepth}`,
+          `pull/${entityNumber}/head:${branchName}`,
+        ]);
+      } else {
+        execGit(["fetch", "origin", `--depth=${fetchDepth}`, branchName]);
+      }
       execGit(["checkout", branchName, "--"]);
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -57,6 +57,7 @@ export type GitHubPullRequest = {
   baseRefName: string;
   headRefName: string;
   headRefOid: string;
+  isCrossRepository: boolean;
   createdAt: string;
   updatedAt?: string;
   lastEditedAt?: string;

--- a/test/data-formatter.test.ts
+++ b/test/data-formatter.test.ts
@@ -24,6 +24,7 @@ describe("formatContext", () => {
       baseRefName: "main",
       headRefName: "feature/test",
       headRefOid: "abc123",
+      isCrossRepository: false,
       createdAt: "2023-01-01T00:00:00Z",
       additions: 50,
       deletions: 30,


### PR DESCRIPTION
## Summary
- Fix fork (cross-repository) PRs failing with `fatal: couldn't find remote ref <branch>`
- Add `isCrossRepository` field to the PR GraphQL query and type
- When a fork PR is detected, fetch using `pull/<number>/head:<branch>` refspec instead of fetching by branch name

## Problem
When `@claude` is tagged on a PR from a fork, the action runs `git fetch origin --depth=20 <branch-name>`. Since the branch only exists on the fork's remote (not origin), this fails. GitHub exposes fork PR content at `refs/pull/<number>/head`, which works regardless of source repo.

## Changes

| File | Change |
|------|--------|
| `src/github/api/queries/github.ts` | Add `isCrossRepository` to PR GraphQL query |
| `src/github/types.ts` | Add `isCrossRepository: boolean` to `GitHubPullRequest` |
| `src/github/operations/branch.ts` | Use `pull/N/head` refspec for fork PRs in `setupBranch()` |
| `test/data-formatter.test.ts` | Add `isCrossRepository` to test fixture |

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` — 664 tests pass, 0 failures

Fixes #1218

🤖 Generated with [Claude Code](https://claude.ai/claude-code)