### PR TITLE
fix: preserve repeated add-dir flags in claude args

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -19,6 +19,7 @@ const ACCUMULATING_FLAGS = new Set([
   "disallowedTools",
   "disallowed-tools",
   "mcp-config",
+  "add-dir",
 ]);
 
 // Delimiter used to join accumulated flag values
@@ -161,6 +162,14 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   // Detect if --json-schema is present (for hasJsonSchema flag)
   const hasJsonSchema = "json-schema" in extraArgs;
 
+  const additionalDirectories = extraArgs["add-dir"]
+    ? extraArgs["add-dir"]
+        .split(ACCUMULATE_DELIMITER)
+        .map((dir) => dir.trim())
+        .filter(Boolean)
+    : [];
+  delete extraArgs["add-dir"];
+
   // Extract and merge allowedTools from all sources:
   // 1. From extraArgs (parsed from claudeArgs - contains tag mode's tools)
   //    - Check both camelCase (--allowedTools) and hyphenated (--allowed-tools) variants
@@ -265,6 +274,8 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
     systemPrompt,
     fallbackModel: options.fallbackModel,
     pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+    additionalDirectories:
+      additionalDirectories.length > 0 ? additionalDirectories : undefined,
 
     // Pass through claudeArgs as extraArgs - CLI handles --mcp-config, --json-schema, etc.
     // Note: allowedTools and disallowedTools have been removed from extraArgs to prevent duplicates

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -298,6 +298,45 @@ describe("parseSdkOptions", () => {
     });
   });
 
+  describe("add-dir handling", () => {
+    test("should accumulate multiple add-dir flags into additionalDirectories", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: '--add-dir "/path/to/dir-a"\n--add-dir "/path/to/dir-b"',
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.additionalDirectories).toEqual([
+        "/path/to/dir-a",
+        "/path/to/dir-b",
+      ]);
+      expect(result.sdkOptions.extraArgs?.["add-dir"]).toBeUndefined();
+    });
+
+    test("should map a single add-dir flag to additionalDirectories", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: '--add-dir "/path/to/dir"',
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.additionalDirectories).toEqual(["/path/to/dir"]);
+      expect(result.sdkOptions.extraArgs?.["add-dir"]).toBeUndefined();
+    });
+
+    test("should preserve other extraArgs when extracting add-dir", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: '--model "claude-3-5-sonnet" --add-dir "/path/to/dir"',
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.additionalDirectories).toEqual(["/path/to/dir"]);
+      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-3-5-sonnet");
+      expect(result.sdkOptions.extraArgs?.["add-dir"]).toBeUndefined();
+    });
+  });
+
   describe("other extraArgs passthrough", () => {
     test("should pass through json-schema in extraArgs", () => {
       const options: ClaudeOptions = {


### PR DESCRIPTION
Fixes #1215

## Summary
- Preserve repeated `--add-dir` flags parsed from `claude_args`.
- Map parsed directory values onto the SDK's typed `additionalDirectories` option.
- Remove `add-dir` from `extraArgs` so the SDK does not receive a single overwritten or delimiter-joined value.

## Root Cause
`parseClaudeArgsToExtraArgs()` stores CLI flags in a record keyed by flag name. Since `add-dir` was not treated as an accumulating flag, repeated values overwrote earlier directories before reaching the SDK.

## Validation
- `bun test test/parse-sdk-options.test.ts -t add-dir`
- `bun test test/parse-sdk-options.test.ts`
- `bun test`
- `bun run typecheck`
- `bunx prettier --check src/parse-sdk-options.ts test/parse-sdk-options.test.ts`