### PR TITLE
fix(env): forward ANTHROPIC_DEFAULT_*_MODEL to Agent SDK sub-call

### DIFF
--- a/base-action/src/setup-claude-code-settings.ts
+++ b/base-action/src/setup-claude-code-settings.ts
@@ -2,6 +2,21 @@ import { $ } from "bun";
 import { homedir } from "os";
 import { readFile } from "fs/promises";
 
+// Env vars that resolve a model alias (sonnet/opus/haiku) to a concrete
+// model id or proxy preset. The Agent SDK's top-level call inherits these
+// from process.env, but spawned sub-call subprocesses (Task tool, sub-agents)
+// have historically dropped them and fallen back to the SDK's hardcoded
+// default — e.g. routing to literal `claude-sonnet-4-6` even when the user
+// opted into a non-Anthropic preset via ANTHROPIC_DEFAULT_SONNET_MODEL.
+// Mirroring these into settings.env guarantees the CLI propagates them to
+// every session, including sub-calls, via the documented settings layer.
+// See: https://github.com/anthropics/claude-code-action/issues/1258
+const MODEL_ALIAS_ENV_VARS = [
+  "ANTHROPIC_DEFAULT_SONNET_MODEL",
+  "ANTHROPIC_DEFAULT_OPUS_MODEL",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+] as const;
+
 export async function setupClaudeCodeSettings(
   settingsInput?: string,
   homeDir?: string,
@@ -62,6 +77,31 @@ export async function setupClaudeCodeSettings(
   // Always set enableAllProjectMcpServers to true
   settings.enableAllProjectMcpServers = true;
   console.log(`Updated settings with enableAllProjectMcpServers: true`);
+
+  // Forward model-alias env vars into settings.env so the CLI propagates them
+  // to every session (top-level + sub-calls). User-provided settings.env
+  // entries take precedence; we only fill in keys the user didn't already set.
+  const userEnv =
+    typeof settings.env === "object" && settings.env !== null
+      ? (settings.env as Record<string, string>)
+      : undefined;
+  const mergedEnv: Record<string, string> = { ...(userEnv ?? {}) };
+  const injectedKeys: string[] = [];
+  for (const key of MODEL_ALIAS_ENV_VARS) {
+    const value = process.env[key];
+    if (value && !(key in mergedEnv)) {
+      mergedEnv[key] = value;
+      injectedKeys.push(key);
+    }
+  }
+  if (injectedKeys.length > 0 || userEnv) {
+    settings.env = mergedEnv;
+    if (injectedKeys.length > 0) {
+      console.log(
+        `Forwarded model-alias env vars to settings.env: ${injectedKeys.join(", ")}`,
+      );
+    }
+  }
 
   await $`echo ${JSON.stringify(settings, null, 2)} > ${settingsPath}`.quiet();
   console.log(`Settings saved successfully`);

--- a/base-action/test/setup-claude-code-settings.test.ts
+++ b/base-action/test/setup-claude-code-settings.test.ts
@@ -147,4 +147,107 @@ describe("setupClaudeCodeSettings", () => {
     expect(settings.newKey).toBe("newValue");
     expect(settings.model).toBe("claude-opus-4-1-20250805");
   });
+
+  describe("model-alias env var forwarding (issue #1258)", () => {
+    const MODEL_ENV_VARS = [
+      "ANTHROPIC_DEFAULT_SONNET_MODEL",
+      "ANTHROPIC_DEFAULT_OPUS_MODEL",
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    ] as const;
+
+    let originalEnv: Record<string, string | undefined>;
+
+    beforeEach(() => {
+      originalEnv = {};
+      for (const key of MODEL_ENV_VARS) {
+        originalEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+    });
+
+    afterEach(() => {
+      for (const key of MODEL_ENV_VARS) {
+        if (originalEnv[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = originalEnv[key];
+        }
+      }
+    });
+
+    test("should mirror ANTHROPIC_DEFAULT_*_MODEL env vars into settings.env", async () => {
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL =
+        "@preset/minimax-minimax-m2-7-no-thinking";
+      process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = "@preset/some-opus-preset";
+      process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = "@preset/some-haiku-preset";
+
+      await setupClaudeCodeSettings(undefined, testHomeDir);
+
+      const settingsContent = await readFile(settingsPath, "utf-8");
+      const settings = JSON.parse(settingsContent);
+
+      expect(settings.env).toEqual({
+        ANTHROPIC_DEFAULT_SONNET_MODEL:
+          "@preset/minimax-minimax-m2-7-no-thinking",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "@preset/some-opus-preset",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "@preset/some-haiku-preset",
+      });
+    });
+
+    test("should forward only the env vars that are set", async () => {
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = "sonnet-preset";
+
+      await setupClaudeCodeSettings(undefined, testHomeDir);
+
+      const settingsContent = await readFile(settingsPath, "utf-8");
+      const settings = JSON.parse(settingsContent);
+
+      expect(settings.env).toEqual({
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "sonnet-preset",
+      });
+    });
+
+    test("should not create settings.env when no model-alias env vars are set", async () => {
+      await setupClaudeCodeSettings(undefined, testHomeDir);
+
+      const settingsContent = await readFile(settingsPath, "utf-8");
+      const settings = JSON.parse(settingsContent);
+
+      expect(settings.env).toBeUndefined();
+    });
+
+    test("should preserve user-provided settings.env keys (user wins on conflict)", async () => {
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = "sonnet-from-env";
+      process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = "opus-from-env";
+
+      const userSettings = JSON.stringify({
+        env: {
+          ANTHROPIC_DEFAULT_SONNET_MODEL: "sonnet-from-user-settings",
+          CUSTOM_VAR: "custom-value",
+        },
+      });
+
+      await setupClaudeCodeSettings(userSettings, testHomeDir);
+
+      const settingsContent = await readFile(settingsPath, "utf-8");
+      const settings = JSON.parse(settingsContent);
+
+      expect(settings.env).toEqual({
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "sonnet-from-user-settings",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "opus-from-env",
+        CUSTOM_VAR: "custom-value",
+      });
+    });
+
+    test("should ignore empty env var values", async () => {
+      process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = "";
+
+      await setupClaudeCodeSettings(undefined, testHomeDir);
+
+      const settingsContent = await readFile(settingsPath, "utf-8");
+      const settings = JSON.parse(settingsContent);
+
+      expect(settings.env).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Why

Closes #1258.

The Agent SDK's top-level call inherits `ANTHROPIC_DEFAULT_SONNET_MODEL` (and `OPUS`/`HAIKU`) from `process.env`, but spawned sub-call subprocesses (Task tool, sub-agents) drop them and fall back to the SDK's hardcoded default. With a non-Anthropic preset configured via `ANTHROPIC_DEFAULT_SONNET_MODEL`, sub-calls leak literal `claude-sonnet-4-6` to the proxy and silently bill the user for Sonnet calls they did not request - see the issue's smoking-gun OpenRouter generation log.

The action.yml already forwards these env vars to the bun process, and `parse-sdk-options.ts` already spreads `process.env` into `sdkOptions.env`. The top-level call honours the override, so that path works. Sub-calls go through a fresh CLI subprocess that reads `~/.claude/settings.json` for env, not the parent's process env, so the override is dropped.

## What

Mirror the three model-alias env vars into `settings.env` from `setupClaudeCodeSettings`. The CLI propagates `settings.env` to every session it spawns, including sub-calls, via the documented settings layer (`Settings.env` in the Agent SDK types).

- User-provided `settings.env` entries always win on conflict; the action only fills in keys the user did not set.
- Empty/unset env vars are skipped - no `settings.env` is written when none of the three are present.
- All three (`ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL`) are handled in the same loop.

## Tested

Added five unit tests under `base-action/test/setup-claude-code-settings.test.ts` in a new `model-alias env var forwarding (issue #1258)` describe block:

- All three env vars mirrored into `settings.env`.
- Only the env vars that are set get forwarded.
- No `settings.env` is created when none are set.
- User-provided `settings.env` keys take precedence over env-var values.
- Empty env var values are skipped.

`beforeEach`/`afterEach` snapshot and restore the three env vars so the suite is hermetic.

- [ ] `bun test base-action/test/setup-claude-code-settings.test.ts`
- [ ] Manual: set `ANTHROPIC_DEFAULT_SONNET_MODEL=@preset/...` in workflow env, run the action, observe sub-call requests now hit the preset rather than literal `claude-sonnet-4-6` (per the reproduction in #1258).
