### PR TITLE
base-action: persist execution log when SDK throws (e.g. max-turns)

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -156,6 +156,7 @@ export async function runClaudeWithSdk(
 
   const messages: SDKMessage[] = [];
   let resultMessage: SDKResultMessage | undefined;
+  let sdkError: unknown;
 
   try {
     for await (const message of query({ prompt, options: sdkOptions })) {
@@ -172,18 +173,24 @@ export async function runClaudeWithSdk(
     }
   } catch (error) {
     console.error("SDK execution error:", error);
-    throw new Error(`SDK execution error: ${error}`);
+    sdkError = error;
   }
 
   const result: ClaudeRunResult = {
     conclusion: "failure",
   };
 
-  // Write execution file
+  // Persist the execution file regardless of whether the SDK threw, so
+  // failures like max-turns still leave a partial transcript on disk for
+  // downstream upload/inspection steps.
   try {
     await writeFile(EXECUTION_FILE, JSON.stringify(messages, null, 2));
     console.log(`Log saved to ${EXECUTION_FILE}`);
     result.executionFile = EXECUTION_FILE;
+    // Publish the output eagerly: index.ts re-throws on SDK errors before
+    // reaching its own setOutput calls, so steps gated on `execution_file`
+    // would otherwise never see it on the failure path.
+    core.setOutput("execution_file", EXECUTION_FILE);
   } catch (error) {
     core.warning(`Failed to write execution file: ${error}`);
   }
@@ -195,6 +202,11 @@ export async function runClaudeWithSdk(
   if (initMessage && "session_id" in initMessage && initMessage.session_id) {
     result.sessionId = initMessage.session_id as string;
     core.info(`Set session_id: ${result.sessionId}`);
+    core.setOutput("session_id", result.sessionId);
+  }
+
+  if (sdkError) {
+    throw new Error(`SDK execution error: ${sdkError}`);
   }
 
   if (!resultMessage) {


### PR DESCRIPTION
## Problem

When the Agent SDK's `query()` iterator throws — most commonly on `--max-turns` exhaustion — the partial transcript is silently lost.

[`base-action/src/run-claude-sdk.ts`](https://github.com/anthropics/claude-code-action/blob/main/base-action/src/run-claude-sdk.ts#L160-L189):

```ts
try {
  for await (const message of query({ prompt, options: sdkOptions })) {
    messages.push(message);
    // ...
  }
} catch (error) {
  console.error("SDK execution error:", error);
  throw new Error(`SDK execution error: ${error}`);  // re-throws here
}

// never reached on SDK error:
try {
  await writeFile(EXECUTION_FILE, JSON.stringify(messages, null, 2));
  result.executionFile = EXECUTION_FILE;
} catch (error) { ... }
```

The rethrow bubbles to `index.ts`, whose `catch` calls `core.setFailed` and sets only `conclusion` — `execution_file` and `session_id` outputs are never set. So:

- `$RUNNER_TEMP/claude-execution-output.json` is never written
- `steps.<id>.outputs.execution_file` is empty
- any downstream step gated on that output (e.g. an S3 upload of the transcript) silently skips
- the partial transcript is unrecoverable

## Repro

A workflow that hits `--max-turns N` fails with:

```
SDK execution error: Error: Claude Code returned an error result: Reached maximum number of turns (N)
```

Exit code 1, no `execution_file` output, no log persisted — even though 1000 turns' worth of data was in memory moments earlier.

## Fix

Capture the SDK error, write the transcript, publish the outputs, then re-throw so the step still fails. Outputs are now set from inside the SDK runner because `index.ts` re-throws before reaching its own `setOutput` calls on the failure path.

On the success path the behavior is unchanged: the outputs get set in `run-claude-sdk.ts` and again in `index.ts` with identical values (last-write-wins, no observable difference).

## Why this matters

Max-turns failures are precisely the runs where the transcript is most valuable — long, expensive runs that the user wants to inspect and recover partial work from. Losing them silently is a bad default.