### PR TITLE
fix: restoreConfigFromBase covers nested CLAUDE.md (#1270)

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -1,13 +1,17 @@
 import { execFileSync } from "child_process";
 import {
   appendFileSync,
-  cpSync,
+  copyFileSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
-  rmSync,
+  readdirSync,
+  realpathSync,
+  rmdirSync,
+  unlinkSync,
 } from "fs";
-import { dirname } from "path";
+import { dirname, join, posix } from "path";
 
 // Paths that are both PR-controllable and read from cwd at CLI startup.
 //
@@ -30,19 +34,523 @@ const SENSITIVE_PATHS = [
 
 const CLAUDE_PR_EXCLUDE_PATTERN = "/.claude-pr/";
 
-function snapshotSensitivePath(src: string, dest: string): void {
+const GITLINK_MODE = "160000";
+const SYMLINK_MODE = "120000";
+const PR_SNAPSHOT_SUFFIX = ".pr-snapshot";
+
+interface GitIndexEntry {
+  mode: string;
+  path: string;
+}
+
+interface GitTreeEntry {
+  mode: string;
+  type: string;
+  objectId: string;
+  path: string;
+}
+
+function lstatIfPresent(path: string) {
   try {
-    cpSync(src, dest, { recursive: true, dereference: true });
+    return lstatSync(path);
   } catch (error) {
-    // Symlinks whose targets are absent on the PR head (e.g. `.claude/CLAUDE.md`
-    // -> `../AGENTS.md` when the PR deleted the target) make dereferenced
-    // copies throw ENOENT. Preserve the symlink for the review snapshot instead.
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      cpSync(src, dest, { recursive: true });
-      return;
+    if (
+      error !== null &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return undefined;
     }
     throw error;
   }
+}
+
+function isInstructionBasename(name: string): boolean {
+  return name === "CLAUDE.md" || name === "CLAUDE.local.md";
+}
+
+function isClaudePrPath(path: string): boolean {
+  return path === ".claude-pr" || path.startsWith(".claude-pr/");
+}
+
+function assertSafeGitPath(path: string): void {
+  const components = path.split("/");
+  if (
+    path.length === 0 ||
+    path.includes("\0") ||
+    posix.isAbsolute(path) ||
+    components.some(
+      (component) =>
+        component.length === 0 || component === "." || component === "..",
+    )
+  ) {
+    throw new Error(`Refusing unsafe repository path: ${JSON.stringify(path)}`);
+  }
+}
+
+function worktreePath(repoRoot: string, path: string): string {
+  assertSafeGitPath(path);
+  return join(repoRoot, ...path.split("/"));
+}
+
+function gitOutput(args: string[], cwd?: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function parseTreeEntries(output: string): GitTreeEntry[] {
+  return output
+    .split("\0")
+    .filter((record) => record.length > 0)
+    .map((record) => {
+      const separator = record.indexOf("\t");
+      if (separator === -1) {
+        throw new Error("Git returned an invalid ls-tree record");
+      }
+
+      const [mode, type, objectId] = record.slice(0, separator).split(" ");
+      const path = record.slice(separator + 1);
+      if (!mode || !type || !objectId || !path) {
+        throw new Error("Git returned an incomplete ls-tree record");
+      }
+      assertSafeGitPath(path);
+      return { mode, type, objectId, path };
+    });
+}
+
+function listBaseTreeEntries(
+  repoRoot: string,
+  baseRef: string,
+): GitTreeEntry[] {
+  return parseTreeEntries(
+    gitOutput(
+      ["--literal-pathspecs", "ls-tree", "-r", "-z", "--full-tree", baseRef],
+      repoRoot,
+    ),
+  );
+}
+
+function getBaseTreeEntry(
+  repoRoot: string,
+  baseRef: string,
+  path: string,
+  cache: Map<string, GitTreeEntry | null>,
+): GitTreeEntry | null {
+  assertSafeGitPath(path);
+  const cached = cache.get(path);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const entries = parseTreeEntries(
+    gitOutput(
+      ["--literal-pathspecs", "ls-tree", "-z", baseRef, "--", path],
+      repoRoot,
+    ),
+  );
+  if (entries.length === 0) {
+    cache.set(path, null);
+    return null;
+  }
+  const [entry] = entries;
+  if (entries.length !== 1 || entry === undefined || entry.path !== path) {
+    throw new Error(
+      `Git returned an ambiguous base-tree result for ${JSON.stringify(path)}`,
+    );
+  }
+
+  cache.set(path, entry);
+  return entry;
+}
+
+function listHeadIndexEntries(repoRoot: string): GitIndexEntry[] {
+  return gitOutput(
+    ["--literal-pathspecs", "ls-files", "--stage", "-z"],
+    repoRoot,
+  )
+    .split("\0")
+    .filter((record) => record.length > 0)
+    .map((record) => {
+      const separator = record.indexOf("\t");
+      if (separator === -1) {
+        throw new Error("Git returned an invalid index record");
+      }
+
+      const [mode] = record.slice(0, separator).split(" ");
+      const path = record.slice(separator + 1);
+      if (!mode || !path) {
+        throw new Error("Git returned an incomplete index record");
+      }
+      assertSafeGitPath(path);
+      return { mode, path };
+    });
+}
+
+function scanGitlinkDirectory(
+  absolutePath: string,
+  gitlinkPath: string,
+  relativePath = "",
+): void {
+  for (const name of readdirSync(absolutePath)) {
+    const childRelativePath =
+      relativePath.length === 0 ? name : posix.join(relativePath, name);
+    if (isInstructionBasename(name)) {
+      throw new Error(
+        `Refusing to continue: populated gitlink ${JSON.stringify(
+          gitlinkPath,
+        )} contains instruction file ${JSON.stringify(childRelativePath)}`,
+      );
+    }
+
+    const childPath = join(absolutePath, name);
+    const stat = lstatSync(childPath);
+    if (stat.isDirectory() && !stat.isSymbolicLink()) {
+      scanGitlinkDirectory(childPath, gitlinkPath, childRelativePath);
+    }
+  }
+}
+
+function assertPopulatedGitlinksContainNoInstructions(
+  repoRoot: string,
+  headGitlinks: ReadonlySet<string>,
+): void {
+  for (const gitlinkPath of headGitlinks) {
+    let absolutePath = repoRoot;
+    const components = gitlinkPath.split("/");
+    let populated = true;
+
+    for (let index = 0; index < components.length; index += 1) {
+      const component = components[index];
+      if (component === undefined) {
+        throw new Error(`Invalid gitlink path ${JSON.stringify(gitlinkPath)}`);
+      }
+      absolutePath = join(absolutePath, component);
+      const stat = lstatIfPresent(absolutePath);
+      if (stat === undefined) {
+        populated = false;
+        break;
+      }
+
+      const isFinal = index === components.length - 1;
+      if (!isFinal && (stat.isSymbolicLink() || !stat.isDirectory())) {
+        throw new Error(
+          `Refusing to inspect populated gitlink ${JSON.stringify(
+            gitlinkPath,
+          )}: an ancestor is not a real directory`,
+        );
+      }
+      if (isFinal && (stat.isSymbolicLink() || !stat.isDirectory())) {
+        throw new Error(
+          `Refusing to inspect populated gitlink ${JSON.stringify(
+            gitlinkPath,
+          )}: its worktree is not a real directory`,
+        );
+      }
+    }
+
+    if (!populated) {
+      continue;
+    }
+    if (isInstructionBasename(posix.basename(gitlinkPath))) {
+      throw new Error(
+        `Refusing to continue: populated gitlink ${JSON.stringify(
+          gitlinkPath,
+        )} has an instruction basename`,
+      );
+    }
+    scanGitlinkDirectory(absolutePath, gitlinkPath);
+  }
+}
+
+function readBaseSymlinkTarget(repoRoot: string, objectId: string): string {
+  return execFileSync("git", ["cat-file", "blob", objectId], {
+    cwd: repoRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).toString("utf8");
+}
+
+function resolveBaseSymlinkTarget(linkPath: string, target: string): string {
+  if (
+    target.length === 0 ||
+    target.includes("\0") ||
+    posix.isAbsolute(target)
+  ) {
+    throw new Error(
+      `Trusted base instruction link ${JSON.stringify(
+        linkPath,
+      )} has an unsafe target ${JSON.stringify(target)}`,
+    );
+  }
+
+  const targetPath = posix.normalize(
+    posix.join(posix.dirname(linkPath), target),
+  );
+  try {
+    assertSafeGitPath(targetPath);
+  } catch {
+    throw new Error(
+      `Trusted base instruction link ${JSON.stringify(
+        linkPath,
+      )} escapes the repository`,
+    );
+  }
+  if (isClaudePrPath(targetPath)) {
+    throw new Error(
+      `Trusted base instruction link ${JSON.stringify(
+        linkPath,
+      )} targets reserved snapshot path ${JSON.stringify(targetPath)}`,
+    );
+  }
+  return targetPath;
+}
+
+function buildTrustedInstructionTargetClosure(
+  repoRoot: string,
+  baseRef: string,
+  instructionPaths: ReadonlySet<string>,
+  baseEntryCache: Map<string, GitTreeEntry | null>,
+): Set<string> {
+  const closure = new Set<string>();
+  const resolved = new Set<string>();
+  const visiting = new Set<string>();
+
+  const visit = (path: string): void => {
+    if (resolved.has(path)) {
+      return;
+    }
+    if (visiting.has(path)) {
+      throw new Error(
+        `Trusted base instruction symlink cycle includes ${JSON.stringify(
+          path,
+        )}`,
+      );
+    }
+
+    const entry = getBaseTreeEntry(repoRoot, baseRef, path, baseEntryCache);
+    if (entry === null) {
+      throw new Error(
+        `Trusted base instruction target ${JSON.stringify(path)} is not tracked`,
+      );
+    }
+    if (entry.type !== "blob") {
+      throw new Error(
+        `Trusted base instruction target ${JSON.stringify(path)} is not a blob`,
+      );
+    }
+    if (entry.mode !== SYMLINK_MODE) {
+      resolved.add(path);
+      return;
+    }
+
+    visiting.add(path);
+    const target = readBaseSymlinkTarget(repoRoot, entry.objectId);
+    const targetPath = resolveBaseSymlinkTarget(path, target);
+    const targetEntry = getBaseTreeEntry(
+      repoRoot,
+      baseRef,
+      targetPath,
+      baseEntryCache,
+    );
+    if (targetEntry === null) {
+      throw new Error(
+        `Trusted base instruction link ${JSON.stringify(
+          path,
+        )} targets untracked path ${JSON.stringify(targetPath)}`,
+      );
+    }
+    if (targetEntry.type !== "blob") {
+      throw new Error(
+        `Trusted base instruction link ${JSON.stringify(
+          path,
+        )} targets non-blob path ${JSON.stringify(targetPath)}`,
+      );
+    }
+
+    closure.add(targetPath);
+    visit(targetPath);
+    visiting.delete(path);
+    resolved.add(path);
+  };
+
+  for (const path of instructionPaths) {
+    visit(path);
+  }
+  return closure;
+}
+
+function canReadWorktreePathWithoutFollowing(
+  repoRoot: string,
+  path: string,
+  headGitlinks: ReadonlySet<string>,
+): boolean {
+  assertSafeGitPath(path);
+  let absolutePath = repoRoot;
+  let prefix = "";
+  const components = path.split("/");
+
+  for (let index = 0; index < components.length; index += 1) {
+    const component = components[index];
+    if (component === undefined) {
+      throw new Error(`Invalid worktree path ${JSON.stringify(path)}`);
+    }
+    prefix = prefix.length === 0 ? component : posix.join(prefix, component);
+    absolutePath = join(absolutePath, component);
+    const stat = lstatIfPresent(absolutePath);
+    if (stat === undefined || headGitlinks.has(prefix)) {
+      return false;
+    }
+
+    const isFinal = index === components.length - 1;
+    if (!isFinal && (stat.isSymbolicLink() || !stat.isDirectory())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function snapshotEntryWithoutFollowing(
+  repoRoot: string,
+  sourcePath: string,
+  destinationParent: string,
+  headGitlinks: ReadonlySet<string>,
+): boolean {
+  if (headGitlinks.has(sourcePath)) {
+    return false;
+  }
+
+  const sourceAbsolutePath = worktreePath(repoRoot, sourcePath);
+  const stat = lstatIfPresent(sourceAbsolutePath);
+  if (stat === undefined || stat.isSymbolicLink()) {
+    return false;
+  }
+
+  const sourceBasename = posix.basename(sourcePath);
+  const destinationBasename = isInstructionBasename(sourceBasename)
+    ? `${sourceBasename}${PR_SNAPSHOT_SUFFIX}`
+    : sourceBasename;
+  const destinationPath = posix.join(destinationParent, destinationBasename);
+  const destinationAbsolutePath = worktreePath(repoRoot, destinationPath);
+
+  if (stat.isDirectory()) {
+    mkdirSync(destinationAbsolutePath, { recursive: true });
+    for (const name of readdirSync(sourceAbsolutePath)) {
+      snapshotEntryWithoutFollowing(
+        repoRoot,
+        posix.join(sourcePath, name),
+        destinationPath,
+        headGitlinks,
+      );
+    }
+    return true;
+  }
+  if (!stat.isFile()) {
+    return false;
+  }
+
+  mkdirSync(dirname(destinationAbsolutePath), { recursive: true });
+  copyFileSync(sourceAbsolutePath, destinationAbsolutePath);
+  return true;
+}
+
+function snapshotSensitivePath(
+  repoRoot: string,
+  sourcePath: string,
+  headGitlinks: ReadonlySet<string>,
+): boolean {
+  if (
+    !canReadWorktreePathWithoutFollowing(repoRoot, sourcePath, headGitlinks)
+  ) {
+    return false;
+  }
+
+  const sourceParent = posix.dirname(sourcePath);
+  const destinationParent =
+    sourceParent === "."
+      ? ".claude-pr"
+      : posix.join(".claude-pr", sourceParent);
+  return snapshotEntryWithoutFollowing(
+    repoRoot,
+    sourcePath,
+    destinationParent,
+    headGitlinks,
+  );
+}
+
+function removeEntryWithoutFollowing(absolutePath: string): void {
+  const stat = lstatIfPresent(absolutePath);
+  if (stat === undefined) {
+    return;
+  }
+
+  if (stat.isDirectory() && !stat.isSymbolicLink()) {
+    for (const name of readdirSync(absolutePath)) {
+      removeEntryWithoutFollowing(join(absolutePath, name));
+    }
+    rmdirSync(absolutePath);
+    return;
+  }
+  unlinkSync(absolutePath);
+}
+
+function prepareWorktreePathForRemoval(
+  repoRoot: string,
+  path: string,
+  headGitlinks: ReadonlySet<string>,
+): string | undefined {
+  assertSafeGitPath(path);
+  let absolutePath = repoRoot;
+  let prefix = "";
+  const components = path.split("/");
+
+  for (let index = 0; index < components.length; index += 1) {
+    const component = components[index];
+    if (component === undefined) {
+      throw new Error(`Invalid worktree path ${JSON.stringify(path)}`);
+    }
+    prefix = prefix.length === 0 ? component : posix.join(prefix, component);
+    absolutePath = join(absolutePath, component);
+    const stat = lstatIfPresent(absolutePath);
+    if (stat === undefined) {
+      return undefined;
+    }
+
+    const isFinal = index === components.length - 1;
+    if (
+      !isFinal &&
+      (headGitlinks.has(prefix) || stat.isSymbolicLink() || !stat.isDirectory())
+    ) {
+      removeEntryWithoutFollowing(absolutePath);
+      return prefix;
+    }
+    if (isFinal) {
+      removeEntryWithoutFollowing(absolutePath);
+      return path;
+    }
+  }
+  return undefined;
+}
+
+function indexContainsPath(
+  entries: readonly GitIndexEntry[],
+  path: string,
+): boolean {
+  return entries.some(
+    (entry) => entry.path === path || entry.path.startsWith(`${path}/`),
+  );
+}
+
+function sortGitPaths(paths: Iterable<string>): string[] {
+  return [...new Set(paths)].sort((left, right) => {
+    const depthDifference = left.split("/").length - right.split("/").length;
+    if (depthDifference !== 0) {
+      return depthDifference;
+    }
+    return left < right ? -1 : left > right ? 1 : 0;
+  });
 }
 
 function ensureClaudePrExcludedFromGit(): void {
@@ -94,64 +602,159 @@ export function restoreConfigFromBase(baseBranch: string): void {
     `Restoring ${SENSITIVE_PATHS.join(", ")} from origin/${baseBranch} (PR head is untrusted)`,
   );
 
-  // Snapshot every PR-authored sensitive path into .claude-pr/ before deletion
-  // so review agents can inspect what the PR changes without those files ever
-  // being executed. Captured before the security delete so it reflects the
-  // PR-authored version.
-  rmSync(".claude-pr", { recursive: true, force: true });
-  for (const p of SENSITIVE_PATHS) {
-    if (existsSync(p)) {
-      snapshotSensitivePath(p, `.claude-pr/${p}`);
+  const repoRoot = realpathSync(
+    gitOutput(["rev-parse", "--show-toplevel"]).trim(),
+  );
+  const headIndexEntries = listHeadIndexEntries(repoRoot);
+  const headGitlinks = new Set(
+    headIndexEntries
+      .filter((entry) => entry.mode === GITLINK_MODE)
+      .map((entry) => entry.path),
+  );
+
+  // A superproject tree cannot describe files below a gitlink. Inspect only
+  // populated gitlink worktrees, with lstat-based traversal and no nested Git
+  // invocation, before changing anything Claude could read.
+  assertPopulatedGitlinksContainNoInstructions(repoRoot, headGitlinks);
+
+  // Fetch without consulting or populating submodules. The trusted base object
+  // graph must be complete and validated before the first worktree mutation.
+  execFileSync(
+    "git",
+    ["fetch", "origin", baseBranch, "--depth=1", "--no-recurse-submodules"],
+    {
+      cwd: repoRoot,
+      stdio: "inherit",
+      env: process.env,
+    },
+  );
+
+  const baseRef = `origin/${baseBranch}`;
+  const restoreNestedInstructions =
+    process.env.DISABLE_NESTED_CLAUDE_MD_RESTORE !== "true";
+
+  const headInstructionPaths = new Set(
+    headIndexEntries
+      .map((entry) => entry.path)
+      .filter(
+        (path) =>
+          !isClaudePrPath(path) &&
+          isInstructionBasename(posix.basename(path)) &&
+          (restoreNestedInstructions || !path.includes("/")),
+      ),
+  );
+  const baseInstructionPaths = new Set(
+    listBaseTreeEntries(repoRoot, baseRef)
+      .map((entry) => entry.path)
+      .filter(
+        (path) =>
+          !isClaudePrPath(path) &&
+          isInstructionBasename(posix.basename(path)) &&
+          (restoreNestedInstructions || !path.includes("/")),
+      ),
+  );
+
+  const affectedPaths = new Set<string>(SENSITIVE_PATHS);
+  for (const path of headInstructionPaths) {
+    affectedPaths.add(path);
+  }
+  for (const path of baseInstructionPaths) {
+    affectedPaths.add(path);
+  }
+
+  const baseEntryCache = new Map<string, GitTreeEntry | null>();
+  for (const path of affectedPaths) {
+    getBaseTreeEntry(repoRoot, baseRef, path, baseEntryCache);
+  }
+
+  const trustedTargetClosure = buildTrustedInstructionTargetClosure(
+    repoRoot,
+    baseRef,
+    baseInstructionPaths,
+    baseEntryCache,
+  );
+  for (const path of trustedTargetClosure) {
+    affectedPaths.add(path);
+  }
+
+  // Every lookup, including recursively derived symlink targets, is complete
+  // before these arrays authorize any worktree deletion or checkout.
+  const basePresentPaths: string[] = [];
+  const baseAbsentPaths: string[] = [];
+  for (const path of sortGitPaths(affectedPaths)) {
+    const entry = getBaseTreeEntry(repoRoot, baseRef, path, baseEntryCache);
+    if (entry === null) {
+      baseAbsentPaths.push(path);
+    } else {
+      basePresentPaths.push(path);
     }
   }
-  if (existsSync(".claude-pr")) {
+
+  // Preserve regular PR-authored files for review. Instruction basenames are
+  // suffixed at every depth, and symlinks are omitted rather than dereferenced.
+  prepareWorktreePathForRemoval(repoRoot, ".claude-pr", headGitlinks);
+  let preservedSnapshot = false;
+  const snapshotPaths = sortGitPaths([
+    ...SENSITIVE_PATHS,
+    ...headInstructionPaths,
+  ]);
+  for (const path of snapshotPaths) {
+    if (snapshotSensitivePath(repoRoot, path, headGitlinks)) {
+      preservedSnapshot = true;
+    }
+  }
+  if (preservedSnapshot) {
     console.log(
       "Preserved PR's sensitive paths -> .claude-pr/ for review agents (not executed)",
     );
     ensureClaudePrExcludedFromGit();
   }
 
-  // Delete PR-controlled versions BEFORE fetching so the attacker-controlled
-  // .gitmodules is absent during the network operation. If git reads .gitmodules
-  // during fetch (fetch.recurseSubmodules=on-demand, the git default), it will
-  // attempt to fetch submodule objects and block on credential prompts in CI —
-  // causing an indefinite hang. Deleting first closes that window.
-  //
-  // If the restore below fails for a given path, that path stays deleted —
-  // the safe fallback (no attacker-controlled config). A bare `git checkout`
-  // alone wouldn't remove files the PR added, so nuke first.
-  for (const p of SENSITIVE_PATHS) {
-    rmSync(p, { recursive: true, force: true });
-  }
-
-  // --no-recurse-submodules: explicitly suppress submodule fetching regardless of
-  // fetch.recurseSubmodules config. Defense-in-depth alongside the delete above.
-  execFileSync(
-    "git",
-    ["fetch", "origin", baseBranch, "--depth=1", "--no-recurse-submodules"],
-    {
-      stdio: "inherit",
-      env: process.env,
-    },
-  );
-
-  for (const p of SENSITIVE_PATHS) {
-    try {
-      execFileSync("git", ["checkout", `origin/${baseBranch}`, "--", p], {
-        stdio: "pipe",
-      });
-    } catch {
-      // Path doesn't exist on base — it stays deleted.
+  const resetPaths = new Set<string>();
+  for (const path of [...baseAbsentPaths, ...basePresentPaths]) {
+    const removedPath = prepareWorktreePathForRemoval(
+      repoRoot,
+      path,
+      headGitlinks,
+    );
+    if (
+      removedPath !== undefined &&
+      indexContainsPath(headIndexEntries, removedPath)
+    ) {
+      resetPaths.add(removedPath);
+    }
+    if (indexContainsPath(headIndexEntries, path)) {
+      resetPaths.add(path);
     }
   }
 
-  // `git checkout <ref> -- <path>` stages the restored files. Unstage so the
-  // revert doesn't silently leak into commits the CLI makes later.
-  try {
-    execFileSync("git", ["reset", "--", ...SENSITIVE_PATHS], {
-      stdio: "pipe",
-    });
-  } catch {
-    // Nothing was staged, or paths don't exist on HEAD — either is fine.
+  // Only paths with an exact, prevalidated base-tree entry reach checkout.
+  // Any checkout failure is fatal rather than being mistaken for base absence.
+  if (basePresentPaths.length > 0) {
+    execFileSync(
+      "git",
+      ["--literal-pathspecs", "checkout", baseRef, "--", ...basePresentPaths],
+      {
+        cwd: repoRoot,
+        stdio: "pipe",
+      },
+    );
+    for (const path of basePresentPaths) {
+      resetPaths.add(path);
+    }
+  }
+
+  // Checkout stages restores. Reset every restored or deleted path literally,
+  // including any tracked obstruction removed above, without touching unrelated
+  // worktree or index state.
+  if (resetPaths.size > 0) {
+    execFileSync(
+      "git",
+      ["--literal-pathspecs", "reset", "--", ...sortGitPaths(resetPaths)],
+      {
+        cwd: repoRoot,
+        stdio: "pipe",
+      },
+    );
   }
 }

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "child_process";
 import {
-  existsSync,
   lstatSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
+  readlinkSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -17,12 +18,16 @@ const CLAUDE_PR_EXCLUDE_PATTERN = "/.claude-pr/";
 
 describe("restoreConfigFromBase", () => {
   let originalCwd: string;
+  let originalDisableNestedRestore: string | undefined;
   let tempDir = "";
   let repoDir: string;
   let remoteDir: string;
 
   beforeEach(() => {
     originalCwd = process.cwd();
+    originalDisableNestedRestore = process.env.DISABLE_NESTED_CLAUDE_MD_RESTORE;
+    delete process.env.DISABLE_NESTED_CLAUDE_MD_RESTORE;
+
     tempDir = mkdtempSync(join("/tmp", "restore-config-"));
     repoDir = join(tempDir, "repo");
     remoteDir = join(tempDir, "origin.git");
@@ -34,24 +39,51 @@ describe("restoreConfigFromBase", () => {
     git(["config", "user.name", "Test User"]);
 
     writeRepoFile("CLAUDE.md", "base claude instructions\n");
+    writeRepoFile("CLAUDE.local.md", "base local claude instructions\n");
     writeRepoFile(
       ".claude/settings.json",
       `${JSON.stringify({ source: "base" })}\n`,
     );
+    writeRepoFile(".mcp.json", `${JSON.stringify({ servers: {} })}\n`);
     writeRepoFile("src/index.ts", "export const base = true;\n");
+    writeRepoFile("packages/foo/CLAUDE.md", "base nested foo instructions\n");
+    writeRepoFile("deeper/nested/dir/CLAUDE.md", "base deep instructions\n");
+    writeRepoFile(
+      "kept-on-base/only/CLAUDE.md",
+      "base-only nested instructions\n",
+    );
+    writeRepoFile(
+      "kept-on-base/only/CLAUDE.local.md",
+      "base-only nested local instructions\n",
+    );
 
-    git(["add", "CLAUDE.md", ".claude/settings.json", "src/index.ts"]);
+    git(["add", "."]);
     git(["commit", "-m", "base config"]);
     git(["remote", "add", "origin", remoteDir]);
     git(["push", "-u", "origin", "main"]);
 
     git(["checkout", "-b", "pr"]);
     writeRepoFile("CLAUDE.md", "pr claude instructions\n");
+    writeRepoFile("CLAUDE.local.md", "pr local claude instructions\n");
     writeRepoFile(
       ".claude/settings.json",
       `${JSON.stringify({ source: "pr" })}\n`,
     );
-    git(["add", "CLAUDE.md", ".claude/settings.json"]);
+    writeRepoFile(
+      ".mcp.json",
+      `${JSON.stringify({ servers: { attacker: true } })}\n`,
+    );
+    writeRepoFile("packages/foo/CLAUDE.md", "pr nested foo instructions\n");
+    writeRepoFile("deeper/nested/dir/CLAUDE.md", "pr deep instructions\n");
+    writeRepoFile("pr-only/CLAUDE.md", "pr-only instructions\n");
+    writeRepoFile(
+      "pr-only/sub/CLAUDE.local.md",
+      "pr-only local instructions\n",
+    );
+    writeRepoFile("docs/CLAUDE.md.notes", "should not be touched\n");
+    rmSync(join(repoDir, "kept-on-base/only/CLAUDE.md"));
+    rmSync(join(repoDir, "kept-on-base/only/CLAUDE.local.md"));
+    git(["add", "-A"]);
     git(["commit", "-m", "pr config"]);
 
     process.chdir(repoDir);
@@ -59,22 +91,26 @@ describe("restoreConfigFromBase", () => {
 
   afterEach(() => {
     process.chdir(originalCwd);
+    if (originalDisableNestedRestore === undefined) {
+      delete process.env.DISABLE_NESTED_CLAUDE_MD_RESTORE;
+    } else {
+      process.env.DISABLE_NESTED_CLAUDE_MD_RESTORE =
+        originalDisableNestedRestore;
+    }
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
 
   test("preserves PR sensitive files while excluding .claude-pr from broad staging", () => {
-    const gitignoreExistedBefore = existsRepoFile(".gitignore");
-    const gitignoreContentsBefore = gitignoreExistedBefore
-      ? readRepoFile(".gitignore")
-      : "";
+    expect(repoPathExistsLexically(".gitignore")).toBe(false);
 
     restoreConfigFromBase("main");
 
-    expect(readRepoFile(".claude-pr/CLAUDE.md")).toBe(
+    expect(readRepoFile(".claude-pr/CLAUDE.md.pr-snapshot")).toBe(
       "pr claude instructions\n",
     );
+    expect(repoPathExistsLexically(".claude-pr/CLAUDE.md")).toBe(false);
     expect(readRepoFile(".claude-pr/.claude/settings.json")).toBe(
       `${JSON.stringify({ source: "pr" })}\n`,
     );
@@ -82,18 +118,15 @@ describe("restoreConfigFromBase", () => {
     expect(readRepoFile(".claude/settings.json")).toBe(
       `${JSON.stringify({ source: "base" })}\n`,
     );
-    expect(git(["check-ignore", ".claude-pr/CLAUDE.md"]).trim()).toBe(
-      ".claude-pr/CLAUDE.md",
-    );
+    expect(
+      git(["check-ignore", ".claude-pr/CLAUDE.md.pr-snapshot"]).trim(),
+    ).toBe(".claude-pr/CLAUDE.md.pr-snapshot");
     expect(countClaudePrExcludeEntries()).toBe(1);
 
     restoreConfigFromBase("main");
 
     expect(countClaudePrExcludeEntries()).toBe(1);
-    expect(existsRepoFile(".gitignore")).toBe(gitignoreExistedBefore);
-    if (gitignoreExistedBefore) {
-      expect(readRepoFile(".gitignore")).toBe(gitignoreContentsBefore);
-    }
+    expect(repoPathExistsLexically(".gitignore")).toBe(false);
 
     writeRepoFile("src/fix.ts", "export const fix = true;\n");
     git(["add", "-A"]);
@@ -117,16 +150,12 @@ describe("restoreConfigFromBase", () => {
     expect(committedFiles.some((file) => file.startsWith(".claude-pr/"))).toBe(
       false,
     );
-    expect(existsRepoFile(".gitignore")).toBe(gitignoreExistedBefore);
-    if (gitignoreExistedBefore) {
-      expect(readRepoFile(".gitignore")).toBe(gitignoreContentsBefore);
-    }
+    expect(repoPathExistsLexically(".gitignore")).toBe(false);
   });
 
   test("restores symlinked CLAUDE.md paths from the PR base branch", () => {
     setupSymlinkedMainBranch();
 
-    git(["checkout", "pr"]);
     writeRepoFile(
       ".claude/settings.json",
       `${JSON.stringify({ source: "pr-with-symlinks" })}\n`,
@@ -137,28 +166,49 @@ describe("restoreConfigFromBase", () => {
     restoreConfigFromBase("main");
 
     expect(lstatRepoFile("CLAUDE.md").isSymbolicLink()).toBe(true);
+    expect(readlinkRepoFile("CLAUDE.md")).toBe("AGENTS.md");
     expect(lstatRepoFile(".claude/CLAUDE.md").isSymbolicLink()).toBe(true);
-    expect(readRepoFile("CLAUDE.md").trim()).toBe("shared agent instructions");
-    expect(readRepoFile(".claude/CLAUDE.md").trim()).toBe(
-      "shared agent instructions",
+    expect(readlinkRepoFile(".claude/CLAUDE.md")).toBe("../AGENTS.md");
+    expect(lstatRepoFile("packages/trusted/CLAUDE.md").isSymbolicLink()).toBe(
+      true,
+    );
+    expect(readlinkRepoFile("packages/trusted/CLAUDE.md")).toBe("AGENTS.md");
+    expect(readRepoFile("CLAUDE.md")).toBe("shared agent instructions\n");
+    expect(readRepoFile(".claude/CLAUDE.md")).toBe(
+      "shared agent instructions\n",
+    );
+    expect(readRepoFile("packages/trusted/CLAUDE.md")).toBe(
+      "nested shared agent instructions\n",
     );
     expect(readRepoFile(".claude/settings.json")).toBe(
       `${JSON.stringify({ source: "base" })}\n`,
     );
   });
 
-  test("snapshots symlinked sensitive paths even when the PR head target is missing", () => {
+  test("omits dangling PR snapshot links while continuing the trusted restore", () => {
     setupSymlinkedMainBranch();
 
-    git(["checkout", "pr"]);
-    rmSync(join(repoDir, "AGENTS.md"), { force: true });
+    rmSync(join(repoDir, "AGENTS.md"));
     git(["add", "-A"]);
     git(["commit", "-m", "pr deletes agents file"]);
 
     restoreConfigFromBase("main");
 
-    expect(lstatRepoFile(".claude-pr/.claude/CLAUDE.md").isSymbolicLink()).toBe(
-      true,
+    expect(repoPathExistsLexically(".claude-pr/CLAUDE.md")).toBe(false);
+    expect(repoPathExistsLexically(".claude-pr/CLAUDE.md.pr-snapshot")).toBe(
+      false,
+    );
+    expect(repoPathExistsLexically(".claude-pr/.claude/CLAUDE.md")).toBe(false);
+    expect(
+      repoPathExistsLexically(".claude-pr/.claude/CLAUDE.md.pr-snapshot"),
+    ).toBe(false);
+    expect(lstatRepoFile("CLAUDE.md").isSymbolicLink()).toBe(true);
+    expect(readlinkRepoFile("CLAUDE.md")).toBe("AGENTS.md");
+    expect(lstatRepoFile(".claude/CLAUDE.md").isSymbolicLink()).toBe(true);
+    expect(readlinkRepoFile(".claude/CLAUDE.md")).toBe("../AGENTS.md");
+    expect(readRepoFile("CLAUDE.md")).toBe("shared agent instructions\n");
+    expect(readRepoFile(".claude/CLAUDE.md")).toBe(
+      "shared agent instructions\n",
     );
     expect(readRepoFile(".claude/settings.json")).toBe(
       `${JSON.stringify({ source: "base" })}\n`,
@@ -178,26 +228,645 @@ describe("restoreConfigFromBase", () => {
     expect(countClaudePrExcludeEntries()).toBe(1);
   });
 
+  test("restores root CLAUDE.md and CLAUDE.local.md from base", () => {
+    restoreConfigFromBase("main");
+
+    expect(readRepoFile("CLAUDE.md")).toBe("base claude instructions\n");
+    expect(readRepoFile("CLAUDE.local.md")).toBe(
+      "base local claude instructions\n",
+    );
+  });
+
+  test("restores nested CLAUDE.md present on both PR and base", () => {
+    restoreConfigFromBase("main");
+
+    expect(readRepoFile("packages/foo/CLAUDE.md")).toBe(
+      "base nested foo instructions\n",
+    );
+    expect(readRepoFile("deeper/nested/dir/CLAUDE.md")).toBe(
+      "base deep instructions\n",
+    );
+  });
+
+  test("restores nested CLAUDE.md and CLAUDE.local.md present only on base", () => {
+    expect(repoPathExistsLexically("kept-on-base/only/CLAUDE.md")).toBe(false);
+    expect(repoPathExistsLexically("kept-on-base/only/CLAUDE.local.md")).toBe(
+      false,
+    );
+
+    restoreConfigFromBase("main");
+
+    expect(readRepoFile("kept-on-base/only/CLAUDE.md")).toBe(
+      "base-only nested instructions\n",
+    );
+    expect(readRepoFile("kept-on-base/only/CLAUDE.local.md")).toBe(
+      "base-only nested local instructions\n",
+    );
+  });
+
+  test("deletes nested CLAUDE.md and CLAUDE.local.md present only on PR head", () => {
+    expect(repoPathExistsLexically("pr-only/CLAUDE.md")).toBe(true);
+    expect(repoPathExistsLexically("pr-only/sub/CLAUDE.local.md")).toBe(true);
+
+    restoreConfigFromBase("main");
+
+    expect(repoPathExistsLexically("pr-only/CLAUDE.md")).toBe(false);
+    expect(repoPathExistsLexically("pr-only/sub/CLAUDE.local.md")).toBe(false);
+  });
+
+  test("snapshots PR instruction files only under .pr-snapshot basenames", () => {
+    restoreConfigFromBase("main");
+
+    expect(readRepoFile(".claude-pr/CLAUDE.md.pr-snapshot")).toBe(
+      "pr claude instructions\n",
+    );
+    expect(readRepoFile(".claude-pr/CLAUDE.local.md.pr-snapshot")).toBe(
+      "pr local claude instructions\n",
+    );
+    expect(readRepoFile(".claude-pr/packages/foo/CLAUDE.md.pr-snapshot")).toBe(
+      "pr nested foo instructions\n",
+    );
+    expect(readRepoFile(".claude-pr/pr-only/CLAUDE.md.pr-snapshot")).toBe(
+      "pr-only instructions\n",
+    );
+    expect(
+      readRepoFile(".claude-pr/pr-only/sub/CLAUDE.local.md.pr-snapshot"),
+    ).toBe("pr-only local instructions\n");
+    expect(repoPathExistsLexically(".claude-pr/CLAUDE.md")).toBe(false);
+    expect(repoPathExistsLexically(".claude-pr/CLAUDE.local.md")).toBe(false);
+    expect(repoPathExistsLexically(".claude-pr/packages/foo/CLAUDE.md")).toBe(
+      false,
+    );
+    expect(repoPathExistsLexically(".claude-pr/pr-only/CLAUDE.md")).toBe(false);
+    expect(
+      repoPathExistsLexically(".claude-pr/pr-only/sub/CLAUDE.local.md"),
+    ).toBe(false);
+  });
+
+  test("does not restore a base instruction basename from .claude-pr", () => {
+    const reservedInstructionPath = ".claude-pr/nested/CLAUDE.md";
+
+    git(["checkout", "main"]);
+    writeRepoFile(
+      reservedInstructionPath,
+      "base instruction inside reserved subtree\n",
+    );
+    git(["add", "-f", "--", reservedInstructionPath]);
+    git(["commit", "-m", "track reserved instruction basename"]);
+    pushMainAndRecreatePr();
+
+    writeRepoFile(
+      reservedInstructionPath,
+      "pr instruction inside reserved subtree\n",
+    );
+    writeRepoFile("CLAUDE.md", "pr root instruction sentinel\n");
+    git(["add", "-A"]);
+    git(["commit", "-m", "tamper with reserved instruction basename"]);
+
+    restoreConfigFromBase("main");
+
+    expect(repoPathExistsLexically(reservedInstructionPath)).toBe(false);
+    expect(readRepoFile(".claude-pr/CLAUDE.md.pr-snapshot")).toBe(
+      "pr root instruction sentinel\n",
+    );
+  });
+
+  test("does not snapshot nested symlinks copied from .claude", () => {
+    const fileSecretPath = join(tempDir, "FILE_SECRET");
+    writeFileSync(fileSecretPath, "FILE EXFIL\n");
+    const directorySecretPath = join(tempDir, "directory-secret");
+    mkdirSync(directorySecretPath, { recursive: true });
+    writeFileSync(join(directorySecretPath, "leak.txt"), "DIRECTORY EXFIL\n");
+
+    mkdirSync(join(repoDir, ".claude/hooks"), { recursive: true });
+    symlinkSync(fileSecretPath, join(repoDir, ".claude/hooks/leak.txt"));
+    symlinkSync(directorySecretPath, join(repoDir, ".claude/leaky"));
+    git(["add", ".claude"]);
+    git(["commit", "-m", "nested symlinks under .claude"]);
+
+    restoreConfigFromBase("main");
+
+    expect(repoPathExistsLexically(".claude-pr/.claude/hooks/leak.txt")).toBe(
+      false,
+    );
+    expect(repoPathExistsLexically(".claude-pr/.claude/leaky")).toBe(false);
+    expect(repoTreeContainsText(".claude-pr", "FILE EXFIL")).toBe(false);
+    expect(repoTreeContainsText(".claude-pr", "DIRECTORY EXFIL")).toBe(false);
+    expect(readFileSync(fileSecretPath, "utf8")).toBe("FILE EXFIL\n");
+    expect(readFileSync(join(directorySecretPath, "leak.txt"), "utf8")).toBe(
+      "DIRECTORY EXFIL\n",
+    );
+  });
+
+  test("renames instruction files inside recursively copied sensitive directories", () => {
+    writeRepoFile(
+      ".claude/hooks/CLAUDE.md",
+      "pr instructions inside .claude\n",
+    );
+    writeRepoFile(
+      ".claude/hooks/CLAUDE.local.md",
+      "pr local instructions inside .claude\n",
+    );
+    git(["add", "."]);
+    git(["commit", "-m", "nested instructions under sensitive directory"]);
+
+    restoreConfigFromBase("main");
+
+    expect(repoPathExistsLexically(".claude-pr/.claude/hooks/CLAUDE.md")).toBe(
+      false,
+    );
+    expect(
+      repoPathExistsLexically(".claude-pr/.claude/hooks/CLAUDE.local.md"),
+    ).toBe(false);
+    expect(readRepoFile(".claude-pr/.claude/hooks/CLAUDE.md.pr-snapshot")).toBe(
+      "pr instructions inside .claude\n",
+    );
+    expect(
+      readRepoFile(".claude-pr/.claude/hooks/CLAUDE.local.md.pr-snapshot"),
+    ).toBe("pr local instructions inside .claude\n");
+  });
+
+  test("snapshots non-auto-loaded sensitive paths under their original names", () => {
+    restoreConfigFromBase("main");
+
+    expect(readRepoFile(".claude-pr/.claude/settings.json")).toBe(
+      `${JSON.stringify({ source: "pr" })}\n`,
+    );
+    expect(readRepoFile(".claude-pr/.mcp.json")).toBe(
+      `${JSON.stringify({ servers: { attacker: true } })}\n`,
+    );
+  });
+
+  test("does not match files whose basename only starts with CLAUDE.md", () => {
+    restoreConfigFromBase("main");
+
+    expect(readRepoFile("docs/CLAUDE.md.notes")).toBe(
+      "should not be touched\n",
+    );
+  });
+
+  test("keeps nested instructions untouched when nested restore is disabled", () => {
+    process.env.DISABLE_NESTED_CLAUDE_MD_RESTORE = "true";
+
+    restoreConfigFromBase("main");
+
+    expect(readRepoFile("CLAUDE.md")).toBe("base claude instructions\n");
+    expect(readRepoFile("CLAUDE.local.md")).toBe(
+      "base local claude instructions\n",
+    );
+    expect(readRepoFile("packages/foo/CLAUDE.md")).toBe(
+      "pr nested foo instructions\n",
+    );
+    expect(readRepoFile("deeper/nested/dir/CLAUDE.md")).toBe(
+      "pr deep instructions\n",
+    );
+    expect(repoPathExistsLexically("pr-only/CLAUDE.md")).toBe(true);
+    expect(repoPathExistsLexically("kept-on-base/only/CLAUDE.md")).toBe(false);
+  });
+
+  test("restores the .claude tree from base", () => {
+    restoreConfigFromBase("main");
+
+    expect(readRepoFile(".claude/settings.json")).toBe(
+      `${JSON.stringify({ source: "base" })}\n`,
+    );
+  });
+
+  test("handles instruction files inside a leading-dash directory", () => {
+    writeRepoFile("-pkg/CLAUDE.md", "pr leading-dash instructions\n");
+    git(["add", "--", "-pkg/CLAUDE.md"]);
+    git(["commit", "-m", "leading-dash instruction path"]);
+
+    restoreConfigFromBase("main");
+
+    expect(repoPathExistsLexically("-pkg/CLAUDE.md")).toBe(false);
+    expect(readRepoFile(".claude-pr/-pkg/CLAUDE.md.pr-snapshot")).toBe(
+      "pr leading-dash instructions\n",
+    );
+  });
+
+  test("does not snapshot or restore a PR-only nested instruction symlink", () => {
+    const secretPath = join(tempDir, "NESTED_SECRET");
+    writeFileSync(secretPath, "NESTED SECRET\n");
+    mkdirSync(join(repoDir, "evil"), { recursive: true });
+    symlinkSync(secretPath, join(repoDir, "evil/CLAUDE.md"));
+    git(["add", "evil/CLAUDE.md"]);
+    git(["commit", "-m", "pr-only nested instruction symlink"]);
+
+    restoreConfigFromBase("main");
+
+    expect(repoPathExistsLexically(".claude-pr/evil/CLAUDE.md")).toBe(false);
+    expect(
+      repoPathExistsLexically(".claude-pr/evil/CLAUDE.md.pr-snapshot"),
+    ).toBe(false);
+    expect(repoPathExistsLexically("evil/CLAUDE.md")).toBe(false);
+    expect(readFileSync(secretPath, "utf8")).toBe("NESTED SECRET\n");
+  });
+
+  test("does not snapshot a root sensitive path replaced with a PR symlink", () => {
+    const secretPath = join(tempDir, "ROOT_SECRET");
+    writeFileSync(secretPath, "ROOT SECRET\n");
+    rmSync(join(repoDir, "CLAUDE.md"));
+    symlinkSync(secretPath, join(repoDir, "CLAUDE.md"));
+    git(["add", "CLAUDE.md"]);
+    git(["commit", "-m", "root instruction symlink"]);
+
+    restoreConfigFromBase("main");
+
+    expect(repoPathExistsLexically(".claude-pr/CLAUDE.md")).toBe(false);
+    expect(repoPathExistsLexically(".claude-pr/CLAUDE.md.pr-snapshot")).toBe(
+      false,
+    );
+    expect(lstatRepoFile("CLAUDE.md").isSymbolicLink()).toBe(false);
+    expect(lstatRepoFile("CLAUDE.md").isFile()).toBe(true);
+    expect(readRepoFile("CLAUDE.md")).toBe("base claude instructions\n");
+    expect(readFileSync(secretPath, "utf8")).toBe("ROOT SECRET\n");
+  });
+
+  test("leaves restored paths unstaged", () => {
+    restoreConfigFromBase("main");
+
+    const statusLines = git(["status", "--porcelain"])
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .filter((line) => !line.startsWith("??"));
+    expect(statusLines.length).toBeGreaterThan(0);
+    for (const line of statusLines) {
+      expect(line[0]).toBe(" ");
+    }
+  });
+
+  test("restores base links and targets after the PR modifies, deletes, and retargets them", () => {
+    git(["checkout", "main"]);
+    rmSync(join(repoDir, "CLAUDE.md"));
+    writeRepoFile("AGENTS.md", "trusted root target\n");
+    symlinkRepoFile("CLAUDE.md", "AGENTS.md");
+    writeRepoFile(".claude/AGENTS.md", "trusted .claude target\n");
+    symlinkRepoFile(".claude/CLAUDE.md", "AGENTS.md");
+    writeRepoFile(
+      "packages/trusted-links/AGENTS.md",
+      "trusted nested target\n",
+    );
+    symlinkRepoFile("packages/trusted-links/CLAUDE.local.md", "AGENTS.md");
+    git(["add", "-A"]);
+    git(["commit", "-m", "trusted instruction link targets"]);
+    pushMainAndRecreatePr();
+
+    writeRepoFile("AGENTS.md", "attacker root target\n");
+    rmSync(join(repoDir, ".claude/AGENTS.md"));
+    writeRepoFile(
+      "packages/trusted-links/AGENTS.md",
+      "attacker nested target\n",
+    );
+    rmSync(join(repoDir, "packages/trusted-links/CLAUDE.local.md"));
+    writeRepoFile(
+      "packages/trusted-links/ATTACKER.md",
+      "retargeted attacker instructions\n",
+    );
+    symlinkRepoFile("packages/trusted-links/CLAUDE.local.md", "ATTACKER.md");
+    git(["add", "-A"]);
+    git(["commit", "-m", "tamper with trusted instruction targets"]);
+
+    restoreConfigFromBase("main");
+
+    expect(lstatRepoFile("CLAUDE.md").isSymbolicLink()).toBe(true);
+    expect(readlinkRepoFile("CLAUDE.md")).toBe("AGENTS.md");
+    expect(readRepoFile("CLAUDE.md")).toBe("trusted root target\n");
+    expect(lstatRepoFile(".claude/CLAUDE.md").isSymbolicLink()).toBe(true);
+    expect(readlinkRepoFile(".claude/CLAUDE.md")).toBe("AGENTS.md");
+    expect(readRepoFile(".claude/CLAUDE.md")).toBe("trusted .claude target\n");
+    expect(
+      lstatRepoFile("packages/trusted-links/CLAUDE.local.md").isSymbolicLink(),
+    ).toBe(true);
+    expect(readlinkRepoFile("packages/trusted-links/CLAUDE.local.md")).toBe(
+      "AGENTS.md",
+    );
+    expect(readRepoFile("packages/trusted-links/CLAUDE.local.md")).toBe(
+      "trusted nested target\n",
+    );
+    expect(
+      repoPathExistsLexically(
+        ".claude-pr/packages/trusted-links/CLAUDE.local.md",
+      ),
+    ).toBe(false);
+    expect(
+      repoPathExistsLexically(
+        ".claude-pr/packages/trusted-links/CLAUDE.local.md.pr-snapshot",
+      ),
+    ).toBe(false);
+  });
+
+  test("restores exact base content through a multi-hop trusted symlink chain", () => {
+    const trustedContents =
+      "trusted multi-hop instruction line one\nline two\n";
+
+    git(["checkout", "main"]);
+    rmSync(join(repoDir, "CLAUDE.md"));
+    writeRepoFile("trusted-content/base-instructions.txt", trustedContents);
+    symlinkRepoFile("CLAUDE.md", "trusted-links/first");
+    symlinkRepoFile("trusted-links/first", "second");
+    symlinkRepoFile(
+      "trusted-links/second",
+      "../trusted-content/base-instructions.txt",
+    );
+    git(["add", "-A"]);
+    git(["commit", "-m", "trusted multi-hop instruction chain"]);
+    pushMainAndRecreatePr();
+
+    rmSync(join(repoDir, "CLAUDE.md"));
+    writeRepoFile("CLAUDE.md", "attacker root instructions\n");
+    rmSync(join(repoDir, "trusted-links/first"));
+    symlinkRepoFile("trusted-links/first", "../attacker-instructions.txt");
+    rmSync(join(repoDir, "trusted-links/second"));
+    writeRepoFile("trusted-links/second", "attacker replaced second hop\n");
+    writeRepoFile(
+      "trusted-content/base-instructions.txt",
+      "attacker replaced trusted content\n",
+    );
+    writeRepoFile("attacker-instructions.txt", "attacker link target\n");
+    git(["add", "-A"]);
+    git(["commit", "-m", "tamper with multi-hop instruction chain"]);
+
+    restoreConfigFromBase("main");
+
+    expect(lstatRepoFile("CLAUDE.md").isSymbolicLink()).toBe(true);
+    expect(readlinkRepoFile("CLAUDE.md")).toBe("trusted-links/first");
+    expect(lstatRepoFile("trusted-links/first").isSymbolicLink()).toBe(true);
+    expect(readlinkRepoFile("trusted-links/first")).toBe("second");
+    expect(lstatRepoFile("trusted-links/second").isSymbolicLink()).toBe(true);
+    expect(readlinkRepoFile("trusted-links/second")).toBe(
+      "../trusted-content/base-instructions.txt",
+    );
+    expect(
+      lstatRepoFile("trusted-content/base-instructions.txt").isFile(),
+    ).toBe(true);
+    expect(readRepoFile("trusted-content/base-instructions.txt")).toBe(
+      trustedContents,
+    );
+    expect(readRepoFile("CLAUDE.md")).toBe(trustedContents);
+    expect(readRepoFile(".claude-pr/CLAUDE.md.pr-snapshot")).toBe(
+      "attacker root instructions\n",
+    );
+  });
+
+  test("fails closed before mutation when a trusted link chain enters .claude-pr", () => {
+    const reservedTarget = ".claude-pr/trusted/AGENTS.md";
+
+    git(["checkout", "main"]);
+    rmSync(join(repoDir, "CLAUDE.md"));
+    writeRepoFile(reservedTarget, "trusted reserved target\n");
+    symlinkRepoFile("CLAUDE.md", "trusted-links/reserved-hop");
+    symlinkRepoFile(
+      "trusted-links/reserved-hop",
+      "../.claude-pr/trusted/AGENTS.md",
+    );
+    git(["add", "-A"]);
+    git(["add", "-f", "--", reservedTarget]);
+    git(["commit", "-m", "trusted chain into reserved subtree"]);
+    pushMainAndRecreatePr();
+
+    rmSync(join(repoDir, "CLAUDE.md"));
+    writeRepoFile("CLAUDE.md", "attacker root instructions\n");
+    writeRepoFile(reservedTarget, "attacker reserved target\n");
+    writeRepoFile(
+      ".claude/settings.json",
+      `${JSON.stringify({ source: "pr-reserved-chain" })}\n`,
+    );
+    git(["add", "-A"]);
+    git(["commit", "-m", "tamper with reserved target chain"]);
+    const prWorktreeBefore = snapshotRepoWorktree();
+
+    expect(() => restoreConfigFromBase("main")).toThrow(/\.claude-pr/);
+
+    expect(snapshotRepoWorktree()).toEqual(prWorktreeBefore);
+  });
+
+  for (const invalidTarget of [
+    {
+      name: "repository escape",
+      expectedError: /escapes the repository/i,
+      setupBase: () => {
+        writeFileSync(
+          join(tempDir, "outside-instructions.md"),
+          "outside repository sentinel\n",
+        );
+        symlinkRepoFile("CLAUDE.md", "../outside-instructions.md");
+      },
+    },
+    {
+      name: "missing target",
+      expectedError: /untracked|not tracked/i,
+      setupBase: () => {
+        symlinkRepoFile("CLAUDE.md", "missing/AGENTS.md");
+      },
+    },
+    {
+      name: "directory target",
+      expectedError: /non-blob|not a blob/i,
+      setupBase: () => {
+        writeRepoFile(
+          "instruction-directory/sentinel.txt",
+          "tracked directory sentinel\n",
+        );
+        symlinkRepoFile("CLAUDE.md", "instruction-directory");
+      },
+    },
+    {
+      name: "symlink cycle",
+      expectedError: /cycle/i,
+      setupBase: () => {
+        symlinkRepoFile("CLAUDE.md", "trusted-links/cycle");
+        symlinkRepoFile("trusted-links/cycle", "../CLAUDE.md");
+      },
+    },
+  ]) {
+    test(`fails closed before PR worktree mutation for a trusted ${invalidTarget.name}`, () => {
+      git(["checkout", "main"]);
+      rmSync(join(repoDir, "CLAUDE.md"));
+      invalidTarget.setupBase();
+      git(["add", "-A"]);
+      git(["commit", "-m", `trusted ${invalidTarget.name}`]);
+      pushMainAndRecreatePr();
+
+      writeRepoFile(
+        ".claude/settings.json",
+        `${JSON.stringify({ source: `pr-${invalidTarget.name}` })}\n`,
+      );
+      writeRepoFile(
+        "CLAUDE.local.md",
+        `pr sentinel for ${invalidTarget.name}\n`,
+      );
+      git(["add", "-A"]);
+      git(["commit", "-m", `pr sentinel for ${invalidTarget.name}`]);
+      const prWorktreeBefore = snapshotRepoWorktree();
+      expect(repoPathExistsLexically(".claude-pr")).toBe(false);
+
+      expect(() => restoreConfigFromBase("main")).toThrow(
+        invalidTarget.expectedError,
+      );
+
+      expect(snapshotRepoWorktree()).toEqual(prWorktreeBefore);
+      expect(repoPathExistsLexically(".claude-pr")).toBe(false);
+    });
+  }
+
+  test("does not follow a PR symlink ancestor while restoring a trusted target", () => {
+    setupInstructionAncestorMainBranch();
+
+    const externalDirectory = join(tempDir, "external-instructions");
+    mkdirSync(externalDirectory, { recursive: true });
+    const externalTarget = join(externalDirectory, "AGENTS.md");
+    writeFileSync(externalTarget, "external sentinel instructions\n");
+    const externalSentinelBefore = readFileSync(externalTarget);
+
+    rmSync(join(repoDir, "instructions"), { recursive: true });
+    symlinkRepoFile("instructions", externalDirectory);
+    git(["add", "-A"]);
+    git(["commit", "-m", "replace target directory with external symlink"]);
+
+    restoreConfigFromBase("main");
+
+    expect(readFileSync(externalTarget).equals(externalSentinelBefore)).toBe(
+      true,
+    );
+    expect(lstatRepoFile("instructions").isSymbolicLink()).toBe(false);
+    expect(lstatRepoFile("instructions").isDirectory()).toBe(true);
+    expect(readRepoFile("instructions/AGENTS.md")).toBe(
+      "trusted directory target\n",
+    );
+    expect(lstatRepoFile("CLAUDE.md").isSymbolicLink()).toBe(true);
+    expect(readlinkRepoFile("CLAUDE.md")).toBe("instructions/AGENTS.md");
+    expect(readRepoFile("CLAUDE.md")).toBe("trusted directory target\n");
+    expect(repoPathExistsLexically(".claude-pr/CLAUDE.md")).toBe(false);
+    expect(repoPathExistsLexically(".claude-pr/CLAUDE.md.pr-snapshot")).toBe(
+      false,
+    );
+  });
+
+  test("does not retain a populated gitlink ancestor while restoring a trusted target", () => {
+    setupInstructionAncestorMainBranch();
+
+    const submoduleSource = createGitRepository("ancestor-submodule", {
+      "AGENTS.md": "attacker gitlink target\n",
+      "sentinel.txt": "external gitlink sentinel\n",
+    });
+    const externalSentinelBefore = readFileSync(
+      join(submoduleSource, "sentinel.txt"),
+    );
+
+    git(["rm", "-r", "instructions"]);
+    git([
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "add",
+      submoduleSource,
+      "instructions",
+    ]);
+    git(["commit", "-m", "replace target directory with populated gitlink"]);
+
+    expect(readRepoFile("instructions/sentinel.txt")).toBe(
+      "external gitlink sentinel\n",
+    );
+    expect(repoPathExistsLexically("instructions/.git")).toBe(true);
+
+    restoreConfigFromBase("main");
+
+    expect(
+      readFileSync(join(submoduleSource, "sentinel.txt")).equals(
+        externalSentinelBefore,
+      ),
+    ).toBe(true);
+    expect(lstatRepoFile("instructions").isSymbolicLink()).toBe(false);
+    expect(lstatRepoFile("instructions").isDirectory()).toBe(true);
+    expect(readRepoFile("instructions/AGENTS.md")).toBe(
+      "trusted directory target\n",
+    );
+    expect(lstatRepoFile("CLAUDE.md").isSymbolicLink()).toBe(true);
+    expect(readlinkRepoFile("CLAUDE.md")).toBe("instructions/AGENTS.md");
+    expect(readRepoFile("CLAUDE.md")).toBe("trusted directory target\n");
+    expect(repoPathExistsLexically(".claude-pr/CLAUDE.md")).toBe(false);
+    expect(repoPathExistsLexically(".claude-pr/CLAUDE.md.pr-snapshot")).toBe(
+      false,
+    );
+    expect(repoPathExistsLexically("instructions/sentinel.txt")).toBe(false);
+    expect(repoPathExistsLexically("instructions/.git")).toBe(false);
+  });
+
+  test("treats pathspec magic literally without changing unrelated worktree or index state", () => {
+    const magicPath = ":(exclude)victim/CLAUDE.md";
+    const unrelatedPath = "src/index.ts";
+
+    git(["checkout", "main"]);
+    writeRepoFile(magicPath, "trusted literal-path instructions\n");
+    git(["--literal-pathspecs", "add", "--", magicPath]);
+    git(["commit", "-m", "trusted literal pathspec instruction"]);
+    pushMainAndRecreatePr();
+
+    writeRepoFile(magicPath, "attacker literal-path instructions\n");
+    git(["--literal-pathspecs", "add", "--", magicPath]);
+    git(["commit", "-m", "tamper with literal pathspec instruction"]);
+
+    writeRepoFile(unrelatedPath, "export const staged = true;\n");
+    git(["add", "--", unrelatedPath]);
+    const unrelatedIndexBefore = git(["show", `:${unrelatedPath}`]);
+    writeRepoFile(unrelatedPath, "export const worktree = true;\n");
+    const unrelatedWorktreeBefore = readRepoFile(unrelatedPath);
+    const unrelatedStatusBefore = git([
+      "status",
+      "--short",
+      "--",
+      unrelatedPath,
+    ]);
+
+    restoreConfigFromBase("main");
+
+    expect(readRepoFile(magicPath)).toBe("trusted literal-path instructions\n");
+    expect(
+      readRepoFile(".claude-pr/:(exclude)victim/CLAUDE.md.pr-snapshot"),
+    ).toBe("attacker literal-path instructions\n");
+    expect(
+      repoPathExistsLexically(".claude-pr/:(exclude)victim/CLAUDE.md"),
+    ).toBe(false);
+    expect(readRepoFile(unrelatedPath)).toBe(unrelatedWorktreeBefore);
+    expect(git(["show", `:${unrelatedPath}`])).toBe(unrelatedIndexBefore);
+    expect(git(["status", "--short", "--", unrelatedPath])).toBe(
+      unrelatedStatusBefore,
+    );
+  });
+
+  test("fails closed when a populated submodule contains nested CLAUDE.md", () => {
+    assertPopulatedSubmoduleFailsClosed("CLAUDE.md");
+  });
+
+  test("fails closed when a populated submodule contains nested CLAUDE.local.md", () => {
+    assertPopulatedSubmoduleFailsClosed("CLAUDE.local.md");
+  });
+
   function git(args: string[]): string {
+    return gitAt(repoDir, args);
+  }
+
+  function gitAt(cwd: string, args: string[]): string {
     return execFileSync("git", args, {
-      cwd: repoDir,
+      cwd,
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
     });
   }
 
-  function writeRepoFile(path: string, contents: string): void {
-    const fullPath = join(repoDir, path);
+  function writeFileAt(root: string, path: string, contents: string): void {
+    const fullPath = join(root, path);
     mkdirSync(dirname(fullPath), { recursive: true });
     writeFileSync(fullPath, contents);
   }
 
-  function readRepoFile(path: string): string {
-    return readFileSync(join(repoDir, path), "utf8");
+  function writeRepoFile(path: string, contents: string): void {
+    writeFileAt(repoDir, path, contents);
   }
 
-  function existsRepoFile(path: string): boolean {
-    return existsSync(join(repoDir, path));
+  function readRepoFile(path: string): string {
+    return readFileSync(join(repoDir, path), "utf8");
   }
 
   function symlinkRepoFile(path: string, target: string): void {
@@ -210,17 +879,206 @@ describe("restoreConfigFromBase", () => {
     return lstatSync(join(repoDir, path));
   }
 
+  function lstatRepoFileIfPresent(path: string) {
+    try {
+      return lstatRepoFile(path);
+    } catch (error) {
+      if (
+        error !== null &&
+        typeof error === "object" &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  function repoPathExistsLexically(path: string): boolean {
+    return lstatRepoFileIfPresent(path) !== undefined;
+  }
+
+  function readlinkRepoFile(path: string): string {
+    return readlinkSync(join(repoDir, path));
+  }
+
+  function repoTreeContainsText(path: string, text: string): boolean {
+    const stat = lstatRepoFileIfPresent(path);
+    if (stat === undefined || stat.isSymbolicLink()) {
+      return false;
+    }
+    if (stat.isDirectory()) {
+      return readdirSync(join(repoDir, path)).some((entry) =>
+        repoTreeContainsText(join(path, entry), text),
+      );
+    }
+    return stat.isFile() && readRepoFile(path).includes(text);
+  }
+
+  function snapshotLexicalTree(
+    rootPath: string,
+    excludedRootEntry?: string,
+  ): Array<[string, string, string]> {
+    const snapshot: Array<[string, string, string]> = [];
+
+    const visit = (absoluteDirectory: string, relativeDirectory: string) => {
+      for (const name of readdirSync(absoluteDirectory).sort()) {
+        if (relativeDirectory === "" && name === excludedRootEntry) {
+          continue;
+        }
+
+        const relativePath =
+          relativeDirectory === "" ? name : `${relativeDirectory}/${name}`;
+        const absolutePath = join(absoluteDirectory, name);
+        const stat = lstatSync(absolutePath);
+        if (stat.isSymbolicLink()) {
+          snapshot.push([relativePath, "symlink", readlinkSync(absolutePath)]);
+        } else if (stat.isDirectory()) {
+          snapshot.push([relativePath, "directory", ""]);
+          visit(absolutePath, relativePath);
+        } else if (stat.isFile()) {
+          snapshot.push([
+            relativePath,
+            "file",
+            readFileSync(absolutePath).toString("base64"),
+          ]);
+        } else {
+          snapshot.push([relativePath, "other", stat.mode.toString(8)]);
+        }
+      }
+    };
+
+    visit(rootPath, "");
+    return snapshot;
+  }
+
+  function snapshotRepoWorktree(): Array<[string, string, string]> {
+    return snapshotLexicalTree(repoDir, ".git");
+  }
+
   function setupSymlinkedMainBranch(): void {
     git(["checkout", "main"]);
-    rmSync(join(repoDir, "CLAUDE.md"), { force: true });
+    rmSync(join(repoDir, "CLAUDE.md"));
     writeRepoFile("AGENTS.md", "shared agent instructions\n");
     symlinkRepoFile("CLAUDE.md", "AGENTS.md");
     symlinkRepoFile(".claude/CLAUDE.md", "../AGENTS.md");
-    git(["add", "AGENTS.md", "CLAUDE.md", ".claude/CLAUDE.md"]);
+    writeRepoFile(
+      "packages/trusted/AGENTS.md",
+      "nested shared agent instructions\n",
+    );
+    symlinkRepoFile("packages/trusted/CLAUDE.md", "AGENTS.md");
+    git([
+      "add",
+      "AGENTS.md",
+      "CLAUDE.md",
+      ".claude/CLAUDE.md",
+      "packages/trusted/AGENTS.md",
+      "packages/trusted/CLAUDE.md",
+    ]);
     git(["commit", "-m", "add symlinked claude files"]);
+    pushMainAndRecreatePr();
+  }
+
+  function setupInstructionAncestorMainBranch(): void {
+    git(["checkout", "main"]);
+    rmSync(join(repoDir, "CLAUDE.md"));
+    writeRepoFile("instructions/AGENTS.md", "trusted directory target\n");
+    symlinkRepoFile("CLAUDE.md", "instructions/AGENTS.md");
+    git(["add", "-A"]);
+    git(["commit", "-m", "trusted instruction target directory"]);
+    pushMainAndRecreatePr();
+  }
+
+  function pushMainAndRecreatePr(): void {
     git(["push", "origin", "main"]);
     git(["branch", "-D", "pr"]);
     git(["checkout", "-b", "pr"]);
+  }
+
+  function createGitRepository(
+    directoryName: string,
+    files: Record<string, string>,
+  ): string {
+    const directory = join(tempDir, directoryName);
+    mkdirSync(directory, { recursive: true });
+    gitAt(directory, ["init"]);
+    gitAt(directory, ["config", "user.email", "test@example.com"]);
+    gitAt(directory, ["config", "user.name", "Test User"]);
+    for (const [path, contents] of Object.entries(files)) {
+      writeFileAt(directory, path, contents);
+    }
+    gitAt(directory, ["add", "."]);
+    gitAt(directory, ["commit", "-m", "submodule fixture"]);
+    return directory;
+  }
+
+  function assertPopulatedSubmoduleFailsClosed(
+    instructionBasename: "CLAUDE.md" | "CLAUDE.local.md",
+  ): void {
+    const sourceDirectoryName =
+      instructionBasename === "CLAUDE.md"
+        ? "instruction-submodule"
+        : "local-instruction-submodule";
+    const instructionContents = `attacker submodule ${instructionBasename}\n`;
+    const submoduleSource = createGitRepository(sourceDirectoryName, {
+      [`nested/${instructionBasename}`]: instructionContents,
+      "sentinel.txt": "external submodule sentinel\n",
+    });
+    symlinkSync("sentinel.txt", join(submoduleSource, "sentinel-link"));
+    gitAt(submoduleSource, ["add", "sentinel-link"]);
+    gitAt(submoduleSource, ["commit", "-m", "add lexical sentinel"]);
+    const externalSentinelBefore = readFileSync(
+      join(submoduleSource, "sentinel.txt"),
+    );
+
+    git([
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "add",
+      submoduleSource,
+      "vendor/untrusted",
+    ]);
+    git(["commit", "-m", `populated ${instructionBasename} submodule`]);
+
+    const checkedOutSubmodule = join(repoDir, "vendor/untrusted");
+    const checkedOutInstruction = join(
+      checkedOutSubmodule,
+      "nested",
+      instructionBasename,
+    );
+    const checkedOutInstructionBefore = readFileSync(checkedOutInstruction);
+    const checkedOutTreeBefore = snapshotLexicalTree(checkedOutSubmodule);
+    expect(readRepoFile(`vendor/untrusted/nested/${instructionBasename}`)).toBe(
+      instructionContents,
+    );
+    expect(readlinkSync(join(checkedOutSubmodule, "sentinel-link"))).toBe(
+      "sentinel.txt",
+    );
+
+    const escapedBasename = instructionBasename.replace(/\./g, "\\.");
+    expect(() => restoreConfigFromBase("main")).toThrow(
+      new RegExp(
+        `populated (?:gitlink|submodule).*${escapedBasename}|${escapedBasename}.*populated (?:gitlink|submodule)`,
+        "i",
+      ),
+    );
+
+    expect(
+      readFileSync(join(submoduleSource, "sentinel.txt")).equals(
+        externalSentinelBefore,
+      ),
+    ).toBe(true);
+    expect(
+      readFileSync(checkedOutInstruction).equals(checkedOutInstructionBefore),
+    ).toBe(true);
+    expect(snapshotLexicalTree(checkedOutSubmodule)).toEqual(
+      checkedOutTreeBefore,
+    );
+    expect(readlinkSync(join(checkedOutSubmodule, "sentinel-link"))).toBe(
+      "sentinel.txt",
+    );
   }
 
   function countClaudePrExcludeEntries(): number {


### PR DESCRIPTION
Fixes #1270

## Problem

`restoreConfigFromBase` replaces PR-controlled configuration with the trusted version from the base branch before Claude Code starts.

The old allowlist covered only `CLAUDE.md` and `CLAUDE.local.md` at the repository root. Claude Code also loads these files from nested working directories, so a pull request could add or change `packages/foo/CLAUDE.md` and leave those instructions active.

## What changed

The restore now covers exact `CLAUDE.md` and `CLAUDE.local.md` basenames at any depth in the superproject, except `.claude-pr`.

1. It reads tracked paths from the PR index and trusted paths from `origin/<base>` using NUL-delimited Git output.
2. It snapshots PR-authored sensitive files under `.claude-pr/`. Auto-loaded instruction names get a `.pr-snapshot` suffix. PR-authored symlinks are not copied.
3. Before changing the worktree, it builds the complete target chain for trusted base symlinks from Git tree entries and blob contents.
4. It rejects trusted links that escape the repository, enter `.claude-pr`, form a cycle, have a missing target, or end at a non-file entry.
5. It checks each worktree path component with `lstat`. PR symlink and gitlink ancestors are removed without being followed.
6. It uses `--literal-pathspecs` for discovered paths, then resets restored paths so the action does not stage them.
7. It stops if a populated submodule contains a nested `CLAUDE.md` or `CLAUDE.local.md`. The action does not run Git inside that submodule.

Set `DISABLE_NESTED_CLAUDE_MD_RESTORE=true` to keep the previous root-only behavior as an emergency opt-out.

## Snapshot safety

The `.claude-pr` snapshot remains available to review agents without creating a second instruction source.

1. Exact instruction basenames get the `.pr-snapshot` suffix, including files copied from `.claude/`.
2. File and directory symlinks are omitted from snapshots.
3. `.claude-pr/` remains in `.git/info/exclude`, so commands such as `git add -A` do not stage it.
4. Base discovery and trusted link resolution exclude the complete `.claude-pr` subtree.

## Tests

`test/restore-config.test.ts` contains 32 integration tests using temporary repositories, a bare remote, and real base and PR branches.

The tests cover root and nested restores, base-only and PR-only files, exact basename matching, the opt-out, snapshot naming, symlink omission, and unstaged restores. They also cover trusted link chains, modified and deleted targets, cycles, repository escapes, missing targets, directory targets, literal pathspecs, symlink ancestors, gitlink ancestors, and populated submodules containing either instruction basename.

Final local checks:

```text
bun test test/restore-config.test.ts
32 passed, 0 failed

bun test
832 passed, 0 failed

bun run typecheck
passed

bun run format:check
passed
```

## Related work

This rebase includes the `.git/info/exclude` protection from #1277. #1186 and #1441 are already part of `main`. #1187 was closed after #1186 landed.