### PR TITLE
fix: multiple --add-dir flags overwrite instead of combining

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -19,6 +19,7 @@ const ACCUMULATING_FLAGS = new Set([
   "disallowedTools",
   "disallowed-tools",
   "mcp-config",
+  "add-dir",
 ]);
 
 // Delimiter used to join accumulated flag values
@@ -211,6 +212,15 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   delete extraArgs["disallowedTools"];
   delete extraArgs["disallowed-tools"];
 
+  // Extract --add-dir values into additionalDirectories array
+  const addDirValues = extraArgs["add-dir"]
+    ? extraArgs["add-dir"]
+        .split(ACCUMULATE_DELIMITER)
+        .map((d) => d.trim())
+        .filter(Boolean)
+    : [];
+  delete extraArgs["add-dir"];
+
   // Merge multiple --mcp-config values by combining their mcpServers objects
   // The action prepends its config (github_comment, github_ci, etc.) as inline JSON,
   // and users may provide their own config as inline JSON or file path
@@ -256,6 +266,8 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   // Build SDK options - use merged tools from both direct options and claudeArgs
   const sdkOptions: SdkOptions = {
     // Direct options from ClaudeOptions inputs
+    additionalDirectories:
+      addDirValues.length > 0 ? addDirValues : undefined,
     model: options.model,
     maxTurns: options.maxTurns ? parseInt(options.maxTurns, 10) : undefined,
     allowedTools:

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -298,6 +298,58 @@ describe("parseSdkOptions", () => {
     });
   });
 
+  describe("add-dir accumulation", () => {
+    test("should pass through single --add-dir", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: '--add-dir "/path/to/dir-a"',
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.additionalDirectories).toEqual(["/path/to/dir-a"]);
+      expect(result.sdkOptions.extraArgs?.["add-dir"]).toBeUndefined();
+    });
+
+    test("should accumulate multiple --add-dir flags", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: '--add-dir "/path/to/dir-a" --add-dir "/path/to/dir-b"',
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.additionalDirectories).toEqual([
+        "/path/to/dir-a",
+        "/path/to/dir-b",
+      ]);
+      expect(result.sdkOptions.extraArgs?.["add-dir"]).toBeUndefined();
+    });
+
+    test("should accumulate --add-dir mixed with other flags", () => {
+      const options: ClaudeOptions = {
+        claudeArgs:
+          '--add-dir "/path/to/dir-a" --model "claude-3" --add-dir "/path/to/dir-b"',
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.additionalDirectories).toEqual([
+        "/path/to/dir-a",
+        "/path/to/dir-b",
+      ]);
+      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-3");
+    });
+
+    test("should return undefined additionalDirectories when no --add-dir is present", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: '--model "claude-3-5-sonnet"',
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.additionalDirectories).toBeUndefined();
+    });
+  });
+
   describe("other extraArgs passthrough", () => {
     test("should pass through json-schema in extraArgs", () => {
       const options: ClaudeOptions = {


### PR DESCRIPTION
Fixes #1215. The `--add-dir` flag was typed as a regular (non-accumulating) flag, causing each subsequent `--add-dir` to overwrite the previous one. Only the last value was used.

## What changed

- **`parse-sdk-options.ts`**: Added `"add-dir"` to `ACCUMULATING_FLAGS`. After parsing, the accumulated values are extracted from `extraArgs`, split, and placed into `sdkOptions.additionalDirectories` (a first-class SDK array property). This follows the same pattern used for `allowedTools` and `disallowedTools`.
- **`parse-sdk-options.test.ts`**: Added 4 tests covering single `--add-dir`, multiple `--add-dir`, mixed with other flags, and absent `--add-dir`.

## How it works

Before: `--add-dir "/a" --add-dir "/b"` → `extraArgs["add-dir"] = "/b"` (overwritten)

After: `--add-dir "/a" --add-dir "/b"` → `sdkOptions.additionalDirectories = ["/a", "/b"]` → SDK emits `--add-dir /a --add-dir /b`

## Test plan

- [x] All 31 `parse-sdk-options` tests pass (27 existing + 4 new)
- [x] Full test suite — only pre-existing Windows path-separator failures, none related to this change