### PR TITLE
chore: bump oven-sh/setup-bun to v2.2.0 (Node.js 24)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -173,7 +173,7 @@ runs:
   steps:
     - name: Install Bun
       if: inputs.path_to_bun_executable == ''
-      uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # https://github.com/oven-sh/setup-bun/releases/tag/v2.1.2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
       with:
         bun-version: 1.3.6
         token: ${{ inputs.github_token || github.token }}

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -97,7 +97,7 @@ runs:
 
     - name: Install Bun
       if: inputs.path_to_bun_executable == ''
-      uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # https://github.com/oven-sh/setup-bun/releases/tag/v2.1.2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
       with:
         bun-version: 1.3.6
 


### PR DESCRIPTION
## Summary
- Bump `oven-sh/setup-bun` pin from v2.1.2 → v2.2.0 (`0c5077e`) in both `action.yml` and `base-action/action.yml`
- v2.2.0 declares `using: "node24"`; v2.1.2 uses Node.js 20, which GitHub-hosted runners will force-migrate on **June 2, 2026**
- `bun-version: 1.3.6` is unchanged — only the installer action's Node runtime is affected

Fixes #1237

## Test plan
- [x] `bun run format:check` passes
- [x] Verified v2.2.0 SHA matches `refs/tags/v2.2.0` and current `refs/tags/v2`
- [x] Verified setup-bun@v2.2.0 `action.yml` declares `using: "node24"`
- [ ] CI green on this PR (runner annotation for Node 20 deprecation should disappear)