### PR TITLE
fix(cli): accumulate multiple --add-dir flags into array (#1215)

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -19,6 +19,7 @@ const ACCUMULATING_FLAGS = new Set([
   "disallowedTools",
   "disallowed-tools",
   "mcp-config",
+  "add-dir",
 ]);
 
 // Delimiter used to join accumulated flag values


### PR DESCRIPTION
## Summary

Fixes #1215 - When multiple `--add-dir` flags are passed via `claude_args`, only the last value was kept due to overwrite semantics. This PR adds `"add-dir"` to the `ACCUMULATING_FLAGS` set so that all values are properly accumulated using the null-char delimiter, consistent with how `--allowed-tools`, `--disallowed-tools`, and `--mcp-config` already work.

## Changes

- Added `"add-dir"` to `ACCUMULATING_FLAGS` in `base-action/src/parse-sdk-options.ts`

## Testing

- All 664 existing tests pass (0 failures, 1409 expect() calls across 35 files)
- The fix follows the exact same pattern used for other accumulating flags