### PR TITLE
docs: pull_request_target guidance and base-action trust model

### DIFF
--- a/base-action/README.md
+++ b/base-action/README.md
@@ -4,6 +4,14 @@ This GitHub Action allows you to run [Claude Code](https://www.anthropic.com/cla
 
 For simply tagging @claude in issues and PRs out of the box, [check out the Claude Code action and GitHub app](https://github.com/anthropics/claude-code-action).
 
+## Trust model
+
+This action is a thin wrapper that installs and runs Claude Code with the inputs you provide. It does **not** enforce any trust boundaries on its own. Running this action in a directory is equivalent to running Claude Code in that directory — Claude reads project-level configuration (`.claude/`, `CLAUDE.md`, `.mcp.json`, etc.) from the working directory, and the action's own setup steps run from there as well.
+
+**The caller is responsible for ensuring the working directory and prompt are trusted.** If your workflow processes untrusted input (issues, fork pull requests, external comments), use [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) instead — it provides actor permission checks, restores project configuration from the base ref in PR contexts, and is the supported path for those scenarios.
+
+See [Claude Code's security documentation](https://docs.anthropic.com/en/docs/claude-code/security) and the [GitHub Actions guidance on `pull_request_target`](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) for background.
+
 ## Usage
 
 Add the following to your workflow file:

--- a/docs/security.md
+++ b/docs/security.md
@@ -28,7 +28,7 @@
 
 ```yaml
 # Preferred — check out the base ref (default).
-- uses: actions/checkout@v4 # no `ref:` → base branch
+- uses: actions/checkout@v6 # no `ref:` → base branch
 - uses: anthropics/claude-code-action@v1
 ```
 
@@ -36,8 +36,8 @@
 # If you need the PR's files locally — check out the base ref at the workspace
 # root (this action expects a git repo there), then check out the head ref into
 # a subdirectory and pass it via --add-dir.
-- uses: actions/checkout@v4 # no `ref:` → base branch at workspace root
-- uses: actions/checkout@v4
+- uses: actions/checkout@v6 # no `ref:` → base branch at workspace root
+- uses: actions/checkout@v6
   with:
     # For workflow_run use: ${{ github.event.workflow_run.head_sha }}
     ref: ${{ github.event.pull_request.head.sha }}

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,6 +20,37 @@
 - **No Cross-Repository Access**: Each action invocation is limited to the repository where it was triggered
 - **Limited Scope**: The token cannot access other repositories or perform actions beyond the configured permissions
 
+## Using this action with `pull_request_target` or `workflow_run`
+
+`pull_request_target` and `workflow_run` execute with the **base repository's secrets**. If your workflow checks out the PR head (`ref: ${{ github.event.pull_request.head.sha }}`) into `$GITHUB_WORKSPACE` before this action, the action and Claude run with that checkout as the working directory.
+
+**Do not check out an untrusted ref into the workspace root before this action.** Use one of these patterns instead:
+
+```yaml
+# Preferred — check out the base ref (default). Claude can still see the PR's
+# changes via `gh pr diff` / `gh pr view`, which the action provides.
+- uses: actions/checkout@v4 # no `ref:` → base branch
+- uses: anthropics/claude-code-action@v1
+```
+
+```yaml
+# If you need the PR's files locally — check out into a subdirectory and
+# pass it via --add-dir, so the workspace root stays clean.
+- uses: actions/checkout@v4
+  with:
+    ref: ${{ github.event.pull_request.head.sha }}
+    path: pr-head
+- uses: anthropics/claude-code-action@v1
+  with:
+    claude_args: "--add-dir pr-head"
+```
+
+This is general `pull_request_target` guidance — see [GitHub's documentation](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).
+
+### `claude-code-action` vs `claude-code-base-action`
+
+`claude-code-base-action` is a lower-level building block that installs and runs Claude Code with the inputs you provide. It does not perform actor permission checks or restore project configuration from the base ref. If you need those behaviors, use this action (`claude-code-action`). See the [base-action README](../base-action/README.md#trust-model) for details.
+
 ## Pull Request Creation
 
 In its default configuration, **Claude does not create pull requests automatically** when responding to `@claude` mentions. Instead:

--- a/docs/security.md
+++ b/docs/security.md
@@ -22,22 +22,24 @@
 
 ## Using this action with `pull_request_target` or `workflow_run`
 
-`pull_request_target` and `workflow_run` execute with the **base repository's secrets**. If your workflow checks out the PR head (`ref: ${{ github.event.pull_request.head.sha }}`) into `$GITHUB_WORKSPACE` before this action, the action and Claude run with that checkout as the working directory.
+`pull_request_target` and `workflow_run` execute with the **base repository's secrets**. If your workflow checks out the PR head (`ref: ${{ github.event.pull_request.head.sha }}` for `pull_request_target`, `ref: ${{ github.event.workflow_run.head_sha }}` for `workflow_run`) into `$GITHUB_WORKSPACE` before this action, the action and Claude run with that checkout as the working directory.
 
 **Do not check out an untrusted ref into the workspace root before this action.** Use one of these patterns instead:
 
 ```yaml
-# Preferred — check out the base ref (default). Claude can still see the PR's
-# changes via `gh pr diff` / `gh pr view`, which the action provides.
+# Preferred — check out the base ref (default).
 - uses: actions/checkout@v4 # no `ref:` → base branch
 - uses: anthropics/claude-code-action@v1
 ```
 
 ```yaml
-# If you need the PR's files locally — check out into a subdirectory and
-# pass it via --add-dir, so the workspace root stays clean.
+# If you need the PR's files locally — check out the base ref at the workspace
+# root (this action expects a git repo there), then check out the head ref into
+# a subdirectory and pass it via --add-dir.
+- uses: actions/checkout@v4 # no `ref:` → base branch at workspace root
 - uses: actions/checkout@v4
   with:
+    # For workflow_run use: ${{ github.event.workflow_run.head_sha }}
     ref: ${{ github.event.pull_request.head.sha }}
     path: pr-head
 - uses: anthropics/claude-code-action@v1
@@ -45,7 +47,7 @@
     claude_args: "--add-dir pr-head"
 ```
 
-This is general `pull_request_target` guidance — see [GitHub's documentation](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).
+This is general guidance for these event types — see [GitHub's documentation](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).
 
 ### `claude-code-action` vs `claude-code-base-action`
 


### PR DESCRIPTION
Adds:
- `docs/security.md` section on safe checkout patterns under `pull_request_target` / `workflow_run`
- `base-action/README.md` trust-model section clarifying the base-action does not enforce trust boundaries; callers should use `claude-code-action` for untrusted-input workflows
- Brief `docs/security.md` pointer to the base-action distinction

<!-- NO CHANGELOG -->