### PR TITLE
fix: tolerate missing vendor/ripgrep in Install Dependencies step [pk-540]

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -194,10 +194,14 @@ runs:
       run: |
         cd ${GITHUB_ACTION_PATH}
         bun install --production
-        # bun install --production strips execute bits from vendored binaries (bun issue #1140).
-        # Restore +x on the ripgrep binaries so the Claude Agent SDK can exec them.
-        find "${GITHUB_ACTION_PATH}/node_modules/@anthropic-ai/claude-agent-sdk/vendor/ripgrep" \
-          -name "rg" -type f -exec chmod +x {} \;
+        # The Agent SDK ships a native binary with ripgrep bundled — no
+        # vendor/ to chmod. Older SDKs (≤0.2.112) shipped vendor/ripgrep and
+        # needed +x restored after bun install stripped it; tolerate either
+        # layout so a lockfile rollback doesn't break.
+        RG_DIR="${GITHUB_ACTION_PATH}/node_modules/@anthropic-ai/claude-agent-sdk/vendor/ripgrep"
+        if [ -d "$RG_DIR" ]; then
+          find "$RG_DIR" -name "rg" -type f -exec chmod +x {} \;
+        fi
 
     - name: Install subprocess isolation dependencies
       # Install subprocess isolation dependencies when processing content from non-write users.


### PR DESCRIPTION
clank-owned-by: pk-540 residual-4-rebase

## Why

Agent SDK ≥0.2.113 ships a native binary with ripgrep bundled and no longer includes `vendor/ripgrep` in the package — anthropics/claude-cli-internal#27624 cut the meta package over to native binaries and `build-agent-sdk.sh` now does `rm -rf $META_DIR/vendor`.

The Install Dependencies step's unconditional

```bash
find "${GITHUB_ACTION_PATH}/.../claude-agent-sdk/vendor/ripgrep" -name rg -type f -exec chmod +x {} \;
```

fails ENOENT and the step exits 1 — every workflow using `@main` fails before reaching Claude. cli-internal's `Label Ant-Only PRs` workflow has failed every run since 2026-04-17 21:35Z (last success 19:36Z; `c68f82cb1` bumping bun.lock → SDK 0.2.113 landed 19:40Z).

anthropics/claude-cli-internal#27624's commit message mentioned dropping the equivalent chmod from cli-internal's own `tag-and-publish-release.yml`, but this cross-repo consumer wasn't tracked.

## What

Make the find conditional on the directory existing. Works against either SDK layout (≤0.2.112 with `vendor/`, ≥0.2.113 without), so a lockfile rollback wouldn't reintroduce the chmod-stripped-execute-bit bug.

## Related

- cli-internal-side mitigation (pin `@main` → `78758edf8`, the last commit whose bun.lock resolves SDK 0.2.112): anthropics/claude-cli-internal#30226. Revert that once this lands.
- Originating change: anthropics/claude-cli-internal#27624.