### PR TITLE
fix: resolve tsconfig.json via realpath to avoid bun fd mismatch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -243,7 +243,7 @@ runs:
       run: |
         bun --no-env-file \
           --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
-          --tsconfig-override="${GITHUB_ACTION_PATH}/tsconfig.json" \
+          --tsconfig-override="$(realpath "${GITHUB_ACTION_PATH}/tsconfig.json")" \
           run ${GITHUB_ACTION_PATH}/src/entrypoints/run.ts
       env:
         # Prepare inputs
@@ -380,7 +380,7 @@ runs:
         [ -x "$BUN_BIN" ] || BUN_BIN="bun"
         "$BUN_BIN" --no-env-file \
           --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
-          --tsconfig-override="${GITHUB_ACTION_PATH}/tsconfig.json" \
+          --tsconfig-override="$(realpath "${GITHUB_ACTION_PATH}/tsconfig.json")" \
           run ${GITHUB_ACTION_PATH}/src/entrypoints/cleanup-ssh-signing.ts
 
     - name: Post buffered inline comments
@@ -397,7 +397,7 @@ runs:
         [ -x "$BUN_BIN" ] || BUN_BIN="bun"
         "$BUN_BIN" --no-env-file \
           --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
-          --tsconfig-override="${GITHUB_ACTION_PATH}/tsconfig.json" \
+          --tsconfig-override="$(realpath "${GITHUB_ACTION_PATH}/tsconfig.json")" \
           run ${GITHUB_ACTION_PATH}/src/entrypoints/post-buffered-inline-comments.ts
 
     - name: Revoke app token

--- a/action.yml
+++ b/action.yml
@@ -241,10 +241,11 @@ runs:
       id: run
       shell: bash
       run: |
+        ACTION_DIR=$(realpath "${GITHUB_ACTION_PATH}")
         bun --no-env-file \
-          --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
-          --tsconfig-override="$(realpath "${GITHUB_ACTION_PATH}/tsconfig.json")" \
-          run ${GITHUB_ACTION_PATH}/src/entrypoints/run.ts
+          --config="${ACTION_DIR}/bunfig.toml" \
+          --tsconfig-override="${ACTION_DIR}/tsconfig.json" \
+          run "${ACTION_DIR}/src/entrypoints/run.ts"
       env:
         # Prepare inputs
         MODE: ${{ inputs.mode }}
@@ -376,12 +377,13 @@ runs:
       if: always() && inputs.ssh_signing_key != ''
       shell: bash
       run: |
-        BUN_BIN="${GITHUB_ACTION_PATH}/bin/bun"
+        ACTION_DIR=$(realpath "${GITHUB_ACTION_PATH}")
+        BUN_BIN="${ACTION_DIR}/bin/bun"
         [ -x "$BUN_BIN" ] || BUN_BIN="bun"
         "$BUN_BIN" --no-env-file \
-          --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
-          --tsconfig-override="$(realpath "${GITHUB_ACTION_PATH}/tsconfig.json")" \
-          run ${GITHUB_ACTION_PATH}/src/entrypoints/cleanup-ssh-signing.ts
+          --config="${ACTION_DIR}/bunfig.toml" \
+          --tsconfig-override="${ACTION_DIR}/tsconfig.json" \
+          run "${ACTION_DIR}/src/entrypoints/cleanup-ssh-signing.ts"
 
     - name: Post buffered inline comments
       if: always() && inputs.classify_inline_comments != 'false'
@@ -393,12 +395,13 @@ runs:
         PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
       run: |
-        BUN_BIN="${GITHUB_ACTION_PATH}/bin/bun"
+        ACTION_DIR=$(realpath "${GITHUB_ACTION_PATH}")
+        BUN_BIN="${ACTION_DIR}/bin/bun"
         [ -x "$BUN_BIN" ] || BUN_BIN="bun"
         "$BUN_BIN" --no-env-file \
-          --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
-          --tsconfig-override="$(realpath "${GITHUB_ACTION_PATH}/tsconfig.json")" \
-          run ${GITHUB_ACTION_PATH}/src/entrypoints/post-buffered-inline-comments.ts
+          --config="${ACTION_DIR}/bunfig.toml" \
+          --tsconfig-override="${ACTION_DIR}/tsconfig.json" \
+          run "${ACTION_DIR}/src/entrypoints/post-buffered-inline-comments.ts"
 
     - name: Revoke app token
       if: always() && inputs.github_token == '' && steps.run.outputs.github_token != '' && steps.run.outputs.skipped_due_to_workflow_validation_mismatch != 'true'


### PR DESCRIPTION
## Summary

Fixes the Bun `Internal error: directory mismatch for directory ".../tsconfig.json", fd N` reported in #1234 by resolving the tsconfig path with `realpath` before passing it to `--tsconfig-override`.

## Root cause

GitHub-hosted runners place actions at paths like `/home/runner/work/_actions/<owner>/<action>/<ref>/`, where `<ref>` (e.g. `v1`) is typically a symlink to the actual SHA-named directory. When `${GITHUB_ACTION_PATH}/tsconfig.json` is passed to bun as-is, bun opens the file via the symlinked path but stores fd metadata keyed by the canonicalized path. On subsequent lookups bun sees a path mismatch and logs the internal error.

Pre-resolving with `realpath` gives bun a canonical path up front, so the fd's stored path and the lookup path agree.

## Changes

- `action.yml`: wrap each of the 3 occurrences of `--tsconfig-override="${GITHUB_ACTION_PATH}/tsconfig.json"` with `$(realpath ...)`.

`realpath` is part of coreutils and is always available on `ubuntu-latest` runners.

## Test plan

- [ ] Trigger `@claude` on a PR with the patched action ref and confirm the bun internal error no longer appears in logs.
- [ ] Verify the action still functions correctly (tsconfig resolution still works for bun's TypeScript execution).

Closes #1234

---
Generated with: Claude Opus 4.7 (1M) | Effort: medium