### PR TITLE
Upgrade Claude model from opus-4-6 to opus-4-7

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,4 +25,4 @@ jobs:
           prompt: "/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
-            --model "claude-opus-4-6"
+            --model "claude-opus-4-7"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,4 +36,4 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --allowedTools "Bash(bun install),Bash(bun test:*),Bash(bun run format),Bash(bun typecheck)"
-            --model "claude-opus-4-6"
+            --model "claude-opus-4-7"


### PR DESCRIPTION
## Summary
Updates the Claude model version used in GitHub Actions workflows from `claude-opus-4-6` to `claude-opus-4-7`.

## Changes
- Updated the model specification in `.github/workflows/claude-review.yml` to use the latest Claude Opus 4.7 model for PR reviews
- Updated the model specification in `.github/workflows/claude.yml` to use the latest Claude Opus 4.7 model for CI/CD tasks

## Details
This change upgrades both the PR review workflow and the main CI/CD workflow to leverage the latest Claude Opus 4.7 model, which provides improved capabilities and performance for code review and automated testing tasks.

https://preview.claude.ai/code/session_01Mc8dExn9NcARLohJ1XG5kv