### PR TITLE
feat: add allow_workflow_modifications input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -150,6 +150,10 @@ inputs:
     description: "Newline-separated list of Claude Code plugin marketplace Git URLs to install from (e.g., 'https://github.com/user/marketplace1.git\nhttps://github.com/user/marketplace2.git')"
     required: false
     default: ""
+  allow_workflow_modifications:
+    description: "Allow Claude to modify files in the .github/workflows directory. Only enable when using a github_token with workflows:write permission (e.g., a custom GitHub App token)."
+    required: false
+    default: "false"
 
 outputs:
   execution_file:
@@ -272,6 +276,7 @@ runs:
         BOT_NAME: ${{ inputs.bot_name }}
         TRACK_PROGRESS: ${{ inputs.track_progress }}
         INCLUDE_FIX_LINKS: ${{ inputs.include_fix_links }}
+        ALLOW_WORKFLOW_MODIFICATIONS: ${{ inputs.allow_workflow_modifications }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         CLAUDE_ARGS: ${{ inputs.claude_args }}
         ALL_INPUTS: ${{ toJson(inputs) }}

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -846,7 +846,7 @@ What You CANNOT Do:
 - Post multiple comments (you only update your initial comment)
 - Execute commands outside the repository context${useCommitSigning ? "\n- Run arbitrary Bash commands (unless explicitly allowed via allowed_tools configuration)" : ""}
 - Perform branch operations (cannot merge branches, rebase, or perform other git operations beyond creating and pushing commits)
-- Modify files in the .github/workflows directory (GitHub App permissions do not allow workflow modifications)
+${context.githubContext?.inputs?.allowWorkflowModifications ? "" : "- Modify files in the .github/workflows directory (GitHub App permissions do not allow workflow modifications)\n"}
 
 When users ask you to perform actions you cannot do, politely explain the limitation and, when applicable, direct them to the FAQ for more information and workarounds:
 "I'm unable to [specific action] due to [reason]. You can find more information and potential workarounds in the [FAQ](https://github.com/anthropics/claude-code-action/blob/main/docs/faq.md)."

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -102,6 +102,7 @@ type BaseContext = {
     includeFixLinks: boolean;
     includeCommentsByActor: string;
     excludeCommentsByActor: string;
+    allowWorkflowModifications: boolean;
   };
 };
 
@@ -164,6 +165,8 @@ export function parseGitHubContext(): GitHubContext {
       includeFixLinks: process.env.INCLUDE_FIX_LINKS === "true",
       includeCommentsByActor: process.env.INCLUDE_COMMENTS_BY_ACTOR ?? "",
       excludeCommentsByActor: process.env.EXCLUDE_COMMENTS_BY_ACTOR ?? "",
+      allowWorkflowModifications:
+        process.env.ALLOW_WORKFLOW_MODIFICATIONS === "true",
     },
   };
 

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -43,6 +43,7 @@ describe("prepareMcpConfig", () => {
       includeFixLinks: true,
       includeCommentsByActor: "",
       excludeCommentsByActor: "",
+      allowWorkflowModifications: false,
     },
   };
 

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -30,6 +30,7 @@ const defaultInputs = {
   includeFixLinks: true,
   includeCommentsByActor: "",
   excludeCommentsByActor: "",
+  allowWorkflowModifications: false,
 };
 
 const defaultRepository = {
@@ -64,6 +65,7 @@ export const createMockContext = (
         ...overrides.inputs,
         includeCommentsByActor: overrides.inputs.includeCommentsByActor ?? "",
         excludeCommentsByActor: overrides.inputs.excludeCommentsByActor ?? "",
+        allowWorkflowModifications: overrides.inputs.allowWorkflowModifications ?? false,
       }
     : defaultInputs;
 
@@ -93,6 +95,7 @@ export const createMockAutomationContext = (
         ...overrides.inputs,
         includeCommentsByActor: overrides.inputs.includeCommentsByActor ?? "",
         excludeCommentsByActor: overrides.inputs.excludeCommentsByActor ?? "",
+        allowWorkflowModifications: overrides.inputs.allowWorkflowModifications ?? false,
       }
     : { ...defaultInputs };
 

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -30,6 +30,7 @@ describe("detectMode with enhanced routing", () => {
       includeFixLinks: true,
       includeCommentsByActor: "",
       excludeCommentsByActor: "",
+      allowWorkflowModifications: false,
     },
   };
 

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -78,6 +78,7 @@ describe("checkWritePermissions", () => {
       includeFixLinks: true,
       includeCommentsByActor: "",
       excludeCommentsByActor: "",
+      allowWorkflowModifications: false,
     },
   });
 


### PR DESCRIPTION
## Summary

Add an optional `allow_workflow_modifications` input (defaults to `false`) that removes the prompt-level restriction preventing Claude from modifying `.github/workflows/` files.

## Problem

The system prompt in `generateDefaultPrompt()` unconditionally tells Claude:

> You CANNOT modify files in the .github/workflows directory

This makes sense for Anthropic's hosted GitHub App, but organizations using custom GitHub App tokens with `workflows:write` have no way to lift this restriction. The prompt contradicts the actual token permissions, causing Claude to refuse operations it could successfully perform.

See #1282 for full context.

## Changes

| File | Change |
|------|--------|
| `action.yml` | Add `allow_workflow_modifications` input + pass as env var |
| `src/github/context.ts` | Parse the new input into `BaseContext.inputs` |
| `src/create-prompt/index.ts` | Conditionally omit the workflow restriction line (follows the existing `includeFixLinks` pattern) |
| `test/**` | Add `allowWorkflowModifications: false` to all test fixtures |

## Behavior

- **Default (`false`)**: No change — Claude still sees the "CANNOT modify workflows" instruction
- **`true`**: The restriction line is omitted from the prompt, allowing Claude to modify workflow files if the token permits it

## Testing

- TypeScript typecheck passes (`bun run typecheck`)
- All existing test fixtures updated
- Validated end-to-end at Doctolib: Claude successfully modified a workflow file, committed, and pushed when given `workflows:write` permission

Closes #1282