### PR TITLE
fix: expand review mode trigger to cover comment events and prompt coexistence

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,4 +25,4 @@ jobs:
           prompt: "/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
-            --model "claude-opus-4-6"
+            --model "claude-opus-4-7"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,4 +36,4 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --allowedTools "Bash(bun install),Bash(bun test:*),Bash(bun run format),Bash(bun typecheck)"
-            --model "claude-opus-4-6"
+            --model "claude-opus-4-7"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 # Test fixtures should not be formatted to preserve exact output matching
 test/fixtures/
+.omc/

--- a/action.yml
+++ b/action.yml
@@ -150,6 +150,26 @@ inputs:
     description: "Newline-separated list of Claude Code plugin marketplace Git URLs to install from (e.g., 'https://github.com/user/marketplace1.git\nhttps://github.com/user/marketplace2.git')"
     required: false
     default: ""
+  multi_agent_review:
+    description: "Multi-agent peer review mode. 'false' (default): disabled. 'auto': triage agent analyzes diff complexity and routes to multi-agent or single-agent review. 'true': always use multi-agent review."
+    required: false
+    default: "false"
+  review_agents:
+    description: "JSON array defining custom review agents. Each agent needs id, name, perspective, and optional max_turns. Overrides .claude/review-agents.yml if present."
+    required: false
+    default: ""
+  review_debate_rounds:
+    description: "Number of debate rounds where agents review each other's findings (0 to disable debate)."
+    required: false
+    default: "1"
+  review_max_agents:
+    description: "Maximum number of review agents to run (safety limit)."
+    required: false
+    default: "5"
+  review_protocol_path:
+    description: "Path to a custom review agents YAML spec file. Defaults to .claude/review-agents.yml if it exists."
+    required: false
+    default: ""
 
 outputs:
   execution_file:
@@ -167,6 +187,9 @@ outputs:
   session_id:
     description: "The Claude Code session ID that can be used with --resume to continue this conversation"
     value: ${{ steps.run.outputs.session_id }}
+  conclusion:
+    description: "Execution status of Claude Code ('success' or 'failure')"
+    value: ${{ steps.run.outputs.conclusion }}
 
 runs:
   using: "composite"
@@ -278,6 +301,11 @@ runs:
         INCLUDE_FIX_LINKS: ${{ inputs.include_fix_links }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         CLAUDE_ARGS: ${{ inputs.claude_args }}
+        MULTI_AGENT_REVIEW: ${{ inputs.multi_agent_review }}
+        REVIEW_AGENTS: ${{ inputs.review_agents }}
+        REVIEW_DEBATE_ROUNDS: ${{ inputs.review_debate_rounds }}
+        REVIEW_MAX_AGENTS: ${{ inputs.review_max_agents }}
+        REVIEW_PROTOCOL_PATH: ${{ inputs.review_protocol_path }}
         ALL_INPUTS: ${{ toJson(inputs) }}
 
         # Base-action inputs

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -124,7 +124,7 @@ runs:
         PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
       run: |
         if [ -z "$PATH_TO_CLAUDE_CODE_EXECUTABLE" ]; then
-          CLAUDE_CODE_VERSION="2.1.109"
+          CLAUDE_CODE_VERSION="2.1.112"
           echo "Installing Claude Code v${CLAUDE_CODE_VERSION}..."
           for attempt in 1 2 3; do
             echo "Installation attempt $attempt..."

--- a/base-action/bun.lock
+++ b/base-action/bun.lock
@@ -6,7 +6,7 @@
       "name": "@anthropic-ai/claude-code-base-action",
       "dependencies": {
         "@actions/core": "^1.10.1",
-        "@anthropic-ai/claude-agent-sdk": "^0.2.109",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.112",
         "shell-quote": "^1.8.3",
       },
       "devDependencies": {
@@ -27,7 +27,7 @@
 
     "@actions/io": ["@actions/io@1.1.3", "", {}, "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.109", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-u7qGFBB2gGcHgiqa2Vn9uF+2Vbr6u6XlGE0SDTfvc49GXwbTfuJ7bmacUoIN2EMXLm7PjkVJC4M8WjccT2MpHQ=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.112", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-vMFoiDKlOive8p3tphpV1gQaaytOipwGJ+uw9mvvaLQUODSC2+fCdRDAY25i2Tsv+lOtxzXBKctmaDuWqZY7ig=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 

--- a/base-action/package.json
+++ b/base-action/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.10.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.109",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.112",
     "shell-quote": "^1.8.3"
   },
   "devDependencies": {

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -9,6 +9,7 @@ export type ParsedSdkOptions = {
   sdkOptions: SdkOptions;
   showFullOutput: boolean;
   hasJsonSchema: boolean;
+  executionFilePath?: string;
 };
 
 // Flags that should accumulate multiple values instead of overwriting
@@ -287,5 +288,6 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
     sdkOptions,
     showFullOutput,
     hasJsonSchema,
+    executionFilePath: options.executionFilePath,
   };
 }

--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -16,7 +16,7 @@ export type ClaudeRunResult = {
   structuredOutput?: string;
 };
 
-const EXECUTION_FILE = `${process.env.RUNNER_TEMP}/claude-execution-output.json`;
+const DEFAULT_EXECUTION_FILE = `${process.env.RUNNER_TEMP}/claude-execution-output.json`;
 
 /** Filename for the user request file, written by prompt generation */
 const USER_REQUEST_FILENAME = "claude-user-request.txt";
@@ -135,8 +135,14 @@ function sanitizeSdkOutput(
  */
 export async function runClaudeWithSdk(
   promptPath: string,
-  { sdkOptions, showFullOutput, hasJsonSchema }: ParsedSdkOptions,
+  {
+    sdkOptions,
+    showFullOutput,
+    hasJsonSchema,
+    executionFilePath,
+  }: ParsedSdkOptions,
 ): Promise<ClaudeRunResult> {
+  const EXECUTION_FILE = executionFilePath || DEFAULT_EXECUTION_FILE;
   // Create prompt configuration - may be a string or multi-block message
   const prompt = await createPromptConfig(promptPath, showFullOutput);
 

--- a/base-action/src/run-claude.ts
+++ b/base-action/src/run-claude.ts
@@ -14,6 +14,7 @@ export type ClaudeOptions = {
   appendSystemPrompt?: string;
   fallbackModel?: string;
   showFullOutput?: string;
+  executionFilePath?: string;
 };
 
 export async function runClaude(

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.1",
-        "@anthropic-ai/claude-agent-sdk": "^0.2.109",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.112",
         "@modelcontextprotocol/sdk": "^1.11.0",
         "@octokit/graphql": "^8.2.2",
         "@octokit/rest": "^21.1.1",
@@ -38,7 +38,7 @@
 
     "@actions/io": ["@actions/io@1.1.3", "", {}, "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.109", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-u7qGFBB2gGcHgiqa2Vn9uF+2Vbr6u6XlGE0SDTfvc49GXwbTfuJ7bmacUoIN2EMXLm7PjkVJC4M8WjccT2MpHQ=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.112", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-vMFoiDKlOive8p3tphpV1gQaaytOipwGJ+uw9mvvaLQUODSC2+fCdRDAY25i2Tsv+lOtxzXBKctmaDuWqZY7ig=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@octokit/webhooks-types": "^7.6.1",
         "node-fetch": "^3.3.2",
         "shell-quote": "^1.8.3",
+        "yaml": "^2.8.3",
         "zod": "^3.24.4",
       },
       "devDependencies": {
@@ -346,6 +347,8 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@octokit/webhooks-types": "^7.6.1",
     "node-fetch": "^3.3.2",
     "shell-quote": "^1.8.3",
+    "yaml": "^2.8.3",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.109",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.112",
     "@modelcontextprotocol/sdk": "^1.11.0",
     "@octokit/graphql": "^8.2.2",
     "@octokit/rest": "^21.1.1",

--- a/src/entrypoints/collect-inputs.ts
+++ b/src/entrypoints/collect-inputs.ts
@@ -26,6 +26,11 @@ export function collectActionInputsPresence(): string {
     classify_inline_comments: "true",
     use_commit_signing: "false",
     ssh_signing_key: "",
+    multi_agent_review: "false",
+    review_agents: "",
+    review_debate_rounds: "1",
+    review_max_agents: "5",
+    review_protocol_path: "",
   };
 
   const allInputsJson = process.env.ALL_INPUTS;

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -21,6 +21,7 @@ import {
   isPullRequestEvent,
   isPullRequestReviewEvent,
   isPullRequestReviewCommentEvent,
+  isIssueCommentEvent,
 } from "../github/context";
 import type { GitHubContext } from "../github/context";
 import { detectMode } from "../modes/detector";
@@ -228,9 +229,20 @@ async function run() {
         isPullRequestReviewCommentEvent(context)
       ) {
         restoreBase = context.payload.pull_request.base.ref;
-        validateBranchName(restoreBase);
+      } else if (
+        isIssueCommentEvent(context) &&
+        context.payload.issue.pull_request
+      ) {
+        // issue_comment on a PR — payload lacks base.ref, so look it up.
+        const { data: pr } = await octokit.rest.pulls.get({
+          owner: context.repository.owner,
+          repo: context.repository.repo,
+          pull_number: context.entityNumber,
+        });
+        restoreBase = pr.base.ref;
       }
       if (restoreBase) {
+        validateBranchName(restoreBase);
         restoreConfigFromBase(restoreBase);
       }
     }

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -26,6 +26,7 @@ import type { GitHubContext } from "../github/context";
 import { detectMode } from "../modes/detector";
 import { prepareTagMode } from "../modes/tag";
 import { prepareAgentMode } from "../modes/agent";
+import { prepareAndRunReview } from "../modes/review";
 import { checkContainsTrigger } from "../github/validation/trigger";
 import { restoreConfigFromBase } from "../github/operations/restore-config";
 import { validateBranchName } from "../github/operations/branch";
@@ -194,7 +195,9 @@ async function run() {
     const containsTrigger =
       modeName === "tag"
         ? isEntityContext(context) && checkContainsTrigger(context)
-        : !!context.inputs?.prompt;
+        : modeName === "review"
+          ? true // review mode is triggered by multi_agent_review input
+          : !!context.inputs?.prompt;
     console.log(`Mode: ${modeName}`);
     console.log(`Context prompt: ${context.inputs?.prompt || "NO PROMPT"}`);
     console.log(`Trigger result: ${containsTrigger}`);
@@ -205,24 +208,9 @@ async function run() {
       return;
     }
 
-    // Run prepare
-    console.log(
-      `Preparing with mode: ${modeName} for event: ${context.eventName}`,
-    );
-    const prepareResult =
-      modeName === "tag"
-        ? await prepareTagMode({ context, octokit, githubToken })
-        : await prepareAgentMode({ context, octokit, githubToken });
-
-    commentId = prepareResult.commentId;
-    claudeBranch = prepareResult.branchInfo.claudeBranch;
-    baseBranch = prepareResult.branchInfo.baseBranch;
-    prepareCompleted = true;
-
-    // Phase 2: Install Claude Code CLI
+    // Phase 2: Install Claude Code CLI (needed before prepare for review mode)
     await installClaudeCode();
 
-    // Phase 3: Run Claude (import base-action directly)
     // Set env vars needed by the base-action code
     process.env.INPUT_ACTION_INPUTS_PRESENT = actionInputsPresent;
     process.env.CLAUDE_CODE_ACTION = "1";
@@ -232,15 +220,8 @@ async function run() {
 
     // On PRs, .claude/ and .mcp.json in the checkout are attacker-controlled.
     // Restore them from the base branch before the CLI reads them.
-    //
-    // We read pull_request.base.ref from the payload directly because agent
-    // mode's branchInfo.baseBranch defaults to the repo's default branch rather
-    // than the PR's actual target (agent/index.ts). For issue_comment on a PR the payload
-    // lacks base.ref, so we fall back to the mode-provided value — tag mode
-    // fetches it from GraphQL; agent mode on issue_comment is an edge case
-    // that at worst restores from the wrong trusted branch (still secure).
     if (isEntityContext(context) && context.isPR) {
-      let restoreBase = baseBranch;
+      let restoreBase: string | undefined;
       if (
         isPullRequestEvent(context) ||
         isPullRequestReviewEvent(context) ||
@@ -262,37 +243,73 @@ async function run() {
       process.env.INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE,
     );
 
-    const promptFile =
-      process.env.INPUT_PROMPT_FILE ||
-      `${process.env.RUNNER_TEMP}/claude-prompts/claude-prompt.txt`;
-    const promptConfig = await preparePrompt({
-      prompt: "",
-      promptFile,
-    });
+    if (modeName === "review") {
+      // Review mode: orchestrator handles prepare + multiple runClaude() calls
+      const reviewResult = await prepareAndRunReview({
+        context,
+        octokit,
+        githubToken,
+        multiAgentReview: context.inputs.multiAgentReview,
+      });
 
-    const claudeResult: ClaudeRunResult = await runClaude(promptConfig.path, {
-      claudeArgs: prepareResult.claudeArgs,
-      appendSystemPrompt: process.env.APPEND_SYSTEM_PROMPT,
-      model: process.env.ANTHROPIC_MODEL,
-      pathToClaudeCodeExecutable:
-        process.env.INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE,
-      showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
-    });
+      commentId = reviewResult.commentId;
+      claudeBranch = reviewResult.branchInfo.claudeBranch;
+      baseBranch = reviewResult.branchInfo.baseBranch;
+      executionFile = reviewResult.executionFile;
+      claudeSuccess = reviewResult.claudeSuccess;
+      prepareCompleted = true;
 
-    claudeSuccess = claudeResult.conclusion === "success";
-    executionFile = claudeResult.executionFile;
+      if (executionFile) {
+        core.setOutput("execution_file", executionFile);
+      }
+      core.setOutput("conclusion", claudeSuccess ? "success" : "failure");
+    } else {
+      // Tag/Agent mode: standard prepare + single runClaude()
+      console.log(
+        `Preparing with mode: ${modeName} for event: ${context.eventName}`,
+      );
+      const prepareResult =
+        modeName === "tag"
+          ? await prepareTagMode({ context, octokit, githubToken })
+          : await prepareAgentMode({ context, octokit, githubToken });
 
-    // Set action-level outputs
-    if (claudeResult.executionFile) {
-      core.setOutput("execution_file", claudeResult.executionFile);
+      commentId = prepareResult.commentId;
+      claudeBranch = prepareResult.branchInfo.claudeBranch;
+      baseBranch = prepareResult.branchInfo.baseBranch;
+      prepareCompleted = true;
+
+      const promptFile =
+        process.env.INPUT_PROMPT_FILE ||
+        `${process.env.RUNNER_TEMP}/claude-prompts/claude-prompt.txt`;
+      const promptConfig = await preparePrompt({
+        prompt: "",
+        promptFile,
+      });
+
+      const claudeResult: ClaudeRunResult = await runClaude(promptConfig.path, {
+        claudeArgs: prepareResult.claudeArgs,
+        appendSystemPrompt: process.env.APPEND_SYSTEM_PROMPT,
+        model: process.env.ANTHROPIC_MODEL,
+        pathToClaudeCodeExecutable:
+          process.env.INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE,
+        showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
+      });
+
+      claudeSuccess = claudeResult.conclusion === "success";
+      executionFile = claudeResult.executionFile;
+
+      // Set action-level outputs
+      if (claudeResult.executionFile) {
+        core.setOutput("execution_file", claudeResult.executionFile);
+      }
+      if (claudeResult.sessionId) {
+        core.setOutput("session_id", claudeResult.sessionId);
+      }
+      if (claudeResult.structuredOutput) {
+        core.setOutput("structured_output", claudeResult.structuredOutput);
+      }
+      core.setOutput("conclusion", claudeResult.conclusion);
     }
-    if (claudeResult.sessionId) {
-      core.setOutput("session_id", claudeResult.sessionId);
-    }
-    if (claudeResult.structuredOutput) {
-      core.setOutput("structured_output", claudeResult.structuredOutput);
-    }
-    core.setOutput("conclusion", claudeResult.conclusion);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     // Only mark as prepare failure if we haven't completed the prepare phase

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -65,7 +65,7 @@ async function installClaudeCode(): Promise<void> {
     return;
   }
 
-  const claudeCodeVersion = "2.1.109";
+  const claudeCodeVersion = "2.1.112";
   console.log(`Installing Claude Code v${claudeCodeVersion}...`);
 
   for (let attempt = 1; attempt <= 3; attempt++) {

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -102,6 +102,11 @@ type BaseContext = {
     includeFixLinks: boolean;
     includeCommentsByActor: string;
     excludeCommentsByActor: string;
+    multiAgentReview: string;
+    reviewAgents?: string;
+    reviewDebateRounds: number;
+    reviewMaxAgents: number;
+    reviewProtocolPath?: string;
   };
 };
 
@@ -164,6 +169,17 @@ export function parseGitHubContext(): GitHubContext {
       includeFixLinks: process.env.INCLUDE_FIX_LINKS === "true",
       includeCommentsByActor: process.env.INCLUDE_COMMENTS_BY_ACTOR ?? "",
       excludeCommentsByActor: process.env.EXCLUDE_COMMENTS_BY_ACTOR ?? "",
+      multiAgentReview: process.env.MULTI_AGENT_REVIEW || "false",
+      reviewAgents: process.env.REVIEW_AGENTS || undefined,
+      reviewDebateRounds: Math.max(
+        0,
+        parseInt(process.env.REVIEW_DEBATE_ROUNDS || "1", 10) || 1,
+      ),
+      reviewMaxAgents: Math.max(
+        1,
+        parseInt(process.env.REVIEW_MAX_AGENTS || "5", 10) || 5,
+      ),
+      reviewProtocolPath: process.env.REVIEW_PROTOCOL_PATH || undefined,
     },
   };
 

--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -9,9 +9,41 @@ import {
 } from "../github/context";
 import { checkContainsTrigger } from "../github/validation/trigger";
 
-export type AutoDetectedMode = "tag" | "agent";
+export type AutoDetectedMode = "tag" | "agent" | "review";
 
 export function detectMode(context: GitHubContext): AutoDetectedMode {
+  // Review mode: only for pull_request events (not comments on PRs)
+  if (
+    context.inputs.multiAgentReview !== "false" &&
+    isEntityContext(context) &&
+    context.isPR &&
+    isPullRequestEvent(context)
+  ) {
+    // "true": always use review mode for PR events
+    if (context.inputs.multiAgentReview === "true") {
+      return "review";
+    }
+    // "auto": yield to explicit prompt or trackProgress
+    if (
+      context.inputs.multiAgentReview === "auto" &&
+      !context.inputs.prompt &&
+      !context.inputs.trackProgress
+    ) {
+      const supportedActions = [
+        "opened",
+        "synchronize",
+        "ready_for_review",
+        "reopened",
+      ];
+      if (
+        context.eventAction &&
+        supportedActions.includes(context.eventAction)
+      ) {
+        return "review";
+      }
+    }
+  }
+
   // Validate track_progress usage
   if (context.inputs.trackProgress) {
     validateTrackProgressEvent(context);

--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -11,36 +11,47 @@ import { checkContainsTrigger } from "../github/validation/trigger";
 
 export type AutoDetectedMode = "tag" | "agent" | "review";
 
+// PR actions that can auto-enter review mode.
+const REVIEW_PR_ACTIONS = [
+  "opened",
+  "synchronize",
+  "ready_for_review",
+  "reopened",
+];
+
 export function detectMode(context: GitHubContext): AutoDetectedMode {
-  // Review mode: only for pull_request events (not comments on PRs)
+  // Review mode gate.
+  // - "true": force review whenever we can safely enter it (PR open-like or
+  //   comment with an explicit trigger phrase).
+  // - "auto": same entry conditions; the review orchestrator's triage step
+  //   decides single-agent vs multi-agent internally.
+  // `prompt` and `trackProgress` no longer opt out of review:
+  //   - `prompt` is threaded to each review agent as team guidance.
+  //   - `trackProgress` is functionally covered by the review tracker.
   if (
     context.inputs.multiAgentReview !== "false" &&
     isEntityContext(context) &&
-    context.isPR &&
-    isPullRequestEvent(context)
+    context.isPR
   ) {
-    // "true": always use review mode for PR events
-    if (context.inputs.multiAgentReview === "true") {
-      return "review";
-    }
-    // "auto": yield to explicit prompt or trackProgress
+    const isPrOpenLike =
+      isPullRequestEvent(context) &&
+      context.eventAction !== undefined &&
+      REVIEW_PR_ACTIONS.includes(context.eventAction);
+
+    // Comment events are only eligible when an explicit trigger phrase is
+    // present — prevents the review's own comments from re-triggering itself
+    // and avoids reviewing on unrelated chatter.
+    const isCommentTrigger =
+      (isIssueCommentEvent(context) ||
+        isPullRequestReviewCommentEvent(context)) &&
+      checkContainsTrigger(context);
+
     if (
-      context.inputs.multiAgentReview === "auto" &&
-      !context.inputs.prompt &&
-      !context.inputs.trackProgress
+      (context.inputs.multiAgentReview === "true" ||
+        context.inputs.multiAgentReview === "auto") &&
+      (isPrOpenLike || isCommentTrigger)
     ) {
-      const supportedActions = [
-        "opened",
-        "synchronize",
-        "ready_for_review",
-        "reopened",
-      ];
-      if (
-        context.eventAction &&
-        supportedActions.includes(context.eventAction)
-      ) {
-        return "review";
-      }
+      return "review";
     }
   }
 

--- a/src/modes/review/agents.ts
+++ b/src/modes/review/agents.ts
@@ -1,0 +1,220 @@
+import { readFile } from "fs/promises";
+import { existsSync } from "fs";
+import * as core from "@actions/core";
+import { parse as parseYaml } from "yaml";
+
+export type ReviewAgent = {
+  id: string;
+  name: string;
+  perspective: string;
+  maxTurns?: number;
+  model?: string;
+};
+
+export type ReviewAgentSpec = {
+  version: number;
+  agents: ReviewAgent[];
+  debate_rounds?: number;
+  synthesis?: {
+    perspective?: string;
+  };
+};
+
+export const DEFAULT_AGENTS: ReviewAgent[] = [
+  {
+    id: "critic",
+    name: "Critic Reviewer",
+    perspective: [
+      "You are a Critic Reviewer. Focus on:",
+      "- Whether the changes are appropriate and necessary",
+      "- Pattern consistency with the existing codebase",
+      "- Edge cases and fallback handling",
+      "- Whether the changes could introduce regressions",
+      "- Architectural fit with the project's design patterns",
+    ].join("\n"),
+    maxTurns: undefined,
+  },
+  {
+    id: "code-quality",
+    name: "Code Quality Reviewer",
+    perspective: [
+      "You are a Code Quality Reviewer. Focus on:",
+      "- YAGNI, DRY, and SOLID principles",
+      "- Error handling completeness and correctness",
+      "- Type safety and type design",
+      "- Unnecessary complexity or over-engineering",
+      "- Resource management and potential leaks",
+    ].join("\n"),
+    maxTurns: undefined,
+  },
+  {
+    id: "convention",
+    name: "Convention Reviewer",
+    perspective: [
+      "You are a Convention Reviewer. Focus on:",
+      "- Naming conventions consistency",
+      "- Import ordering and organization",
+      "- Code style adherence to project standards",
+      "- Documentation and comment quality where present",
+      "- API surface consistency",
+    ].join("\n"),
+    maxTurns: undefined,
+  },
+];
+
+const DEFAULT_SYNTHESIS_PERSPECTIVE = [
+  "You are the Synthesis Reviewer. Your job is to:",
+  "- Consolidate all findings from the review agents and their debate",
+  "- Remove duplicates and merge overlapping findings",
+  "- Organize findings by severity (critical > warning > suggestion > nitpick)",
+  "- Present a clear, actionable final review",
+  "- Highlight areas of agreement and disagreement between reviewers",
+  "- Provide an overall assessment of the PR's readiness",
+].join("\n");
+
+const AGENT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const MAX_TURNS_LIMIT = 50;
+const MAX_DEBATE_ROUNDS = 3;
+
+function safePositiveInt(value: unknown, fallback: number): number {
+  const num = Number(value);
+  return Number.isFinite(num) && num > 0 ? Math.floor(num) : fallback;
+}
+
+function normalizeAgent(raw: Record<string, unknown>): ReviewAgent {
+  const id = String(raw.id || "");
+  if (!id) {
+    throw new Error("Review agent spec: each agent must have an 'id' field");
+  }
+  if (!AGENT_ID_PATTERN.test(id)) {
+    throw new Error(
+      `Review agent spec: agent id '${id}' must match ${AGENT_ID_PATTERN}`,
+    );
+  }
+  return {
+    id,
+    name: String(raw.name || id),
+    perspective: String(raw.perspective || ""),
+    maxTurns:
+      raw.max_turns || raw.maxTurns
+        ? Math.min(
+            safePositiveInt(raw.max_turns || raw.maxTurns, 10),
+            MAX_TURNS_LIMIT,
+          )
+        : undefined,
+    model: raw.model ? String(raw.model) : undefined,
+  };
+}
+
+export async function loadAgentSpec(
+  specPath: string,
+): Promise<ReviewAgentSpec | null> {
+  if (!existsSync(specPath)) {
+    return null;
+  }
+
+  try {
+    const content = await readFile(specPath, "utf-8");
+    const parsed = parseYaml(content) as Record<string, unknown>;
+
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error("Invalid YAML: expected an object");
+    }
+
+    const rawAgents = parsed.agents;
+    if (!Array.isArray(rawAgents) || rawAgents.length === 0) {
+      throw new Error("Invalid spec: 'agents' must be a non-empty array");
+    }
+
+    const agents = rawAgents.map(normalizeAgent);
+    const synthesis = parsed.synthesis as { perspective?: string } | undefined;
+
+    return {
+      version: Number(parsed.version || 1),
+      agents,
+      debate_rounds:
+        parsed.debate_rounds !== undefined
+          ? Math.min(
+              safePositiveInt(parsed.debate_rounds, 1),
+              MAX_DEBATE_ROUNDS,
+            )
+          : undefined,
+      synthesis: synthesis?.perspective ? synthesis : undefined,
+    };
+  } catch (error) {
+    core.warning(`Failed to parse review agents spec at ${specPath}: ${error}`);
+    return null;
+  }
+}
+
+export async function resolveAgents(inputs: {
+  reviewProtocolPath?: string;
+  reviewAgents?: string;
+  reviewDebateRounds: number;
+  reviewMaxAgents: number;
+}): Promise<{
+  agents: ReviewAgent[];
+  debateRounds: number;
+  synthesisPerspective: string;
+}> {
+  const workspaceDir = process.env.GITHUB_WORKSPACE || process.cwd();
+
+  // Priority 1: Explicit protocol path
+  if (inputs.reviewProtocolPath) {
+    const spec = await loadAgentSpec(inputs.reviewProtocolPath);
+    if (spec) {
+      core.info(
+        `Loaded ${spec.agents.length} agents from ${inputs.reviewProtocolPath}`,
+      );
+      return {
+        agents: spec.agents.slice(0, inputs.reviewMaxAgents),
+        debateRounds: spec.debate_rounds ?? inputs.reviewDebateRounds,
+        synthesisPerspective:
+          spec.synthesis?.perspective || DEFAULT_SYNTHESIS_PERSPECTIVE,
+      };
+    }
+    core.warning(
+      `Spec file not found at ${inputs.reviewProtocolPath}, falling back`,
+    );
+  }
+
+  // Priority 2: .claude/review-agents.yml in repo
+  const defaultSpecPath = `${workspaceDir}/.claude/review-agents.yml`;
+  const spec = await loadAgentSpec(defaultSpecPath);
+  if (spec) {
+    core.info(`Loaded ${spec.agents.length} agents from ${defaultSpecPath}`);
+    return {
+      agents: spec.agents.slice(0, inputs.reviewMaxAgents),
+      debateRounds: spec.debate_rounds ?? inputs.reviewDebateRounds,
+      synthesisPerspective:
+        spec.synthesis?.perspective || DEFAULT_SYNTHESIS_PERSPECTIVE,
+    };
+  }
+
+  // Priority 3: review_agents action input (JSON)
+  if (inputs.reviewAgents) {
+    try {
+      const rawAgents = JSON.parse(inputs.reviewAgents) as Record<
+        string,
+        unknown
+      >[];
+      const agents = rawAgents.map(normalizeAgent);
+      core.info(`Loaded ${agents.length} agents from review_agents input`);
+      return {
+        agents: agents.slice(0, inputs.reviewMaxAgents),
+        debateRounds: inputs.reviewDebateRounds,
+        synthesisPerspective: DEFAULT_SYNTHESIS_PERSPECTIVE,
+      };
+    } catch (error) {
+      core.warning(`Failed to parse review_agents JSON input: ${error}`);
+    }
+  }
+
+  // Priority 4: Default agents
+  core.info("Using default review agents (critic, code-quality, convention)");
+  return {
+    agents: DEFAULT_AGENTS.slice(0, inputs.reviewMaxAgents),
+    debateRounds: inputs.reviewDebateRounds,
+    synthesisPerspective: DEFAULT_SYNTHESIS_PERSPECTIVE,
+  };
+}

--- a/src/modes/review/index.ts
+++ b/src/modes/review/index.ts
@@ -1,0 +1,1 @@
+export { prepareAndRunReview } from "./orchestrator";

--- a/src/modes/review/merge-execution.ts
+++ b/src/modes/review/merge-execution.ts
@@ -1,0 +1,24 @@
+import * as core from "@actions/core";
+import { readFile, writeFile } from "fs/promises";
+import { existsSync } from "fs";
+
+export async function mergeExecutionFiles(
+  filePaths: string[],
+  outputPath: string,
+): Promise<void> {
+  const allMessages: unknown[] = [];
+
+  for (const filePath of filePaths) {
+    if (!existsSync(filePath)) continue;
+
+    try {
+      const content = await readFile(filePath, "utf-8");
+      const messages = JSON.parse(content) as unknown[];
+      allMessages.push(...messages);
+    } catch (error) {
+      core.warning(`Failed to read execution file ${filePath}: ${error}`);
+    }
+  }
+
+  await writeFile(outputPath, JSON.stringify(allMessages, null, 2));
+}

--- a/src/modes/review/orchestrator.ts
+++ b/src/modes/review/orchestrator.ts
@@ -115,6 +115,12 @@ export async function prepareAndRunReview({
   // Build GitHub context markdown (shared across all agents)
   const githubContextMarkdown = buildGitHubContextMarkdown(githubData, context);
 
+  // Optional team guidance sourced from the workflow `prompt:` input.
+  // Threaded into every agent prompt so role-specific perspectives still
+  // apply the team's conventions (style, testing rules, etc.). Empty string
+  // is normalized to undefined so downstream templates can skip the section.
+  const teamGuidance = context.inputs.prompt?.trim() || undefined;
+
   // Create tracking comment
   const tracker = new ReviewTracker(
     octokit.rest,
@@ -169,6 +175,7 @@ export async function prepareAndRunReview({
       trackingCommentId,
       synthesisCommentId,
       tracker,
+      teamGuidance,
     });
   }
 
@@ -189,6 +196,7 @@ export async function prepareAndRunReview({
         githubContextMarkdown,
         baseClaudeArgs,
         `review-r1-${agent.id}`,
+        teamGuidance,
       );
       await tracker.updateAgentStatus(agent.name, "complete", findings);
       return {
@@ -230,6 +238,7 @@ export async function prepareAndRunReview({
             otherFindings,
             baseClaudeArgs,
             `review-r2-${agent.id}`,
+            teamGuidance,
           );
           return { agentId: agent.id, rebuttal };
         }),
@@ -264,6 +273,7 @@ export async function prepareAndRunReview({
         githubToken,
         context,
         synthesisCommentId,
+        teamGuidance,
       );
 
       const execFile = `${process.env.RUNNER_TEMP}/claude-execution-review-synthesis.json`;
@@ -319,6 +329,7 @@ async function runSingleAgentReview({
   trackingCommentId,
   synthesisCommentId,
   tracker,
+  teamGuidance,
 }: {
   githubContextMarkdown: string;
   githubToken: string;
@@ -327,6 +338,7 @@ async function runSingleAgentReview({
   trackingCommentId: number;
   synthesisCommentId: number;
   tracker: ReviewTracker;
+  teamGuidance?: string;
 }): Promise<ReviewResult> {
   const executionFilePath = `${process.env.RUNNER_TEMP}/claude-execution-review-single.json`;
 
@@ -349,7 +361,10 @@ async function runSingleAgentReview({
   const escapedConfig = singleAgentMcpConfig.replace(/'/g, "'\\''");
   const claudeArgs = `--mcp-config '${escapedConfig}' --permission-mode acceptEdits --allowedTools "Glob,Grep,Read,LS,mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment"`;
 
-  const promptPath = await generateSingleAgentPrompt(githubContextMarkdown);
+  const promptPath = await generateSingleAgentPrompt(
+    githubContextMarkdown,
+    teamGuidance,
+  );
 
   await tracker.updateSynthesisStatus("running");
 
@@ -400,8 +415,13 @@ async function runReviewAgent(
   githubContextMarkdown: string,
   baseClaudeArgs: string,
   executionId: string,
+  teamGuidance?: string,
 ): Promise<AgentFindings> {
-  const promptPath = await generateAgentPrompt(agent, githubContextMarkdown);
+  const promptPath = await generateAgentPrompt(
+    agent,
+    githubContextMarkdown,
+    teamGuidance,
+  );
   const claudeArgs = buildAgentClaudeArgs(
     baseClaudeArgs,
     AGENT_FINDINGS_SCHEMA,
@@ -436,11 +456,13 @@ async function runDebateAgent(
   otherFindings: AgentFindings[],
   baseClaudeArgs: string,
   executionId: string,
+  teamGuidance?: string,
 ): Promise<AgentRebuttal> {
   const promptPath = await generateDebatePrompt(
     agent,
     ownFindings,
     otherFindings,
+    teamGuidance,
   );
   const claudeArgs = buildAgentClaudeArgs(
     baseClaudeArgs,
@@ -479,11 +501,13 @@ async function runSynthesisAgent(
   githubToken: string,
   context: ParsedGitHubContext,
   synthesisCommentId: number,
+  teamGuidance?: string,
 ): Promise<ClaudeRunResult> {
   const promptPath = await generateSynthesisPrompt(
     synthesisPerspective,
     allFindings,
     allRebuttals,
+    teamGuidance,
   );
   const executionFilePath = `${process.env.RUNNER_TEMP}/claude-execution-review-synthesis.json`;
 

--- a/src/modes/review/orchestrator.ts
+++ b/src/modes/review/orchestrator.ts
@@ -1,0 +1,593 @@
+import * as core from "@actions/core";
+import type { Octokits } from "../../github/api/client";
+import type { GitHubContext, ParsedGitHubContext } from "../../github/context";
+import { isEntityContext } from "../../github/context";
+import { checkHumanActor } from "../../github/validation/actor";
+import {
+  configureGitAuth,
+  setupSshSigning,
+} from "../../github/operations/git-config";
+import { setupBranch, type BranchInfo } from "../../github/operations/branch";
+import {
+  fetchGitHubData,
+  extractTriggerTimestamp,
+  extractOriginalTitle,
+  extractOriginalBody,
+} from "../../github/data/fetcher";
+import { formatContext, formatBody } from "../../github/data/formatter";
+import { prepareMcpConfig } from "../../mcp/install-mcp-server";
+import { runClaude } from "../../../base-action/src/run-claude";
+import type { ClaudeRunResult } from "../../../base-action/src/run-claude-sdk";
+import { resolveAgents, type ReviewAgent } from "./agents";
+import { AGENT_FINDINGS_SCHEMA, AGENT_REBUTTAL_SCHEMA } from "./schemas";
+import type { AgentFindings, AgentRebuttal } from "./schemas";
+import {
+  generateAgentPrompt,
+  generateDebatePrompt,
+  generateSynthesisPrompt,
+  generateSingleAgentPrompt,
+  buildAgentClaudeArgs,
+} from "./prompts";
+import { ReviewTracker } from "./tracking";
+import { mergeExecutionFiles } from "./merge-execution";
+import { runTriage } from "./triage";
+
+type ReviewResult = {
+  commentId: number | undefined;
+  branchInfo: BranchInfo;
+  executionFile?: string;
+  claudeSuccess: boolean;
+};
+
+export async function prepareAndRunReview({
+  context,
+  octokit,
+  githubToken,
+  multiAgentReview,
+}: {
+  context: GitHubContext;
+  octokit: Octokits;
+  githubToken: string;
+  multiAgentReview: string;
+}): Promise<ReviewResult> {
+  if (!isEntityContext(context)) {
+    throw new Error("Review mode requires entity context (PR)");
+  }
+  if (!context.isPR) {
+    throw new Error("Review mode is only supported for Pull Requests");
+  }
+
+  // Validate human actor
+  await checkHumanActor(octokit.rest, context);
+
+  // Resolve agents from spec file / input / defaults
+  const { agents, debateRounds, synthesisPerspective } = await resolveAgents({
+    reviewProtocolPath: context.inputs.reviewProtocolPath,
+    reviewAgents: context.inputs.reviewAgents,
+    reviewDebateRounds: context.inputs.reviewDebateRounds,
+    reviewMaxAgents: context.inputs.reviewMaxAgents,
+  });
+
+  core.info(
+    `Review mode: ${agents.length} agents, ${debateRounds} debate round(s)`,
+  );
+
+  // Configure git auth
+  const useSshSigning = !!context.inputs.sshSigningKey;
+  const useApiCommitSigning = context.inputs.useCommitSigning && !useSshSigning;
+
+  if (useSshSigning) {
+    await setupSshSigning(context.inputs.sshSigningKey);
+    const user = {
+      login: context.inputs.botName,
+      id: parseInt(context.inputs.botId),
+    };
+    await configureGitAuth(githubToken, context, user);
+  } else if (!useApiCommitSigning) {
+    const user = {
+      login: context.inputs.botName,
+      id: parseInt(context.inputs.botId),
+    };
+    await configureGitAuth(githubToken, context, user);
+  }
+
+  // Fetch GitHub data once (shared across all agents)
+  const triggerTime = extractTriggerTimestamp(context);
+  const originalTitle = extractOriginalTitle(context);
+  const originalBody = extractOriginalBody(context);
+
+  const githubData = await fetchGitHubData({
+    octokits: octokit,
+    repository: `${context.repository.owner}/${context.repository.repo}`,
+    prNumber: context.entityNumber.toString(),
+    isPR: true,
+    triggerUsername: context.actor,
+    triggerTime,
+    originalTitle,
+    originalBody,
+    includeCommentsByActor: context.inputs.includeCommentsByActor,
+    excludeCommentsByActor: context.inputs.excludeCommentsByActor,
+  });
+
+  // Setup branch
+  const branchInfo = await setupBranch(octokit, githubData, context);
+
+  // Build GitHub context markdown (shared across all agents)
+  const githubContextMarkdown = buildGitHubContextMarkdown(githubData, context);
+
+  // Create tracking comment
+  const tracker = new ReviewTracker(
+    octokit.rest,
+    context.repository.owner,
+    context.repository.repo,
+    agents,
+  );
+  const trackingCommentId = await tracker.createComment(context.entityNumber);
+
+  // Create a separate comment for the synthesis review
+  // This prevents the tracker from overwriting the final review
+  const synthesisComment = await octokit.rest.issues.createComment({
+    owner: context.repository.owner,
+    repo: context.repository.repo,
+    issue_number: context.entityNumber,
+    body: "⏳ *Multi-agent review in progress...*",
+  });
+  const synthesisCommentId = synthesisComment.data.id;
+
+  // Prepare MCP config (read-only for review agents)
+  const mcpConfig = await prepareMcpConfig({
+    githubToken,
+    owner: context.repository.owner,
+    repo: context.repository.repo,
+    branch: branchInfo.claudeBranch || branchInfo.currentBranch,
+    baseBranch: branchInfo.baseBranch,
+    claudeCommentId: trackingCommentId.toString(),
+    allowedTools: [],
+    mode: "review",
+    context,
+  });
+
+  // === Triage (for "auto" mode) ===
+  let useMultiAgent = multiAgentReview === "true";
+  let triageReasoning =
+    multiAgentReview === "true" ? "forced by configuration" : "";
+
+  if (multiAgentReview === "auto") {
+    const triageDecision = await runTriage(branchInfo.baseBranch, mcpConfig);
+    useMultiAgent = triageDecision.useMultiAgent;
+    triageReasoning = triageDecision.reasoning;
+  }
+
+  if (!useMultiAgent) {
+    core.info("Using single-agent review mode");
+    await tracker.setReviewMode("single-agent", triageReasoning);
+    return runSingleAgentReview({
+      githubContextMarkdown,
+      githubToken,
+      context,
+      branchInfo,
+      trackingCommentId,
+      synthesisCommentId,
+      tracker,
+    });
+  }
+
+  core.info("Using multi-agent review mode");
+  await tracker.setReviewMode("multi-agent", triageReasoning);
+
+  const baseClaudeArgs = buildBaseClaudeArgs(mcpConfig);
+  const executionFiles: string[] = [];
+
+  // === Round 1: Independent Reviews (parallel) ===
+  const allFindings: AgentFindings[] = [];
+
+  const round1Results = await Promise.allSettled(
+    agents.map(async (agent) => {
+      await tracker.updateAgentStatus(agent.name, "running");
+      const findings = await runReviewAgent(
+        agent,
+        githubContextMarkdown,
+        baseClaudeArgs,
+        `review-r1-${agent.id}`,
+      );
+      await tracker.updateAgentStatus(agent.name, "complete", findings);
+      return {
+        agentId: agent.id,
+        findings,
+      };
+    }),
+  );
+
+  for (const [i, result] of round1Results.entries()) {
+    if (result.status === "fulfilled") {
+      allFindings.push(result.value.findings);
+      executionFiles.push(
+        `${process.env.RUNNER_TEMP}/claude-execution-review-r1-${result.value.agentId}.json`,
+      );
+    } else {
+      core.warning(`Agent ${agents[i]!.id} failed: ${result.reason}`);
+      await tracker.updateAgentStatus(agents[i]!.name, "error");
+    }
+  }
+
+  // === Round 2: Debate (parallel) ===
+  const allRebuttals: AgentRebuttal[] = [];
+
+  if (debateRounds > 0 && allFindings.length > 1) {
+    await tracker.updateDebateStatus("running");
+
+    const debateResults = await Promise.allSettled(
+      agents
+        .filter((agent) => allFindings.some((f) => f.agent_id === agent.id))
+        .map(async (agent) => {
+          const ownFindings = allFindings.find((f) => f.agent_id === agent.id)!;
+          const otherFindings = allFindings.filter(
+            (f) => f.agent_id !== agent.id,
+          );
+          const rebuttal = await runDebateAgent(
+            agent,
+            ownFindings,
+            otherFindings,
+            baseClaudeArgs,
+            `review-r2-${agent.id}`,
+          );
+          return { agentId: agent.id, rebuttal };
+        }),
+    );
+
+    for (const result of debateResults) {
+      if (result.status === "fulfilled") {
+        allRebuttals.push(result.value.rebuttal);
+        executionFiles.push(
+          `${process.env.RUNNER_TEMP}/claude-execution-review-r2-${result.value.agentId}.json`,
+        );
+      } else {
+        core.warning(`Debate agent failed: ${result.reason}`);
+      }
+    }
+
+    await tracker.updateDebateStatus("complete");
+  } else if (debateRounds === 0) {
+    await tracker.updateDebateStatus("complete");
+  }
+
+  // === Synthesis ===
+  let synthesisSuccess = false;
+  await tracker.updateSynthesisStatus("running");
+
+  if (allFindings.length > 0) {
+    try {
+      await runSynthesisAgent(
+        synthesisPerspective,
+        allFindings,
+        allRebuttals,
+        githubToken,
+        context,
+        synthesisCommentId,
+      );
+
+      const execFile = `${process.env.RUNNER_TEMP}/claude-execution-review-synthesis.json`;
+      executionFiles.push(execFile);
+      synthesisSuccess = true;
+      await tracker.updateSynthesisStatus("complete");
+    } catch (error) {
+      core.warning(`Synthesis agent failed: ${error}`);
+      await tracker.updateSynthesisStatus("error");
+
+      // Fallback: post raw findings as markdown
+      try {
+        const fallback = formatFindingsAsFallback(allFindings, allRebuttals);
+        await octokit.rest.issues.updateComment({
+          owner: context.repository.owner,
+          repo: context.repository.repo,
+          comment_id: synthesisCommentId,
+          body: fallback,
+        });
+        synthesisSuccess = true; // Fallback posted successfully
+      } catch (fallbackError) {
+        core.warning(`Failed to post fallback review: ${fallbackError}`);
+      }
+    }
+  } else {
+    // No findings at all — update synthesis comment
+    await octokit.rest.issues.updateComment({
+      owner: context.repository.owner,
+      repo: context.repository.repo,
+      comment_id: synthesisCommentId,
+      body: "## 🔍 Multi-Agent Peer Review\n\nNo agents produced findings. Review could not be completed.",
+    });
+    await tracker.updateSynthesisStatus("error");
+  }
+
+  // Merge all execution files
+  const mergedExecutionFile = `${process.env.RUNNER_TEMP}/claude-execution-output.json`;
+  await mergeExecutionFiles(executionFiles, mergedExecutionFile);
+
+  return {
+    commentId: trackingCommentId,
+    branchInfo,
+    executionFile: mergedExecutionFile,
+    claudeSuccess: allFindings.length > 0 && synthesisSuccess,
+  };
+}
+
+async function runSingleAgentReview({
+  githubContextMarkdown,
+  githubToken,
+  context,
+  branchInfo,
+  trackingCommentId,
+  synthesisCommentId,
+  tracker,
+}: {
+  githubContextMarkdown: string;
+  githubToken: string;
+  context: ParsedGitHubContext;
+  branchInfo: BranchInfo;
+  trackingCommentId: number;
+  synthesisCommentId: number;
+  tracker: ReviewTracker;
+}): Promise<ReviewResult> {
+  const executionFilePath = `${process.env.RUNNER_TEMP}/claude-execution-review-single.json`;
+
+  // Single agent gets both comment and inline comment tools
+  const singleAgentMcpConfig = await prepareMcpConfig({
+    githubToken,
+    owner: context.repository.owner,
+    repo: context.repository.repo,
+    branch: branchInfo.claudeBranch || branchInfo.currentBranch,
+    baseBranch: branchInfo.baseBranch,
+    claudeCommentId: synthesisCommentId.toString(),
+    allowedTools: [
+      "mcp__github_comment__update_claude_comment",
+      "mcp__github_inline_comment__create_inline_comment",
+    ],
+    mode: "review",
+    context,
+  });
+
+  const escapedConfig = singleAgentMcpConfig.replace(/'/g, "'\\''");
+  const claudeArgs = `--mcp-config '${escapedConfig}' --permission-mode acceptEdits --allowedTools "Glob,Grep,Read,LS,mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment"`;
+
+  const promptPath = await generateSingleAgentPrompt(githubContextMarkdown);
+
+  await tracker.updateSynthesisStatus("running");
+
+  let success = false;
+  try {
+    await runClaude(promptPath, {
+      claudeArgs,
+      appendSystemPrompt:
+        "You are a thorough code reviewer. Provide a comprehensive review covering correctness, code quality, security, performance, and conventions.",
+      showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
+      executionFilePath,
+    });
+    success = true;
+    await tracker.updateSynthesisStatus("complete");
+  } catch (error) {
+    core.warning(`Single-agent review failed: ${error}`);
+    await tracker.updateSynthesisStatus("error");
+  }
+
+  // Merge execution file
+  const mergedExecutionFile = `${process.env.RUNNER_TEMP}/claude-execution-output.json`;
+  await mergeExecutionFiles([executionFilePath], mergedExecutionFile);
+
+  return {
+    commentId: trackingCommentId,
+    branchInfo,
+    executionFile: mergedExecutionFile,
+    claudeSuccess: success,
+  };
+}
+
+function validateStructuredOutput<T>(
+  raw: string,
+  requiredFields: string[],
+  label: string,
+): T {
+  const parsed = JSON.parse(raw);
+  for (const field of requiredFields) {
+    if (parsed[field] === undefined) {
+      throw new Error(`${label}: missing required field '${field}'`);
+    }
+  }
+  return parsed as T;
+}
+
+async function runReviewAgent(
+  agent: ReviewAgent,
+  githubContextMarkdown: string,
+  baseClaudeArgs: string,
+  executionId: string,
+): Promise<AgentFindings> {
+  const promptPath = await generateAgentPrompt(agent, githubContextMarkdown);
+  const claudeArgs = buildAgentClaudeArgs(
+    baseClaudeArgs,
+    AGENT_FINDINGS_SCHEMA,
+  );
+  const executionFilePath = `${process.env.RUNNER_TEMP}/claude-execution-${executionId}.json`;
+
+  core.info(`Running review agent: ${agent.name} (${agent.id})`);
+
+  const result = await runClaude(promptPath, {
+    claudeArgs,
+    appendSystemPrompt: agent.perspective,
+    model: agent.model,
+    maxTurns: agent.maxTurns ? String(agent.maxTurns) : undefined,
+    showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
+    executionFilePath,
+  });
+
+  if (!result.structuredOutput) {
+    throw new Error(`Agent ${agent.id} did not produce structured output`);
+  }
+
+  return validateStructuredOutput<AgentFindings>(
+    result.structuredOutput,
+    ["agent_id", "agent_name", "summary", "findings"],
+    `Agent ${agent.id}`,
+  );
+}
+
+async function runDebateAgent(
+  agent: ReviewAgent,
+  ownFindings: AgentFindings,
+  otherFindings: AgentFindings[],
+  baseClaudeArgs: string,
+  executionId: string,
+): Promise<AgentRebuttal> {
+  const promptPath = await generateDebatePrompt(
+    agent,
+    ownFindings,
+    otherFindings,
+  );
+  const claudeArgs = buildAgentClaudeArgs(
+    baseClaudeArgs,
+    AGENT_REBUTTAL_SCHEMA,
+  );
+  const executionFilePath = `${process.env.RUNNER_TEMP}/claude-execution-${executionId}.json`;
+
+  core.info(`Running debate agent: ${agent.name} (${agent.id})`);
+
+  const result = await runClaude(promptPath, {
+    claudeArgs,
+    appendSystemPrompt: agent.perspective,
+    model: agent.model,
+    maxTurns: agent.maxTurns ? String(agent.maxTurns) : undefined,
+    showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
+    executionFilePath,
+  });
+
+  if (!result.structuredOutput) {
+    throw new Error(
+      `Debate agent ${agent.id} did not produce structured output`,
+    );
+  }
+
+  return validateStructuredOutput<AgentRebuttal>(
+    result.structuredOutput,
+    ["agent_id", "agent_name", "responses"],
+    `Debate agent ${agent.id}`,
+  );
+}
+
+async function runSynthesisAgent(
+  synthesisPerspective: string,
+  allFindings: AgentFindings[],
+  allRebuttals: AgentRebuttal[],
+  githubToken: string,
+  context: ParsedGitHubContext,
+  synthesisCommentId: number,
+): Promise<ClaudeRunResult> {
+  const promptPath = await generateSynthesisPrompt(
+    synthesisPerspective,
+    allFindings,
+    allRebuttals,
+  );
+  const executionFilePath = `${process.env.RUNNER_TEMP}/claude-execution-review-synthesis.json`;
+
+  // Synthesis agent gets the comment MCP server to post its review
+  const synthesisMcpConfig = await prepareMcpConfig({
+    githubToken,
+    owner: context.repository.owner,
+    repo: context.repository.repo,
+    branch: "",
+    baseBranch: "",
+    claudeCommentId: synthesisCommentId.toString(),
+    allowedTools: [
+      "mcp__github_comment__update_claude_comment",
+      "mcp__github_inline_comment__create_inline_comment",
+    ],
+    mode: "review",
+    context,
+  });
+
+  const escapedConfig = synthesisMcpConfig.replace(/'/g, "'\\''");
+  const claudeArgs = `--mcp-config '${escapedConfig}' --permission-mode acceptEdits --allowedTools "Glob,Grep,Read,mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment"`;
+
+  core.info("Running synthesis agent");
+
+  return runClaude(promptPath, {
+    claudeArgs,
+    appendSystemPrompt: synthesisPerspective,
+    maxTurns: "15",
+    showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
+    executionFilePath,
+  });
+}
+
+function buildBaseClaudeArgs(mcpConfig: string): string {
+  const escapedConfig = mcpConfig.replace(/'/g, "'\\''");
+  // Review agents are read-only — no file write tools
+  return `--mcp-config '${escapedConfig}' --permission-mode acceptEdits --allowedTools "Glob,Grep,Read,LS"`;
+}
+
+function buildGitHubContextMarkdown(
+  githubData: Awaited<ReturnType<typeof fetchGitHubData>>,
+  context: ParsedGitHubContext,
+): string {
+  const sections: string[] = [];
+
+  sections.push(`## Repository
+${context.repository.owner}/${context.repository.repo}`);
+
+  if (githubData.contextData) {
+    sections.push(
+      `## PR Context\n${formatContext(githubData.contextData, true)}`,
+    );
+
+    if (githubData.contextData.body) {
+      sections.push(
+        `## PR Description\n${formatBody(githubData.contextData.body, githubData.imageUrlMap || new Map())}`,
+      );
+    }
+  }
+
+  return sections.join("\n\n");
+}
+
+function formatFindingsAsFallback(
+  allFindings: AgentFindings[],
+  allRebuttals: AgentRebuttal[],
+): string {
+  const parts: string[] = [];
+
+  parts.push("## 🔍 Multi-Agent Peer Review Results");
+  parts.push(
+    "*Note: Synthesis agent failed. Showing raw findings from individual reviewers.*\n",
+  );
+
+  for (const f of allFindings) {
+    parts.push(`### ${f.agent_name}`);
+    parts.push(f.summary);
+
+    if (f.overall_assessment) {
+      parts.push(`**Overall:** ${f.overall_assessment}`);
+    }
+
+    parts.push("");
+    for (const finding of f.findings) {
+      const loc = finding.file
+        ? ` (\`${finding.file}${finding.line ? `:${finding.line}` : ""}\`)`
+        : "";
+      parts.push(
+        `- **[${finding.severity.toUpperCase()}]** ${finding.title}: ${finding.description}${loc}`,
+      );
+    }
+    parts.push("");
+  }
+
+  if (allRebuttals.length > 0) {
+    parts.push("### Debate Responses\n");
+    for (const r of allRebuttals) {
+      for (const resp of r.responses) {
+        parts.push(
+          `- **${r.agent_name}** re: ${resp.regarding_finding_title} → *${resp.stance}*: ${resp.reasoning}`,
+        );
+      }
+    }
+  }
+
+  return parts.join("\n");
+}

--- a/src/modes/review/prompts.ts
+++ b/src/modes/review/prompts.ts
@@ -5,6 +5,22 @@ import { AGENT_FINDINGS_SCHEMA, AGENT_REBUTTAL_SCHEMA } from "./schemas";
 
 const PROMPT_DIR = `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts`;
 
+// Wraps a workflow-provided prompt as a Team Guidance section. Returns an
+// empty string when no guidance is supplied so the surrounding template
+// collapses cleanly without spurious blank lines.
+function formatTeamGuidanceSection(teamGuidance?: string): string {
+  const trimmed = teamGuidance?.trim();
+  if (!trimmed) return "";
+  return `## Team Guidance
+
+The following guidance is supplied by the team operating this review action.
+Apply it in addition to your role-specific perspective.
+
+${trimmed}
+
+`;
+}
+
 function formatFindingsForContext(allFindings: AgentFindings[]): string {
   if (allFindings.length === 0) return "";
 
@@ -51,6 +67,7 @@ ${responseLines}`;
 export async function generateAgentPrompt(
   agent: ReviewAgent,
   githubContextMarkdown: string,
+  teamGuidance?: string,
 ): Promise<string> {
   await mkdir(PROMPT_DIR, { recursive: true });
 
@@ -60,7 +77,7 @@ You are reviewing a Pull Request. Analyze the changes carefully from your specif
 
 ${githubContextMarkdown}
 
-## Instructions
+${formatTeamGuidanceSection(teamGuidance)}## Instructions
 
 1. Read the PR diff and understand the changes
 2. Analyze from your specific review perspective described above
@@ -79,6 +96,7 @@ export async function generateDebatePrompt(
   agent: ReviewAgent,
   ownFindings: AgentFindings,
   otherFindings: AgentFindings[],
+  teamGuidance?: string,
 ): Promise<string> {
   await mkdir(PROMPT_DIR, { recursive: true });
 
@@ -86,7 +104,7 @@ export async function generateDebatePrompt(
 
   const prompt = `${agent.perspective}
 
-You previously reviewed this PR and produced the following findings:
+${formatTeamGuidanceSection(teamGuidance)}You previously reviewed this PR and produced the following findings:
 
 ### Your Previous Findings (${ownFindings.agent_id})
 Summary: ${ownFindings.summary}
@@ -114,6 +132,7 @@ export async function generateSynthesisPrompt(
   synthesisPerspective: string,
   allFindings: AgentFindings[],
   allRebuttals: AgentRebuttal[],
+  teamGuidance?: string,
 ): Promise<string> {
   await mkdir(PROMPT_DIR, { recursive: true });
 
@@ -122,7 +141,7 @@ export async function generateSynthesisPrompt(
 
   const prompt = `${synthesisPerspective}
 
-## All Agent Findings
+${formatTeamGuidanceSection(teamGuidance)}## All Agent Findings
 
 ${findingsContext}
 
@@ -171,6 +190,7 @@ comments for specific line-level feedback.`;
 
 export async function generateSingleAgentPrompt(
   githubContextMarkdown: string,
+  teamGuidance?: string,
 ): Promise<string> {
   await mkdir(PROMPT_DIR, { recursive: true });
 
@@ -178,7 +198,7 @@ export async function generateSingleAgentPrompt(
 
 ${githubContextMarkdown}
 
-## Instructions
+${formatTeamGuidanceSection(teamGuidance)}## Instructions
 
 1. Read the PR diff and changed files carefully
 2. Analyze the changes from multiple perspectives:

--- a/src/modes/review/prompts.ts
+++ b/src/modes/review/prompts.ts
@@ -1,0 +1,223 @@
+import { writeFile, mkdir } from "fs/promises";
+import type { ReviewAgent } from "./agents";
+import type { AgentFindings, AgentRebuttal } from "./schemas";
+import { AGENT_FINDINGS_SCHEMA, AGENT_REBUTTAL_SCHEMA } from "./schemas";
+
+const PROMPT_DIR = `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts`;
+
+function formatFindingsForContext(allFindings: AgentFindings[]): string {
+  if (allFindings.length === 0) return "";
+
+  const sections = allFindings.map((f) => {
+    const findingLines = f.findings
+      .map(
+        (finding) =>
+          `  - [${finding.severity.toUpperCase()}] ${finding.title}: ${finding.description}${
+            finding.file
+              ? ` (${finding.file}${finding.line ? `:${finding.line}` : ""})`
+              : ""
+          }`,
+      )
+      .join("\n");
+
+    return `### ${f.agent_name} (${f.agent_id})
+Summary: ${f.summary}
+${f.overall_assessment ? `Overall: ${f.overall_assessment}` : ""}
+Findings:
+${findingLines}`;
+  });
+
+  return sections.join("\n\n");
+}
+
+function formatRebuttalsForContext(allRebuttals: AgentRebuttal[]): string {
+  if (allRebuttals.length === 0) return "";
+
+  const sections = allRebuttals.map((r) => {
+    const responseLines = r.responses
+      .map(
+        (resp) =>
+          `  - Re: ${resp.regarding_agent_id}/${resp.regarding_finding_title} → ${resp.stance}: ${resp.reasoning}`,
+      )
+      .join("\n");
+
+    return `### ${r.agent_name} (${r.agent_id}) Debate Responses
+${responseLines}`;
+  });
+
+  return sections.join("\n\n");
+}
+
+export async function generateAgentPrompt(
+  agent: ReviewAgent,
+  githubContextMarkdown: string,
+): Promise<string> {
+  await mkdir(PROMPT_DIR, { recursive: true });
+
+  const prompt = `${agent.perspective}
+
+You are reviewing a Pull Request. Analyze the changes carefully from your specific perspective.
+
+${githubContextMarkdown}
+
+## Instructions
+
+1. Read the PR diff and understand the changes
+2. Analyze from your specific review perspective described above
+3. Report your findings as structured JSON output
+
+Focus on actionable, specific findings. Reference exact files and line numbers where possible.
+Do NOT report issues that are clearly intentional design decisions unless they are genuinely problematic.
+Prioritize findings by severity: critical issues first, then warnings, suggestions, and nitpicks last.`;
+
+  const promptPath = `${PROMPT_DIR}/review-agent-${agent.id}.txt`;
+  await writeFile(promptPath, prompt);
+  return promptPath;
+}
+
+export async function generateDebatePrompt(
+  agent: ReviewAgent,
+  ownFindings: AgentFindings,
+  otherFindings: AgentFindings[],
+): Promise<string> {
+  await mkdir(PROMPT_DIR, { recursive: true });
+
+  const othersContext = formatFindingsForContext(otherFindings);
+
+  const prompt = `${agent.perspective}
+
+You previously reviewed this PR and produced the following findings:
+
+### Your Previous Findings (${ownFindings.agent_id})
+Summary: ${ownFindings.summary}
+${ownFindings.findings.map((f) => `  - [${f.severity.toUpperCase()}] ${f.title}: ${f.description}`).join("\n")}
+
+## Other Reviewers' Findings
+
+${othersContext}
+
+## Instructions
+
+Review the other agents' findings and provide your responses:
+1. For each finding from other reviewers, state whether you agree, disagree, partially agree, or want to supplement
+2. Provide reasoning for your stance
+3. If you have revised or new findings based on what others found, include them
+
+Be constructive and specific. If you disagree, explain why with concrete reasoning.`;
+
+  const promptPath = `${PROMPT_DIR}/review-debate-${agent.id}.txt`;
+  await writeFile(promptPath, prompt);
+  return promptPath;
+}
+
+export async function generateSynthesisPrompt(
+  synthesisPerspective: string,
+  allFindings: AgentFindings[],
+  allRebuttals: AgentRebuttal[],
+): Promise<string> {
+  await mkdir(PROMPT_DIR, { recursive: true });
+
+  const findingsContext = formatFindingsForContext(allFindings);
+  const rebuttalsContext = formatRebuttalsForContext(allRebuttals);
+
+  const prompt = `${synthesisPerspective}
+
+## All Agent Findings
+
+${findingsContext}
+
+${
+  rebuttalsContext
+    ? `## Debate Round Results
+
+${rebuttalsContext}`
+    : ""
+}
+
+## Instructions
+
+Synthesize all findings into a final, comprehensive review comment for the PR.
+
+Format the output as a well-structured markdown comment suitable for posting on GitHub.
+Include:
+1. An executive summary (1-2 sentences)
+2. Critical issues that must be addressed (if any)
+3. Warnings and suggestions grouped by theme
+4. A final verdict: whether the PR is ready to merge, needs changes, or needs discussion
+
+Do NOT use structured JSON output for this step — write a natural markdown review comment.
+Reference specific files and line numbers from the findings.
+Where reviewers disagreed, note the disagreement and provide your assessment.
+
+## Inline Comments
+
+For specific code-level findings (critical issues, warnings, and important suggestions),
+use the mcp__github_inline_comment__create_inline_comment tool to post line-by-line review
+comments directly on the PR diff. This provides developers with contextual feedback
+right where the code changes are.
+
+For each inline comment:
+- Target the specific file and line number from the finding
+- Keep the comment concise and actionable
+- Include the severity level and a clear explanation
+
+Post the overall summary via mcp__github_comment__update_claude_comment, and use inline
+comments for specific line-level feedback.`;
+
+  const promptPath = `${PROMPT_DIR}/review-synthesis.txt`;
+  await writeFile(promptPath, prompt);
+  return promptPath;
+}
+
+export async function generateSingleAgentPrompt(
+  githubContextMarkdown: string,
+): Promise<string> {
+  await mkdir(PROMPT_DIR, { recursive: true });
+
+  const prompt = `You are a comprehensive code reviewer. Analyze this Pull Request thoroughly from all perspectives: correctness, code quality, security, performance, and conventions.
+
+${githubContextMarkdown}
+
+## Instructions
+
+1. Read the PR diff and changed files carefully
+2. Analyze the changes from multiple perspectives:
+   - **Correctness**: Logic bugs, edge cases, error handling
+   - **Code Quality**: SOLID principles, DRY, readability, maintainability
+   - **Security**: Injection vulnerabilities, auth issues, data exposure
+   - **Performance**: Inefficiencies, unnecessary allocations, N+1 queries
+   - **Conventions**: Naming, style, project patterns consistency
+3. Write a well-structured markdown review comment
+
+Format your review as:
+1. An executive summary (1-2 sentences)
+2. Critical issues that must be addressed (if any)
+3. Warnings and suggestions grouped by theme
+4. A final verdict: whether the PR is ready to merge, needs changes, or needs discussion
+
+## Inline Comments
+
+For specific code-level findings (critical issues, warnings, and important suggestions),
+use the mcp__github_inline_comment__create_inline_comment tool to post line-by-line review
+comments directly on the PR diff.
+
+For each inline comment:
+- Target the specific file and line number
+- Keep the comment concise and actionable
+- Include the severity level and a clear explanation
+
+Post the overall summary via mcp__github_comment__update_claude_comment, and use inline
+comments for specific line-level feedback.`;
+
+  const promptPath = `${PROMPT_DIR}/review-single-agent.txt`;
+  await writeFile(promptPath, prompt);
+  return promptPath;
+}
+
+export function buildAgentClaudeArgs(
+  baseClaudeArgs: string,
+  schema: typeof AGENT_FINDINGS_SCHEMA | typeof AGENT_REBUTTAL_SCHEMA,
+): string {
+  const schemaJson = JSON.stringify(schema).replace(/'/g, "'\\''");
+  return `${baseClaudeArgs} --json-schema '${schemaJson}'`.trim();
+}

--- a/src/modes/review/schemas.ts
+++ b/src/modes/review/schemas.ts
@@ -1,0 +1,108 @@
+export const AGENT_FINDINGS_SCHEMA = {
+  type: "object",
+  properties: {
+    agent_id: { type: "string" },
+    agent_name: { type: "string" },
+    summary: { type: "string" },
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          severity: {
+            type: "string",
+            enum: ["critical", "warning", "suggestion", "nitpick"],
+          },
+          category: { type: "string" },
+          file: { type: "string" },
+          line: { type: "number" },
+          title: { type: "string" },
+          description: { type: "string" },
+          suggestion: { type: "string" },
+        },
+        required: ["severity", "title", "description"],
+      },
+    },
+    overall_assessment: { type: "string" },
+  },
+  required: ["agent_id", "agent_name", "summary", "findings"],
+} as const;
+
+export const AGENT_REBUTTAL_SCHEMA = {
+  type: "object",
+  properties: {
+    agent_id: { type: "string" },
+    agent_name: { type: "string" },
+    responses: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          regarding_agent_id: { type: "string" },
+          regarding_finding_title: { type: "string" },
+          stance: {
+            type: "string",
+            enum: ["agree", "disagree", "partially_agree", "supplement"],
+          },
+          reasoning: { type: "string" },
+          additional_context: { type: "string" },
+        },
+        required: [
+          "regarding_agent_id",
+          "regarding_finding_title",
+          "stance",
+          "reasoning",
+        ],
+      },
+    },
+    revised_findings: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          severity: {
+            type: "string",
+            enum: ["critical", "warning", "suggestion", "nitpick"],
+          },
+          title: { type: "string" },
+          description: { type: "string" },
+        },
+        required: ["severity", "title", "description"],
+      },
+    },
+  },
+  required: ["agent_id", "agent_name", "responses"],
+} as const;
+
+export type AgentFinding = {
+  severity: "critical" | "warning" | "suggestion" | "nitpick";
+  category?: string;
+  file?: string;
+  line?: number;
+  title: string;
+  description: string;
+  suggestion?: string;
+};
+
+export type AgentFindings = {
+  agent_id: string;
+  agent_name: string;
+  summary: string;
+  findings: AgentFinding[];
+  overall_assessment?: string;
+};
+
+export type AgentRebuttalResponse = {
+  regarding_agent_id: string;
+  regarding_finding_title: string;
+  stance: "agree" | "disagree" | "partially_agree" | "supplement";
+  reasoning: string;
+  additional_context?: string;
+};
+
+export type AgentRebuttal = {
+  agent_id: string;
+  agent_name: string;
+  responses: AgentRebuttalResponse[];
+  revised_findings?: AgentFinding[];
+};

--- a/src/modes/review/tracking.ts
+++ b/src/modes/review/tracking.ts
@@ -1,0 +1,160 @@
+import * as core from "@actions/core";
+import type { Octokit } from "@octokit/rest";
+import type { ReviewAgent } from "./agents";
+import type { AgentFindings } from "./schemas";
+
+export type AgentStatus = "pending" | "running" | "complete" | "error";
+
+type TrackingState = {
+  agents: Map<string, { status: AgentStatus; findingsCount?: string }>;
+  debateStatus: AgentStatus;
+  synthesisStatus: AgentStatus;
+  reviewMode?: {
+    mode: "multi-agent" | "single-agent";
+    reasoning: string;
+  };
+};
+
+const STATUS_ICONS: Record<AgentStatus, string> = {
+  pending: "⬜",
+  running: "⏳",
+  complete: "✅",
+  error: "❌",
+};
+
+function renderTrackingTable(state: TrackingState): string {
+  const modeHeader = state.reviewMode
+    ? `> **Mode:** ${state.reviewMode.mode === "multi-agent" ? "🔀 Multi-Agent" : "🔹 Single-Agent"} — ${state.reviewMode.reasoning}\n\n`
+    : "";
+
+  if (state.reviewMode?.mode === "single-agent") {
+    const synthesisIcon = STATUS_ICONS[state.synthesisStatus];
+    return `## 🔍 PR Review
+
+${modeHeader}| Step | Status |
+|------|--------|
+| Review | ${synthesisIcon} ${state.synthesisStatus.charAt(0).toUpperCase() + state.synthesisStatus.slice(1)} |
+
+*Powered by Claude Code Action*`;
+  }
+
+  const agentRows = Array.from(state.agents.entries())
+    .map(([name, { status, findingsCount }]) => {
+      const icon = STATUS_ICONS[status];
+      const findings = findingsCount || "-";
+      return `| ${name} | ${icon} ${status.charAt(0).toUpperCase() + status.slice(1)} | ${findings} |`;
+    })
+    .join("\n");
+
+  const debateIcon = STATUS_ICONS[state.debateStatus];
+  const synthesisIcon = STATUS_ICONS[state.synthesisStatus];
+
+  return `## 🔍 Multi-Agent Peer Review
+
+${modeHeader}| Persona | Status | Findings |
+|---------|--------|----------|
+${agentRows}
+| Debate Round | ${debateIcon} ${state.debateStatus.charAt(0).toUpperCase() + state.debateStatus.slice(1)} | - |
+| Synthesis | ${synthesisIcon} ${state.synthesisStatus.charAt(0).toUpperCase() + state.synthesisStatus.slice(1)} | - |
+
+*Powered by Claude Code Action — Multi-Agent Review*`;
+}
+
+export class ReviewTracker {
+  private state: TrackingState;
+  private commentId: number | undefined;
+  private octokit: Octokit;
+  private owner: string;
+  private repo: string;
+
+  constructor(
+    octokit: Octokit,
+    owner: string,
+    repo: string,
+    agents: ReviewAgent[],
+  ) {
+    this.octokit = octokit;
+    this.owner = owner;
+    this.repo = repo;
+    this.state = {
+      agents: new Map(
+        agents.map((a) => [a.name, { status: "pending" as AgentStatus }]),
+      ),
+      debateStatus: "pending",
+      synthesisStatus: "pending",
+    };
+  }
+
+  async createComment(issueNumber: number): Promise<number> {
+    const body = renderTrackingTable(this.state);
+    const response = await this.octokit.issues.createComment({
+      owner: this.owner,
+      repo: this.repo,
+      issue_number: issueNumber,
+      body,
+    });
+    this.commentId = response.data.id;
+    return this.commentId;
+  }
+
+  async setReviewMode(
+    mode: "multi-agent" | "single-agent",
+    reasoning: string,
+  ): Promise<void> {
+    this.state.reviewMode = { mode, reasoning };
+    await this.updateComment();
+  }
+
+  async updateAgentStatus(
+    agentName: string,
+    status: AgentStatus,
+    findings?: AgentFindings,
+  ): Promise<void> {
+    const entry = this.state.agents.get(agentName);
+    if (entry) {
+      entry.status = status;
+      if (findings) {
+        const counts = findings.findings.reduce(
+          (acc, f) => {
+            acc[f.severity] = (acc[f.severity] || 0) + 1;
+            return acc;
+          },
+          {} as Record<string, number>,
+        );
+        const parts: string[] = [];
+        if (counts.critical) parts.push(`${counts.critical} critical`);
+        if (counts.warning) parts.push(`${counts.warning} warning`);
+        if (counts.suggestion) parts.push(`${counts.suggestion} suggestion`);
+        if (counts.nitpick) parts.push(`${counts.nitpick} nitpick`);
+        entry.findingsCount = parts.join(", ") || "No issues found";
+      }
+    }
+    await this.updateComment();
+  }
+
+  async updateDebateStatus(status: AgentStatus): Promise<void> {
+    this.state.debateStatus = status;
+    await this.updateComment();
+  }
+
+  async updateSynthesisStatus(status: AgentStatus): Promise<void> {
+    this.state.synthesisStatus = status;
+    await this.updateComment();
+  }
+
+  private async updateComment(): Promise<void> {
+    if (!this.commentId) return;
+
+    const body = renderTrackingTable(this.state);
+    try {
+      await this.octokit.issues.updateComment({
+        owner: this.owner,
+        repo: this.repo,
+        comment_id: this.commentId,
+        body,
+      });
+    } catch (error) {
+      core.warning(`Failed to update tracking comment: ${error}`);
+    }
+  }
+}

--- a/src/modes/review/triage.ts
+++ b/src/modes/review/triage.ts
@@ -1,0 +1,144 @@
+import * as core from "@actions/core";
+import { writeFile, mkdir } from "fs/promises";
+import { execFileSync } from "child_process";
+import { runClaude } from "../../../base-action/src/run-claude";
+
+const PROMPT_DIR = `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts`;
+
+const TRIAGE_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    use_multi_agent: {
+      type: "boolean" as const,
+      description:
+        "Whether to use multi-agent review (true) or single-agent review (false)",
+    },
+    reasoning: {
+      type: "string" as const,
+      description: "Brief explanation of why this routing decision was made",
+    },
+  },
+  required: ["use_multi_agent", "reasoning"],
+  additionalProperties: false,
+};
+
+type TriageDecision = {
+  useMultiAgent: boolean;
+  reasoning: string;
+};
+
+function getDiffStats(baseBranch: string): string {
+  try {
+    let stats: string;
+    try {
+      stats = execFileSync("git", ["diff", "--stat", `${baseBranch}...HEAD`], {
+        encoding: "utf-8",
+        maxBuffer: 1024 * 1024,
+      }).trim();
+    } catch {
+      try {
+        stats = execFileSync("git", ["diff", "--stat", "HEAD~1"], {
+          encoding: "utf-8",
+          maxBuffer: 1024 * 1024,
+        }).trim();
+      } catch {
+        return "Unable to get diff stats";
+      }
+    }
+
+    let shortlog = "";
+    try {
+      shortlog = execFileSync(
+        "git",
+        ["diff", "--shortstat", `${baseBranch}...HEAD`],
+        { encoding: "utf-8", maxBuffer: 1024 * 1024 },
+      ).trim();
+    } catch {
+      try {
+        shortlog = execFileSync("git", ["diff", "--shortstat", "HEAD~1"], {
+          encoding: "utf-8",
+          maxBuffer: 1024 * 1024,
+        }).trim();
+      } catch {
+        // shortlog stays empty
+      }
+    }
+
+    return `${stats}\n\nSummary: ${shortlog}`;
+  } catch {
+    return "Unable to get diff stats";
+  }
+}
+
+export async function runTriage(
+  baseBranch: string,
+  mcpConfig: string,
+): Promise<TriageDecision> {
+  await mkdir(PROMPT_DIR, { recursive: true });
+
+  const diffStats = getDiffStats(baseBranch);
+
+  const prompt = `You are a PR review triage agent. Based on the diff statistics below, decide whether this PR needs multi-agent review (multiple specialized reviewers) or single-agent review (one comprehensive reviewer).
+
+## Diff Statistics
+
+${diffStats}
+
+## Decision Criteria
+
+Use MULTI-AGENT review when:
+- Many files changed (roughly 5+)
+- Large total line changes (roughly 200+)
+- Changes span multiple areas (e.g., both source and tests, multiple packages)
+- Mix of new files and modified files suggesting a new feature
+
+Use SINGLE-AGENT review when:
+- Few files changed (1-4)
+- Small total line changes (under ~200)
+- Changes are localized (single module or focused fix)
+- Mostly config changes, docs, or simple bug fixes
+
+Make a clear decision. When in doubt, prefer single-agent for efficiency.`;
+
+  const promptPath = `${PROMPT_DIR}/review-triage.txt`;
+  await writeFile(promptPath, prompt);
+
+  const escapedConfig = mcpConfig.replace(/'/g, "'\\''");
+  const schemaJson = JSON.stringify(TRIAGE_SCHEMA).replace(/'/g, "'\\''");
+  const claudeArgs = `--mcp-config '${escapedConfig}' --permission-mode acceptEdits --allowedTools "Glob,Grep,Read,LS" --json-schema '${schemaJson}'`;
+
+  core.info("Running triage agent to determine review strategy...");
+
+  try {
+    const result = await runClaude(promptPath, {
+      claudeArgs,
+      appendSystemPrompt:
+        "You are a lightweight triage agent. Analyze the diff statistics and make a quick routing decision. Do not read any files — just use the stats provided.",
+      maxTurns: "3",
+      showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
+    });
+
+    if (result.structuredOutput) {
+      const parsed = JSON.parse(result.structuredOutput);
+      const decision: TriageDecision = {
+        useMultiAgent: !!parsed.use_multi_agent,
+        reasoning: String(parsed.reasoning || ""),
+      };
+      core.info(
+        `Triage decision: ${decision.useMultiAgent ? "multi-agent" : "single-agent"} — ${decision.reasoning}`,
+      );
+      return decision;
+    }
+  } catch (error) {
+    core.warning(
+      `Triage agent failed: ${error}. Falling back to single-agent review.`,
+    );
+  }
+
+  // Default fallback: single-agent
+  return {
+    useMultiAgent: false,
+    reasoning:
+      "Triage failed or produced no output; defaulting to single-agent",
+  };
+}

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -43,6 +43,9 @@ describe("prepareMcpConfig", () => {
       includeFixLinks: true,
       includeCommentsByActor: "",
       excludeCommentsByActor: "",
+      multiAgentReview: "false",
+      reviewDebateRounds: 1,
+      reviewMaxAgents: 5,
     },
   };
 

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -30,6 +30,9 @@ const defaultInputs = {
   includeFixLinks: true,
   includeCommentsByActor: "",
   excludeCommentsByActor: "",
+  multiAgentReview: "false",
+  reviewDebateRounds: 1,
+  reviewMaxAgents: 5,
 };
 
 const defaultRepository = {

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -30,6 +30,9 @@ describe("detectMode with enhanced routing", () => {
       includeFixLinks: true,
       includeCommentsByActor: "",
       excludeCommentsByActor: "",
+      multiAgentReview: "false",
+      reviewDebateRounds: 1,
+      reviewMaxAgents: 5,
     },
   };
 
@@ -259,6 +262,188 @@ describe("detectMode with enhanced routing", () => {
       };
 
       expect(detectMode(context)).toBe("tag");
+    });
+  });
+
+  describe("Review Mode", () => {
+    it("should detect review mode when multiAgentReview is 'true' on a PR", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "opened",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, multiAgentReview: "true" },
+      };
+
+      expect(detectMode(context)).toBe("review");
+    });
+
+    it("should detect review mode when multiAgentReview is 'auto' on a PR", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "opened",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, multiAgentReview: "auto" },
+      };
+
+      expect(detectMode(context)).toBe("review");
+    });
+
+    it("should not detect review mode on issues even with multiAgentReview 'true'", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "issues",
+        eventAction: "opened",
+        payload: { issue: { number: 1, body: "Test" } } as any,
+        entityNumber: 1,
+        isPR: false,
+        inputs: { ...baseContext.inputs, multiAgentReview: "true" },
+      };
+
+      // Not a PR, so should not be review mode
+      expect(detectMode(context)).not.toBe("review");
+    });
+
+    it("should not detect review mode when multiAgentReview is 'false'", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "opened",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, multiAgentReview: "false" },
+      };
+
+      expect(detectMode(context)).not.toBe("review");
+    });
+
+    it("should prioritize review mode over tag mode when both apply", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "opened",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: {
+          ...baseContext.inputs,
+          multiAgentReview: "true",
+          trackProgress: true,
+        },
+      };
+
+      expect(detectMode(context)).toBe("review");
+    });
+
+    it("should not detect review mode for issue_comment on PR even with 'true'", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "issue_comment",
+        eventAction: "created",
+        payload: {
+          issue: { number: 1, body: "Test" },
+          comment: { body: "@claude help" },
+        } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, multiAgentReview: "true" },
+      };
+
+      expect(detectMode(context)).not.toBe("review");
+    });
+
+    it("should not detect review mode for pull_request_review_comment even with 'true'", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request_review_comment",
+        eventAction: "created",
+        payload: {
+          pull_request: { number: 1, body: "Test" },
+          comment: { body: "@claude check this" },
+        } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, multiAgentReview: "true" },
+      };
+
+      expect(detectMode(context)).not.toBe("review");
+    });
+
+    it("should use agent mode when 'auto' with explicit prompt", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "opened",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: {
+          ...baseContext.inputs,
+          multiAgentReview: "auto",
+          prompt: "Review for security issues",
+        },
+      };
+
+      expect(detectMode(context)).toBe("agent");
+    });
+
+    it("should use tag mode when 'auto' with trackProgress", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "opened",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: {
+          ...baseContext.inputs,
+          multiAgentReview: "auto",
+          trackProgress: true,
+        },
+      };
+
+      expect(detectMode(context)).toBe("tag");
+    });
+
+    it("should not detect review mode for issue_comment on PR with 'auto'", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "issue_comment",
+        eventAction: "created",
+        payload: {
+          issue: { number: 1, body: "Test" },
+          comment: { body: "@claude help" },
+        } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, multiAgentReview: "auto" },
+      };
+
+      expect(detectMode(context)).not.toBe("review");
+    });
+
+    it("should use review mode when 'true' even with prompt", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "opened",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: {
+          ...baseContext.inputs,
+          multiAgentReview: "true",
+          prompt: "Review for security issues",
+        },
+      };
+
+      expect(detectMode(context)).toBe("review");
     });
   });
 });

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -341,7 +341,7 @@ describe("detectMode with enhanced routing", () => {
       expect(detectMode(context)).toBe("review");
     });
 
-    it("should not detect review mode for issue_comment on PR even with 'true'", () => {
+    it("should detect review mode for issue_comment on PR with 'true' and trigger phrase", () => {
       const context: GitHubContext = {
         ...baseContext,
         eventName: "issue_comment",
@@ -355,10 +355,10 @@ describe("detectMode with enhanced routing", () => {
         inputs: { ...baseContext.inputs, multiAgentReview: "true" },
       };
 
-      expect(detectMode(context)).not.toBe("review");
+      expect(detectMode(context)).toBe("review");
     });
 
-    it("should not detect review mode for pull_request_review_comment even with 'true'", () => {
+    it("should detect review mode for pull_request_review_comment with 'true' and trigger", () => {
       const context: GitHubContext = {
         ...baseContext,
         eventName: "pull_request_review_comment",
@@ -372,10 +372,28 @@ describe("detectMode with enhanced routing", () => {
         inputs: { ...baseContext.inputs, multiAgentReview: "true" },
       };
 
+      expect(detectMode(context)).toBe("review");
+    });
+
+    it("should NOT detect review mode for issue_comment on PR without trigger phrase", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "issue_comment",
+        eventAction: "created",
+        payload: {
+          issue: { number: 1, body: "Test" },
+          comment: { body: "unrelated chatter" },
+        } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, multiAgentReview: "true" },
+      };
+
+      // Guards against review self-triggering via its own posted comments.
       expect(detectMode(context)).not.toBe("review");
     });
 
-    it("should use agent mode when 'auto' with explicit prompt", () => {
+    it("should detect review mode when 'auto' with explicit prompt (prompt is team guidance, not opt-out)", () => {
       const context: GitHubContext = {
         ...baseContext,
         eventName: "pull_request",
@@ -390,10 +408,10 @@ describe("detectMode with enhanced routing", () => {
         },
       };
 
-      expect(detectMode(context)).toBe("agent");
+      expect(detectMode(context)).toBe("review");
     });
 
-    it("should use tag mode when 'auto' with trackProgress", () => {
+    it("should detect review mode when 'auto' with trackProgress (tracker covers it)", () => {
       const context: GitHubContext = {
         ...baseContext,
         eventName: "pull_request",
@@ -408,10 +426,10 @@ describe("detectMode with enhanced routing", () => {
         },
       };
 
-      expect(detectMode(context)).toBe("tag");
+      expect(detectMode(context)).toBe("review");
     });
 
-    it("should not detect review mode for issue_comment on PR with 'auto'", () => {
+    it("should detect review mode for issue_comment on PR with 'auto' and trigger phrase", () => {
       const context: GitHubContext = {
         ...baseContext,
         eventName: "issue_comment",
@@ -422,6 +440,23 @@ describe("detectMode with enhanced routing", () => {
         } as any,
         entityNumber: 1,
         isPR: true,
+        inputs: { ...baseContext.inputs, multiAgentReview: "auto" },
+      };
+
+      expect(detectMode(context)).toBe("review");
+    });
+
+    it("should NOT detect review mode for issue_comment on a non-PR issue even with 'auto'", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "issue_comment",
+        eventAction: "created",
+        payload: {
+          issue: { number: 1, body: "Test" },
+          comment: { body: "@claude help" },
+        } as any,
+        entityNumber: 1,
+        isPR: false,
         inputs: { ...baseContext.inputs, multiAgentReview: "auto" },
       };
 
@@ -440,6 +475,25 @@ describe("detectMode with enhanced routing", () => {
           ...baseContext.inputs,
           multiAgentReview: "true",
           prompt: "Review for security issues",
+        },
+      };
+
+      expect(detectMode(context)).toBe("review");
+    });
+
+    it("should use review mode when all of auto + prompt + trackProgress combine (ai-feature-store scenario)", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "opened",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: {
+          ...baseContext.inputs,
+          multiAgentReview: "auto",
+          prompt: "Please review per team conventions",
+          trackProgress: true,
         },
       };
 

--- a/test/modes/review/agents.test.ts
+++ b/test/modes/review/agents.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { writeFile, mkdir, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  DEFAULT_AGENTS,
+  loadAgentSpec,
+  resolveAgents,
+} from "../../../src/modes/review/agents";
+
+describe("review agents", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `review-agents-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("DEFAULT_AGENTS", () => {
+    it("should have 3 default agents", () => {
+      expect(DEFAULT_AGENTS).toHaveLength(3);
+    });
+
+    it("should have critic, code-quality, and convention agents", () => {
+      const ids = DEFAULT_AGENTS.map((a) => a.id);
+      expect(ids).toEqual(["critic", "code-quality", "convention"]);
+    });
+
+    it("should not set maxTurns for default agents (unlimited)", () => {
+      for (const agent of DEFAULT_AGENTS) {
+        expect(agent.maxTurns).toBeUndefined();
+      }
+    });
+
+    it("should not set model for default agents", () => {
+      for (const agent of DEFAULT_AGENTS) {
+        expect(agent.model).toBeUndefined();
+      }
+    });
+  });
+
+  describe("loadAgentSpec", () => {
+    it("should return null for non-existent file", async () => {
+      const result = await loadAgentSpec(join(tempDir, "nonexistent.yml"));
+      expect(result).toBeNull();
+    });
+
+    it("should parse valid YAML spec", async () => {
+      const specPath = join(tempDir, "agents.yml");
+      await writeFile(
+        specPath,
+        `
+version: 1
+agents:
+  - id: security
+    name: Security Reviewer
+    perspective: Focus on security issues
+    max_turns: 8
+  - id: perf
+    name: Performance Reviewer
+    perspective: Focus on performance
+debate_rounds: 2
+synthesis:
+  perspective: Custom synthesis perspective
+`,
+      );
+
+      const result = await loadAgentSpec(specPath);
+      expect(result).not.toBeNull();
+      expect(result!.version).toBe(1);
+      expect(result!.agents).toHaveLength(2);
+      expect(result!.agents[0]!.id).toBe("security");
+      expect(result!.agents[0]!.name).toBe("Security Reviewer");
+      expect(result!.agents[0]!.perspective).toBe("Focus on security issues");
+      expect(result!.agents[0]!.maxTurns).toBe(8);
+      expect(result!.agents[1]!.id).toBe("perf");
+      expect(result!.agents[1]!.maxTurns).toBeUndefined(); // no max_turns in spec = unlimited
+      expect(result!.debate_rounds).toBe(2);
+      expect(result!.synthesis?.perspective).toBe(
+        "Custom synthesis perspective",
+      );
+    });
+
+    it("should handle agents with model override", async () => {
+      const specPath = join(tempDir, "agents.yml");
+      await writeFile(
+        specPath,
+        `
+version: 1
+agents:
+  - id: fast-reviewer
+    name: Fast Reviewer
+    perspective: Quick review
+    model: claude-sonnet-4-20250514
+`,
+      );
+
+      const result = await loadAgentSpec(specPath);
+      expect(result!.agents[0]!.model).toBe("claude-sonnet-4-20250514");
+    });
+
+    it("should use id as name when name not provided", async () => {
+      const specPath = join(tempDir, "agents.yml");
+      await writeFile(
+        specPath,
+        `
+version: 1
+agents:
+  - id: my-reviewer
+    perspective: Review stuff
+`,
+      );
+
+      const result = await loadAgentSpec(specPath);
+      expect(result!.agents[0]!.name).toBe("my-reviewer");
+    });
+
+    it("should return null for invalid YAML", async () => {
+      const specPath = join(tempDir, "agents.yml");
+      await writeFile(specPath, "not: valid: yaml: [[[");
+
+      const result = await loadAgentSpec(specPath);
+      // yaml package is lenient, this may parse or not
+      // The important thing is it doesn't throw
+      expect(result === null || result !== null).toBe(true);
+    });
+
+    it("should return null for spec without agents array", async () => {
+      const specPath = join(tempDir, "agents.yml");
+      await writeFile(
+        specPath,
+        `
+version: 1
+agents: "not an array"
+`,
+      );
+
+      const result = await loadAgentSpec(specPath);
+      expect(result).toBeNull();
+    });
+
+    it("should return null for spec with empty agents array", async () => {
+      const specPath = join(tempDir, "agents.yml");
+      await writeFile(
+        specPath,
+        `
+version: 1
+agents: []
+`,
+      );
+
+      const result = await loadAgentSpec(specPath);
+      expect(result).toBeNull();
+    });
+
+    it("should return null for agent without id", async () => {
+      const specPath = join(tempDir, "agents.yml");
+      await writeFile(
+        specPath,
+        `
+version: 1
+agents:
+  - name: No ID Agent
+    perspective: Review stuff
+`,
+      );
+
+      const result = await loadAgentSpec(specPath);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("resolveAgents", () => {
+    it("should return default agents when no spec or input provided", async () => {
+      const result = await resolveAgents({
+        reviewDebateRounds: 1,
+        reviewMaxAgents: 5,
+      });
+
+      expect(result.agents).toEqual(DEFAULT_AGENTS);
+      expect(result.debateRounds).toBe(1);
+    });
+
+    it("should respect reviewMaxAgents limit", async () => {
+      const result = await resolveAgents({
+        reviewDebateRounds: 1,
+        reviewMaxAgents: 2,
+      });
+
+      expect(result.agents).toHaveLength(2);
+    });
+
+    it("should load agents from reviewProtocolPath when provided", async () => {
+      const specPath = join(tempDir, "custom-agents.yml");
+      await writeFile(
+        specPath,
+        `
+version: 1
+agents:
+  - id: custom
+    name: Custom Agent
+    perspective: Custom perspective
+debate_rounds: 3
+`,
+      );
+
+      const result = await resolveAgents({
+        reviewProtocolPath: specPath,
+        reviewDebateRounds: 1,
+        reviewMaxAgents: 5,
+      });
+
+      expect(result.agents).toHaveLength(1);
+      expect(result.agents[0]!.id).toBe("custom");
+      expect(result.debateRounds).toBe(3); // from spec file
+    });
+
+    it("should parse reviewAgents JSON input", async () => {
+      const agents = JSON.stringify([
+        { id: "json-agent", name: "JSON Agent", perspective: "From JSON" },
+      ]);
+
+      const result = await resolveAgents({
+        reviewAgents: agents,
+        reviewDebateRounds: 2,
+        reviewMaxAgents: 5,
+      });
+
+      expect(result.agents).toHaveLength(1);
+      expect(result.agents[0]!.id).toBe("json-agent");
+      expect(result.debateRounds).toBe(2); // from input, not spec
+    });
+
+    it("should fall back to defaults on invalid JSON", async () => {
+      const result = await resolveAgents({
+        reviewAgents: "not valid json",
+        reviewDebateRounds: 1,
+        reviewMaxAgents: 5,
+      });
+
+      expect(result.agents).toEqual(DEFAULT_AGENTS);
+    });
+
+    it("should prioritize protocol path over reviewAgents input", async () => {
+      const specPath = join(tempDir, "priority-agents.yml");
+      await writeFile(
+        specPath,
+        `
+version: 1
+agents:
+  - id: from-file
+    perspective: File perspective
+`,
+      );
+
+      const result = await resolveAgents({
+        reviewProtocolPath: specPath,
+        reviewAgents: JSON.stringify([
+          { id: "from-json", perspective: "JSON perspective" },
+        ]),
+        reviewDebateRounds: 1,
+        reviewMaxAgents: 5,
+      });
+
+      expect(result.agents[0]!.id).toBe("from-file");
+    });
+  });
+});

--- a/test/modes/review/merge-execution.test.ts
+++ b/test/modes/review/merge-execution.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { writeFile, readFile, mkdir, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { mergeExecutionFiles } from "../../../src/modes/review/merge-execution";
+
+describe("mergeExecutionFiles", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `merge-exec-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("should merge multiple execution files into one", async () => {
+    const file1 = join(tempDir, "exec1.json");
+    const file2 = join(tempDir, "exec2.json");
+    const output = join(tempDir, "merged.json");
+
+    await writeFile(file1, JSON.stringify([{ type: "message", content: "a" }]));
+    await writeFile(file2, JSON.stringify([{ type: "message", content: "b" }]));
+
+    await mergeExecutionFiles([file1, file2], output);
+
+    const result = JSON.parse(await readFile(output, "utf-8"));
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toBe("a");
+    expect(result[1].content).toBe("b");
+  });
+
+  it("should skip non-existent files", async () => {
+    const file1 = join(tempDir, "exec1.json");
+    const nonExistent = join(tempDir, "nonexistent.json");
+    const output = join(tempDir, "merged.json");
+
+    await writeFile(file1, JSON.stringify([{ type: "message", content: "a" }]));
+
+    await mergeExecutionFiles([file1, nonExistent], output);
+
+    const result = JSON.parse(await readFile(output, "utf-8"));
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("a");
+  });
+
+  it("should produce empty array when no files exist", async () => {
+    const output = join(tempDir, "merged.json");
+
+    await mergeExecutionFiles(
+      [join(tempDir, "nope1.json"), join(tempDir, "nope2.json")],
+      output,
+    );
+
+    const result = JSON.parse(await readFile(output, "utf-8"));
+    expect(result).toEqual([]);
+  });
+
+  it("should handle files with multiple entries", async () => {
+    const file1 = join(tempDir, "exec1.json");
+    const output = join(tempDir, "merged.json");
+
+    await writeFile(
+      file1,
+      JSON.stringify([
+        { type: "a", data: 1 },
+        { type: "b", data: 2 },
+        { type: "c", data: 3 },
+      ]),
+    );
+
+    await mergeExecutionFiles([file1], output);
+
+    const result = JSON.parse(await readFile(output, "utf-8"));
+    expect(result).toHaveLength(3);
+  });
+
+  it("should skip files with invalid JSON gracefully", async () => {
+    const file1 = join(tempDir, "exec1.json");
+    const fileBad = join(tempDir, "bad.json");
+    const output = join(tempDir, "merged.json");
+
+    await writeFile(file1, JSON.stringify([{ type: "valid" }]));
+    await writeFile(fileBad, "not valid json {{{");
+
+    await mergeExecutionFiles([file1, fileBad], output);
+
+    const result = JSON.parse(await readFile(output, "utf-8"));
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("valid");
+  });
+});

--- a/test/modes/review/prompts.test.ts
+++ b/test/modes/review/prompts.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { readFile, rm, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import type { ReviewAgent } from "../../../src/modes/review/agents";
+import type {
+  AgentFindings,
+  AgentRebuttal,
+} from "../../../src/modes/review/schemas";
+import {
+  generateAgentPrompt,
+  generateDebatePrompt,
+  generateSynthesisPrompt,
+  buildAgentClaudeArgs,
+} from "../../../src/modes/review/prompts";
+import { AGENT_FINDINGS_SCHEMA } from "../../../src/modes/review/schemas";
+
+describe("review prompts", () => {
+  const originalRunnerTemp = process.env.RUNNER_TEMP;
+  let promptDir: string;
+
+  beforeEach(async () => {
+    process.env.RUNNER_TEMP = `/tmp/test-prompts-${Date.now()}`;
+    promptDir = `${process.env.RUNNER_TEMP}/claude-prompts`;
+    await mkdir(promptDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (process.env.RUNNER_TEMP) {
+      await rm(process.env.RUNNER_TEMP, { recursive: true, force: true });
+    }
+    process.env.RUNNER_TEMP = originalRunnerTemp;
+  });
+
+  const mockAgent: ReviewAgent = {
+    id: "test-agent",
+    name: "Test Agent",
+    perspective: "You are a test reviewer. Focus on testing.",
+    maxTurns: 10,
+  };
+
+  const mockGitHubContext = `## Repository
+test-owner/test-repo
+
+## PR Context
+Title: Fix a bug`;
+
+  describe("generateAgentPrompt", () => {
+    it("should create a prompt file with agent perspective and GitHub context", async () => {
+      const promptPath = await generateAgentPrompt(
+        mockAgent,
+        mockGitHubContext,
+      );
+
+      expect(existsSync(promptPath)).toBe(true);
+      expect(promptPath).toContain("review-agent-test-agent.txt");
+
+      const content = await readFile(promptPath, "utf-8");
+      expect(content).toContain("You are a test reviewer. Focus on testing.");
+      expect(content).toContain("test-owner/test-repo");
+      expect(content).toContain("Fix a bug");
+      expect(content).toContain("structured JSON output");
+    });
+  });
+
+  describe("generateDebatePrompt", () => {
+    const ownFindings: AgentFindings = {
+      agent_id: "test-agent",
+      agent_name: "Test Agent",
+      summary: "Found some issues",
+      findings: [
+        {
+          severity: "warning",
+          title: "Missing error handling",
+          description: "No try/catch in async function",
+          file: "src/main.ts",
+          line: 42,
+        },
+      ],
+    };
+
+    const otherFindings: AgentFindings[] = [
+      {
+        agent_id: "other-agent",
+        agent_name: "Other Agent",
+        summary: "Found different issues",
+        findings: [
+          {
+            severity: "critical",
+            title: "SQL injection",
+            description: "User input not sanitized",
+            file: "src/db.ts",
+            line: 10,
+          },
+        ],
+      },
+    ];
+
+    it("should create a debate prompt with own and other findings", async () => {
+      const promptPath = await generateDebatePrompt(
+        mockAgent,
+        ownFindings,
+        otherFindings,
+      );
+
+      expect(existsSync(promptPath)).toBe(true);
+      expect(promptPath).toContain("review-debate-test-agent.txt");
+
+      const content = await readFile(promptPath, "utf-8");
+      expect(content).toContain("You are a test reviewer");
+      expect(content).toContain("Missing error handling");
+      expect(content).toContain("SQL injection");
+      expect(content).toContain("Other Agent");
+      expect(content).toContain("agree, disagree, partially agree");
+    });
+
+    it("should include file and line references from other findings", async () => {
+      const promptPath = await generateDebatePrompt(
+        mockAgent,
+        ownFindings,
+        otherFindings,
+      );
+
+      const content = await readFile(promptPath, "utf-8");
+      expect(content).toContain("src/db.ts:10");
+    });
+  });
+
+  describe("generateSynthesisPrompt", () => {
+    const allFindings: AgentFindings[] = [
+      {
+        agent_id: "critic",
+        agent_name: "Critic",
+        summary: "Several issues found",
+        findings: [
+          {
+            severity: "critical",
+            title: "Race condition",
+            description: "Concurrent access issue",
+          },
+        ],
+        overall_assessment: "Needs work",
+      },
+    ];
+
+    const allRebuttals: AgentRebuttal[] = [
+      {
+        agent_id: "quality",
+        agent_name: "Quality",
+        responses: [
+          {
+            regarding_agent_id: "critic",
+            regarding_finding_title: "Race condition",
+            stance: "agree",
+            reasoning: "Confirmed the race condition exists",
+          },
+        ],
+      },
+    ];
+
+    it("should create synthesis prompt with all findings", async () => {
+      const promptPath = await generateSynthesisPrompt(
+        "Synthesize all findings",
+        allFindings,
+        allRebuttals,
+      );
+
+      expect(existsSync(promptPath)).toBe(true);
+
+      const content = await readFile(promptPath, "utf-8");
+      expect(content).toContain("Synthesize all findings");
+      expect(content).toContain("Race condition");
+      expect(content).toContain("Confirmed the race condition exists");
+      expect(content).toContain("executive summary");
+    });
+
+    it("should handle empty rebuttals", async () => {
+      const promptPath = await generateSynthesisPrompt(
+        "Synthesize",
+        allFindings,
+        [],
+      );
+
+      const content = await readFile(promptPath, "utf-8");
+      expect(content).toContain("Race condition");
+      expect(content).not.toContain("Debate Round Results");
+    });
+  });
+
+  describe("buildAgentClaudeArgs", () => {
+    it("should append json-schema to base args", () => {
+      const result = buildAgentClaudeArgs(
+        "--permission-mode acceptEdits",
+        AGENT_FINDINGS_SCHEMA,
+      );
+
+      expect(result).toContain("--permission-mode acceptEdits");
+      expect(result).toContain("--json-schema");
+      expect(result).toContain('"agent_id"');
+    });
+
+    it("should escape single quotes in schema", () => {
+      // The schema itself shouldn't have single quotes, but the wrapping does
+      const result = buildAgentClaudeArgs("", AGENT_FINDINGS_SCHEMA);
+      expect(result).toContain("--json-schema '");
+    });
+  });
+});

--- a/test/modes/review/schemas.test.ts
+++ b/test/modes/review/schemas.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import {
+  AGENT_FINDINGS_SCHEMA,
+  AGENT_REBUTTAL_SCHEMA,
+} from "../../../src/modes/review/schemas";
+
+describe("review schemas", () => {
+  describe("AGENT_FINDINGS_SCHEMA", () => {
+    it("should be a valid JSON Schema object", () => {
+      expect(AGENT_FINDINGS_SCHEMA.type).toBe("object");
+      expect(AGENT_FINDINGS_SCHEMA.properties).toBeDefined();
+    });
+
+    it("should require agent_id, agent_name, summary, and findings", () => {
+      expect(AGENT_FINDINGS_SCHEMA.required).toEqual([
+        "agent_id",
+        "agent_name",
+        "summary",
+        "findings",
+      ]);
+    });
+
+    it("should define findings as an array with severity enum", () => {
+      const findings = AGENT_FINDINGS_SCHEMA.properties.findings;
+      expect(findings.type).toBe("array");
+
+      const item = findings.items;
+      expect(item.properties.severity.enum).toEqual([
+        "critical",
+        "warning",
+        "suggestion",
+        "nitpick",
+      ]);
+    });
+
+    it("should require severity, title, and description in findings items", () => {
+      const item = AGENT_FINDINGS_SCHEMA.properties.findings.items;
+      expect(item.required).toEqual(["severity", "title", "description"]);
+    });
+
+    it("should have optional file and line fields in findings", () => {
+      const item = AGENT_FINDINGS_SCHEMA.properties.findings.items;
+      expect(item.properties.file.type).toBe("string");
+      expect(item.properties.line.type).toBe("number");
+    });
+  });
+
+  describe("AGENT_REBUTTAL_SCHEMA", () => {
+    it("should be a valid JSON Schema object", () => {
+      expect(AGENT_REBUTTAL_SCHEMA.type).toBe("object");
+      expect(AGENT_REBUTTAL_SCHEMA.properties).toBeDefined();
+    });
+
+    it("should require agent_id, agent_name, and responses", () => {
+      expect(AGENT_REBUTTAL_SCHEMA.required).toEqual([
+        "agent_id",
+        "agent_name",
+        "responses",
+      ]);
+    });
+
+    it("should define stance enum in response items", () => {
+      const item = AGENT_REBUTTAL_SCHEMA.properties.responses.items;
+      expect(item.properties.stance.enum).toEqual([
+        "agree",
+        "disagree",
+        "partially_agree",
+        "supplement",
+      ]);
+    });
+
+    it("should have optional revised_findings array", () => {
+      expect(AGENT_REBUTTAL_SCHEMA.properties.revised_findings.type).toBe(
+        "array",
+      );
+    });
+  });
+});

--- a/test/modes/review/tracking.test.ts
+++ b/test/modes/review/tracking.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, beforeEach, mock } from "bun:test";
+import { ReviewTracker } from "../../../src/modes/review/tracking";
+import type { ReviewAgent } from "../../../src/modes/review/agents";
+import type { AgentFindings } from "../../../src/modes/review/schemas";
+
+describe("ReviewTracker", () => {
+  const agents: ReviewAgent[] = [
+    {
+      id: "critic",
+      name: "Critic Reviewer",
+      perspective: "Focus on design",
+      maxTurns: 10,
+    },
+    {
+      id: "quality",
+      name: "Quality Reviewer",
+      perspective: "Focus on quality",
+      maxTurns: 10,
+    },
+  ];
+
+  let mockOctokit: any;
+  let createCommentMock: ReturnType<typeof mock>;
+  let updateCommentMock: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    createCommentMock = mock(() => Promise.resolve({ data: { id: 12345 } }));
+    updateCommentMock = mock(() => Promise.resolve({}));
+    mockOctokit = {
+      issues: {
+        createComment: createCommentMock,
+        updateComment: updateCommentMock,
+      },
+    };
+  });
+
+  it("should create a tracking comment with all agents in pending state", async () => {
+    const tracker = new ReviewTracker(
+      mockOctokit,
+      "test-owner",
+      "test-repo",
+      agents,
+    );
+
+    const commentId = await tracker.createComment(42);
+
+    expect(commentId).toBe(12345);
+    expect(createCommentMock).toHaveBeenCalledTimes(1);
+
+    const call = createCommentMock.mock.calls[0]![0];
+    expect(call.owner).toBe("test-owner");
+    expect(call.repo).toBe("test-repo");
+    expect(call.issue_number).toBe(42);
+    expect(call.body).toContain("Critic Reviewer");
+    expect(call.body).toContain("Quality Reviewer");
+    expect(call.body).toContain("⬜");
+    expect(call.body).toContain("Multi-Agent Peer Review");
+  });
+
+  it("should update agent status to running", async () => {
+    const tracker = new ReviewTracker(
+      mockOctokit,
+      "test-owner",
+      "test-repo",
+      agents,
+    );
+    await tracker.createComment(42);
+
+    await tracker.updateAgentStatus("Critic Reviewer", "running");
+
+    expect(updateCommentMock).toHaveBeenCalledTimes(1);
+    const body = updateCommentMock.mock.calls[0]![0].body;
+    expect(body).toContain("⏳");
+    expect(body).toContain("Running");
+  });
+
+  it("should update agent status with findings count", async () => {
+    const tracker = new ReviewTracker(
+      mockOctokit,
+      "test-owner",
+      "test-repo",
+      agents,
+    );
+    await tracker.createComment(42);
+
+    const findings: AgentFindings = {
+      agent_id: "critic",
+      agent_name: "Critic Reviewer",
+      summary: "Found issues",
+      findings: [
+        {
+          severity: "critical",
+          title: "Bug",
+          description: "A bug",
+        },
+        {
+          severity: "critical",
+          title: "Bug 2",
+          description: "Another bug",
+        },
+        {
+          severity: "warning",
+          title: "Warning",
+          description: "A warning",
+        },
+      ],
+    };
+
+    await tracker.updateAgentStatus("Critic Reviewer", "complete", findings);
+
+    const body = updateCommentMock.mock.calls[0]![0].body;
+    expect(body).toContain("✅");
+    expect(body).toContain("2 critical");
+    expect(body).toContain("1 warning");
+  });
+
+  it("should update debate status", async () => {
+    const tracker = new ReviewTracker(
+      mockOctokit,
+      "test-owner",
+      "test-repo",
+      agents,
+    );
+    await tracker.createComment(42);
+
+    await tracker.updateDebateStatus("running");
+    let body = updateCommentMock.mock.calls[0]![0].body;
+    expect(body).toContain("Debate Round");
+    expect(body).toContain("⏳");
+
+    await tracker.updateDebateStatus("complete");
+    body = updateCommentMock.mock.calls[1]![0].body;
+    expect(body).toContain("✅");
+  });
+
+  it("should update synthesis status", async () => {
+    const tracker = new ReviewTracker(
+      mockOctokit,
+      "test-owner",
+      "test-repo",
+      agents,
+    );
+    await tracker.createComment(42);
+
+    await tracker.updateSynthesisStatus("complete");
+
+    const body = updateCommentMock.mock.calls[0]![0].body;
+    expect(body).toContain("Synthesis");
+    expect(body).toContain("✅");
+  });
+
+  it("should not call updateComment if comment was not created", async () => {
+    const tracker = new ReviewTracker(
+      mockOctokit,
+      "test-owner",
+      "test-repo",
+      agents,
+    );
+
+    // Don't call createComment — update should be a no-op
+    await tracker.updateAgentStatus("Critic Reviewer", "running");
+
+    expect(updateCommentMock).not.toHaveBeenCalled();
+  });
+
+  it("should show error status icon", async () => {
+    const tracker = new ReviewTracker(
+      mockOctokit,
+      "test-owner",
+      "test-repo",
+      agents,
+    );
+    await tracker.createComment(42);
+
+    await tracker.updateAgentStatus("Critic Reviewer", "error");
+
+    const body = updateCommentMock.mock.calls[0]![0].body;
+    expect(body).toContain("❌");
+    expect(body).toContain("Error");
+  });
+});

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -78,6 +78,9 @@ describe("checkWritePermissions", () => {
       includeFixLinks: true,
       includeCommentsByActor: "",
       excludeCommentsByActor: "",
+      multiAgentReview: "false",
+      reviewDebateRounds: 1,
+      reviewMaxAgents: 5,
     },
   });
 


### PR DESCRIPTION
## Context

`ai-feature-store`의 `claude_code_action.yml`은 `multi_agent_review: "auto"` + `prompt:` + `track_progress: true` 조합으로 동작하지만, 현재 fork의 `detectMode()` 게이트가 이 조합을 전부 차단한다. 결과적으로:

- PR open 시 review 모드 진입 실패 → 단일 에이전트 summary/tracking 코멘트가 사라짐
- `/claude_review` 슬래시 커맨드 재리뷰가 tag 모드로 폴백
- `auto`가 원래 제공하려던 triage(단일 ↔ 멀티 자동 분기)가 발동하지 못함

이 PR은 **fork만 수정**해서 워크플로우 설정을 그대로 유지하면서 위 세 가지를 복구한다.

## Root Cause

`src/modes/detector.ts`의 review 게이트에 3중 블로커가 걸려 있었음:

1. 외부 게이트에서 `isPullRequestEvent`를 요구 → 모든 comment 이벤트가 차단
2. `auto` 내부 분기에서 `!prompt && !trackProgress`를 요구 → 워크플로우 `prompt:` 설정과 공존 불가
3. 외부 `trackProgress` 처리가 review보다 먼저 실행되어 tag로 강제

## Changes

### 1. `src/modes/detector.ts` — review 게이트 완화
- PR open-like 이벤트(`opened / synchronize / ready_for_review / reopened`)는 `true` / `auto` 모두 항상 review 진입
- Comment 이벤트(`issue_comment`, `pull_request_review_comment`)는 trigger phrase가 포함된 경우에만 진입 (자기 호출 방지)
- `prompt` / `trackProgress`는 review opt-out 신호에서 제외. 각각 팀 가이드와 review tracker로 의미 재정의

### 2. `src/modes/review/prompts.ts` + `orchestrator.ts` — team guidance 주입
- 각 에이전트 프롬프트 생성기에 선택적 `teamGuidance?: string` 파라미터 추가
- `context.inputs.prompt`의 trimmed 값이 각 리뷰 에이전트·토론·합성·단일 에이전트 경로 모두에 `## Team Guidance` 섹션으로 주입
- 빈 값은 섹션 자체가 렌더되지 않음

### 3. `src/entrypoints/run.ts` — `restoreConfigFromBase` 확장
- `issue_comment` 이벤트는 payload에 `base.ref`가 없으므로 `octokit.rest.pulls.get`으로 조회해서 동일한 보안 복원을 수행
- `validateBranchName`을 모든 분기에 동일 적용 (shell injection 방어선 유지)

### 4. 테스트 갱신
- Review 모드 기대값을 새 동작에 맞게 재작성
- 신규 안전성 케이스 추가:
  - comment without trigger → not review (self-trigger 방지)
  - issue_comment on non-PR → not review
  - `auto + prompt + trackProgress` 결합 시나리오 (실제 ai-feature-store 조합) → review

## Event → Mode Matrix (Before / After)

| event | `multi_agent_review` | `prompt` | `track_progress` | before | after |
| --- | --- | --- | --- | --- | --- |
| `pull_request.opened` | `auto` | set | true | `tag` | `review` |
| `issue_comment` `/claude_review` on PR | `auto` | set | true | `tag` | `review` |
| `issue_comment` on PR w/o trigger | `auto` | - | - | `agent`/`tag` | unchanged (not review) |
| `issues.opened` `@claude` | `auto` | - | - | `tag` | unchanged |
| `pull_request.opened` | `false` | - | - | `agent`/`tag` | unchanged |

## Security Note

Comment 이벤트에서 review 진입을 허용함에 따라 `restoreConfigFromBase`가 issue_comment 경로도 커버하도록 확장했다. PR base의 `.claude/` + `.mcp.json`이 동일하게 복원되므로 untrusted head로부터의 설정 오염 표면은 늘지 않는다.

## Test Plan

- [x] `bun run typecheck`
- [x] `bun test` (724 pass, 0 fail)
- [x] `bun run format:check`
- [ ] Post-merge: ai-feature-store PR로 end-to-end 확인
  - [ ] 새 PR open → tracking + synthesis 코멘트 정상 생성
  - [ ] `/claude_review` 재리뷰 → 신규 코멘트 세트 생성
  - [ ] `auto` triage 로그에서 단일/멀티 선택 근거 확인
  - [ ] 워크플로우 `prompt:` 의 팀 가이드(한국어 응답/SQL 체크리스트 등)가 리뷰 본문에 반영