### PR TITLE
feat: display syntax errors for settings and workflow config

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -1,3 +1,4 @@
+import * as core from "@actions/core";
 import { parse as parseShellArgs } from "shell-quote";
 import type { ClaudeOptions } from "./run-claude";
 import type { Options as SdkOptions } from "@anthropic-ai/claude-agent-sdk";
@@ -147,6 +148,35 @@ function parseClaudeArgsToExtraArgs(
 }
 
 /**
+ * Warn if tool list entries look like YAML list markers were accidentally included.
+ * This catches a common mistake where users write:
+ *   allowed_tools: |
+ *     - Edit
+ *     - Read
+ * instead of:
+ *   allowed_tools: |
+ *     Edit
+ *     Read
+ */
+function warnOnYamlListMarkers(
+  tools: string[],
+  inputName: string,
+): string[] {
+  const hasListMarkers = tools.some((t) => t === "-" || t.startsWith("- "));
+  if (!hasListMarkers) return tools;
+
+  core.warning(
+    `${inputName} appears to contain YAML list markers ("-"). ` +
+      `When using pipe (|) notation, list items directly without "- " prefixes. ` +
+      `Example:\n  ${inputName}: |\n    Edit\n    Read`,
+  );
+
+  return tools
+    .filter((t) => t !== "-")
+    .map((t) => (t.startsWith("- ") ? t.slice(2) : t));
+}
+
+/**
  * Parse ClaudeOptions into SDK-compatible options
  * Uses extraArgs for CLI pass-through instead of duplicating option parsing
  */
@@ -182,9 +212,10 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   const directAllowedTools = options.allowedTools
     ? options.allowedTools.split(",").map((t) => t.trim())
     : [];
-  const mergedAllowedTools = [
-    ...new Set([...extraArgsAllowedTools, ...directAllowedTools]),
-  ];
+  const mergedAllowedTools = warnOnYamlListMarkers(
+    [...new Set([...extraArgsAllowedTools, ...directAllowedTools])],
+    "allowed_tools",
+  );
   delete extraArgs["allowedTools"];
   delete extraArgs["allowed-tools"];
 
@@ -205,9 +236,10 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   const directDisallowedTools = options.disallowedTools
     ? options.disallowedTools.split(",").map((t) => t.trim())
     : [];
-  const mergedDisallowedTools = [
-    ...new Set([...extraArgsDisallowedTools, ...directDisallowedTools]),
-  ];
+  const mergedDisallowedTools = warnOnYamlListMarkers(
+    [...new Set([...extraArgsDisallowedTools, ...directDisallowedTools])],
+    "disallowed_tools",
+  );
   delete extraArgs["disallowedTools"];
   delete extraArgs["disallowed-tools"];
 

--- a/base-action/src/setup-claude-code-settings.ts
+++ b/base-action/src/setup-claude-code-settings.ts
@@ -1,4 +1,5 @@
 import { $ } from "bun";
+import * as core from "@actions/core";
 import { homedir } from "os";
 import { readFile } from "fs/promises";
 
@@ -27,7 +28,13 @@ export async function setupClaudeCodeSettings(
       console.log(`Settings file exists but is empty`);
     }
   } catch (e) {
-    console.log(`No existing settings file found, creating new one`);
+    if (e instanceof SyntaxError) {
+      core.warning(
+        `Failed to parse existing .claude/settings.json: ${e.message}. Starting with empty settings.`,
+      );
+    } else {
+      console.log(`No existing settings file found, creating new one`);
+    }
   }
 
   // Handle settings input (either file path or JSON string)
@@ -40,7 +47,17 @@ export async function setupClaudeCodeSettings(
       inputSettings = JSON.parse(settingsInput);
       console.log(`Parsed settings input as JSON`);
     } catch (e) {
-      // If not JSON, treat as file path
+      // If it looks like JSON (starts with {), report the syntax error
+      if (settingsInput.trim().startsWith("{")) {
+        const message =
+          e instanceof SyntaxError ? e.message : String(e);
+        core.error(
+          `Invalid JSON in settings input: ${message}`,
+        );
+        throw new Error(`Invalid JSON in settings input: ${message}`);
+      }
+
+      // Otherwise treat as file path
       console.log(
         `Settings input is not JSON, treating as file path: ${settingsInput}`,
       );
@@ -49,7 +66,11 @@ export async function setupClaudeCodeSettings(
         inputSettings = JSON.parse(fileContent);
         console.log(`Successfully read and parsed settings from file`);
       } catch (fileError) {
-        console.error(`Failed to read or parse settings file: ${fileError}`);
+        const message =
+          fileError instanceof SyntaxError
+            ? `Invalid JSON in settings file ${settingsInput}: ${fileError.message}`
+            : `Failed to read or parse settings file: ${fileError}`;
+        core.error(message);
         throw new Error(`Failed to process settings input: ${fileError}`);
       }
     }

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -298,6 +298,48 @@ describe("parseSdkOptions", () => {
     });
   });
 
+  describe("YAML list marker detection", () => {
+    test("should strip YAML list markers from allowed_tools", () => {
+      const options: ClaudeOptions = {
+        allowedTools: "- Edit,- Read,- Write",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.allowedTools).toEqual(["Edit", "Read", "Write"]);
+    });
+
+    test("should strip YAML list markers from disallowed_tools", () => {
+      const options: ClaudeOptions = {
+        disallowedTools: "- Bash,- Write",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.disallowedTools).toEqual(["Bash", "Write"]);
+    });
+
+    test("should not modify tools without YAML list markers", () => {
+      const options: ClaudeOptions = {
+        allowedTools: "Edit,Read,Write",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.allowedTools).toEqual(["Edit", "Read", "Write"]);
+    });
+
+    test("should filter out standalone dash entries", () => {
+      const options: ClaudeOptions = {
+        allowedTools: "-,Edit,-,Read",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.allowedTools).toEqual(["Edit", "Read"]);
+    });
+  });
+
   describe("other extraArgs passthrough", () => {
     test("should pass through json-schema in extraArgs", () => {
       const options: ClaudeOptions = {

--- a/base-action/test/setup-claude-code-settings.test.ts
+++ b/base-action/test/setup-claude-code-settings.test.ts
@@ -94,16 +94,35 @@ describe("setupClaudeCodeSettings", () => {
     expect(settings.model).toBe("test-model");
   });
 
-  test("should throw error for invalid JSON string", async () => {
+  test("should throw error with syntax details for invalid JSON string", async () => {
     expect(() =>
       setupClaudeCodeSettings("{ invalid json", testHomeDir),
-    ).toThrow();
+    ).toThrow(/Invalid JSON in settings input/);
   });
 
   test("should throw error for non-existent file path", async () => {
     expect(() =>
       setupClaudeCodeSettings("/non/existent/file.json", testHomeDir),
     ).toThrow();
+  });
+
+  test("should throw error with syntax details for invalid JSON in settings file", async () => {
+    await writeFile(testSettingsPath, "{ bad json }");
+
+    expect(() =>
+      setupClaudeCodeSettings(testSettingsPath, testHomeDir),
+    ).toThrow(/Failed to process settings input/);
+  });
+
+  test("should warn and continue when existing settings.json has invalid JSON", async () => {
+    await mkdir(join(testHomeDir, ".claude"), { recursive: true });
+    await writeFile(settingsPath, "{ not valid json }");
+
+    await setupClaudeCodeSettings(undefined, testHomeDir);
+
+    const settingsContent = await readFile(settingsPath, "utf-8");
+    const settings = JSON.parse(settingsContent);
+    expect(settings.enableAllProjectMcpServers).toBe(true);
   });
 
   test("should handle empty string input", async () => {


### PR DESCRIPTION
## Summary

Syntax errors in `.claude/settings.json` and workflow inputs like `allowed_tools` are currently silently ignored, making debugging difficult for users. This adds clear error messages when configuration has issues.

## Changes

**`base-action/src/setup-claude-code-settings.ts`**
- Surface JSON parse errors with the specific syntax error message when `.claude/settings.json` or the `settings` input contains invalid JSON
- Use `core.warning()` for recoverable issues (corrupt existing file) and `core.error()` for blocking issues (bad input)

**`base-action/src/parse-sdk-options.ts`**
- Detect YAML list markers (`-` prefixes) in `allowed_tools` / `disallowed_tools` entries, a common mistake when using pipe (`|`) notation in workflow YAML
- Emit `core.warning()` with a corrective example and strip the markers so tools still work

**Tests**
- 3 new tests for settings JSON validation
- 4 new tests for YAML marker detection

All 42 tests pass. Typecheck clean.

Fixes #242