### PR TITLE
fix: make trigger_phrase match case-insensitive

### DIFF
--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -51,6 +51,7 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     // Check for exact match with word boundaries or punctuation
     const regex = new RegExp(
       `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
+      "i",
     );
 
     // Check in body
@@ -77,6 +78,7 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     // Check for exact match with word boundaries or punctuation
     const regex = new RegExp(
       `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
+      "i",
     );
 
     // Check in body
@@ -105,6 +107,7 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     // Check for exact match with word boundaries or punctuation
     const regex = new RegExp(
       `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
+      "i",
     );
     if (regex.test(reviewBody)) {
       console.log(
@@ -125,6 +128,7 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     // Check for exact match with word boundaries or punctuation
     const regex = new RegExp(
       `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
+      "i",
     );
     if (regex.test(commentBody)) {
       console.log(`Comment contains exact trigger phrase '${triggerPhrase}'`);

--- a/test/trigger-validation.test.ts
+++ b/test/trigger-validation.test.ts
@@ -186,6 +186,8 @@ describe("checkContainsTrigger", () => {
         { issueBody: "@claude: here's the issue", expected: true },
         { issueBody: "@claude; and another thing", expected: true },
         { issueBody: "Hey @claude, can you help?", expected: true },
+        { issueBody: "@Claude can you help?", expected: true },
+        { issueBody: "@CLAUDE fix this", expected: true },
         { issueBody: "claudette contains claude", expected: false },
         { issueBody: "email@claude.com", expected: false },
       ];


### PR DESCRIPTION
Closes #910.

`@Claude` (capital C — from GitHub's @-mention autocomplete or iOS autocorrect) doesn't trigger the action because the regex in `checkContainsTrigger` has no `i` flag:

```
trigger_phrase: @claude
No trigger was met for @claude
Trigger result: false
No trigger found, skipping remaining steps
```

The workflow's outer `if: contains(github.event.comment.body, '@claude')` is case-insensitive, so the job runs but the action silently exits — looks to the user like Claude saw the mention and ignored it.

**Fix:** add `"i"` to the four `RegExp` constructions. Word-boundary behavior (`email@claude.com` → false) is unchanged. Added test cases for `@Claude` and `@CLAUDE`.

```
$ bun test
665 pass, 0 fail
```