### PR TITLE
fix: configure git credentials before installing plugin marketplaces

### DIFF
--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import * as core from "@actions/core";
+import { $ } from "bun";
 import { preparePrompt } from "./prepare-prompt";
 import { runClaude } from "./run-claude";
 import { setupClaudeCodeSettings } from "./setup-claude-code-settings";
@@ -9,6 +10,14 @@ import { installPlugins } from "./install-plugins";
 import { setExecutionFileOutputIfPresent } from "./execution-file";
 import { setupWorkloadIdentity } from "./workload-identity";
 import type { WorkloadIdentityHandle } from "./workload-identity";
+
+async function configureGitCredentials(token: string): Promise<void> {
+  // Configure a global git credential helper so that git clone operations
+  // (e.g. when installing plugin marketplaces from private repos) can
+  // authenticate using the provided GitHub token.
+  process.env.GH_TOKEN = token;
+  await $`git config --global credential.helper '!f() { echo "username=x-access-token"; echo "password=$GH_TOKEN"; }; f'`;
+}
 
 async function run() {
   let workloadIdentity: WorkloadIdentityHandle | undefined;
@@ -31,6 +40,13 @@ async function run() {
       process.env.INPUT_SETTINGS,
       undefined, // homeDir
     );
+
+    // Configure git credentials before installing plugins so that private
+    // marketplace repositories can be cloned successfully.
+    const githubToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+    if (githubToken) {
+      await configureGitCredentials(githubToken);
+    }
 
     // Install Claude Code plugins if specified
     await installPlugins(


### PR DESCRIPTION
When `plugin_marketplaces` references a private or internal GitHub repository, the `plugin marketplace add` subprocess spawned by `installPlugins()` fails to authenticate with git because no credential helper is configured at that point. The `configureGitAuth()` function in `src/github/operations/git-config.ts` correctly sets up credentials, but it is only called in execution paths—never in `base-action/src/index.ts`.

This adds a `configureGitCredentials()` helper in `base-action/src/index.ts` that sets a global git credential helper using the `GITHUB_TOKEN` (always available in GitHub Actions environments) before `installPlugins()` is invoked. The credential helper reads `GH_TOKEN` from the environment at authentication time, so the token is never embedded in `.git/config`. This mirrors the approach already used in the `ALLOWED_NON_WRITE_USERS` branch of `configureGitAuth()`.

**Changes:**
- `base-action/src/index.ts`: added `configureGitCredentials()` and call it with the available `GITHUB_TOKEN`/`GH_TOKEN` before `installPlugins()` runs.

Fixes #850