### PR TITLE
fix: clear stale claude-prompts dir before each write

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import * as core from "@actions/core";
-import { writeFile, mkdir } from "fs/promises";
+import { writeFile, mkdir, rm } from "fs/promises";
 import type { FetchDataResult } from "../github/data/fetcher";
 import {
   formatContext,
@@ -931,9 +931,14 @@ export async function createPrompt(
       claudeBranch,
     );
 
-    await mkdir(`${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts`, {
-      recursive: true,
-    });
+    // Clear any stale prompt files from a prior invocation. RUNNER_TEMP is documented
+    // to be emptied between jobs, but on non-ephemeral self-hosted runners this is
+    // not reliably honored — a stale claude-user-request.txt left behind by a prior
+    // mention-mode invocation would not be overwritten by a subsequent agent-mode
+    // invocation, and would leak into the model's context.
+    const promptDir = `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts`;
+    await rm(promptDir, { recursive: true, force: true });
+    await mkdir(promptDir, { recursive: true });
 
     // Generate the prompt directly
     const promptContent = generatePrompt(
@@ -949,10 +954,7 @@ export async function createPrompt(
     console.log("=======================");
 
     // Write the prompt file
-    await writeFile(
-      `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts/claude-prompt.txt`,
-      promptContent,
-    );
+    await writeFile(`${promptDir}/claude-prompt.txt`, promptContent);
 
     // Extract and write the user request separately for SDK multi-block messaging
     // This allows the CLI to process slash commands (e.g., "@claude /review-pr")
@@ -961,10 +963,7 @@ export async function createPrompt(
       githubData,
     );
     if (userRequest) {
-      await writeFile(
-        `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts/${USER_REQUEST_FILENAME}`,
-        userRequest,
-      );
+      await writeFile(`${promptDir}/${USER_REQUEST_FILENAME}`, userRequest);
       console.log("===== USER REQUEST =====");
       console.log(userRequest);
       console.log("========================");

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "fs/promises";
+import { mkdir, rm, writeFile } from "fs/promises";
 import { prepareMcpConfig } from "../../mcp/install-mcp-server";
 import { parseAllowedTools } from "./parse-tools";
 import {
@@ -64,20 +64,19 @@ export async function prepareAgentMode({
     }
   }
 
-  // Create prompt directory
-  await mkdir(`${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts`, {
-    recursive: true,
-  });
+  // Create prompt directory. Clear any stale files from a prior invocation first —
+  // see src/create-prompt/index.ts for context (non-ephemeral self-hosted runners
+  // do not reliably honor the RUNNER_TEMP cleanup contract).
+  const promptDir = `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts`;
+  await rm(promptDir, { recursive: true, force: true });
+  await mkdir(promptDir, { recursive: true });
 
   // Write the prompt file - use the user's prompt directly
   const promptContent =
     context.inputs.prompt ||
     `Repository: ${context.repository.owner}/${context.repository.repo}`;
 
-  await writeFile(
-    `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts/claude-prompt.txt`,
-    promptContent,
-  );
+  await writeFile(`${promptDir}/claude-prompt.txt`, promptContent);
 
   // Parse allowed tools from user's claude_args
   const userClaudeArgs = process.env.CLAUDE_ARGS || "";


### PR DESCRIPTION
Fixes #1287.

## Problem

`${RUNNER_TEMP}/claude-prompts/` is shared across jobs on non-ephemeral self-hosted runners — the documented `RUNNER_TEMP` cleanup contract is not honored there. In particular, `claude-user-request.txt` is only written by `create-prompt` when a user request exists; in `agent` mode it is left untouched, so a stale value left by an earlier mention-mode job in repo A leaks into a later agent-mode job in repo B running on the same runner agent.

We observed this happen on ~40% of `agent`-mode review jobs landing on an affected runner agent over a 5-day window — every affected review surfaced an unrelated stale question from a much-earlier mention-mode job in another repo.

Issue #1287 has the full reproducer, evidence, and root-cause analysis.

## Fix

Add `await rm(dir, { recursive: true, force: true })` before each `await mkdir(...)` in both write sites:

- `src/create-prompt/index.ts` (tag/comment mode — writes `claude-prompt.txt` and `claude-user-request.txt`)
- `src/modes/agent/index.ts` (agent mode — writes `claude-prompt.txt`)

Each invocation now starts with a guaranteed-clean directory.

Side effect: extracted the shared path into a `promptDir` local in both files, eliminating four duplicated `\${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts` literals.

## Why this approach

Considered alternatives (per #1287):

1. Per-invocation subdirectory keyed by `${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${GITHUB_JOB}`.  
   Cleaner isolation but requires changes at every consumer (`src/entrypoints/run.ts:269` reads `${RUNNER_TEMP}/claude-prompts/claude-prompt.txt`), bigger blast radius.
2. **Cleanup at the start (this PR).** One-line guard, idempotent, no consumer changes, handles every existing and future file in the directory uniformly.
3. Always-write `claude-user-request.txt` (sentinel). Fixes the specific leak but leaves the general cross-job staleness intact for any future file added to the directory.

Option 2 is the smallest, least invasive change and self-heals on every invocation.

## Tests

The fs writes here are not covered by existing tests (`test/create-prompt.test.ts`, `test/modes/agent.test.ts` neither mock nor exercise the mkdir/writeFile path). I did not add new tests to keep the patch focused; happy to add an integration-style test that:
- creates a stale `claude-user-request.txt` in `RUNNER_TEMP/claude-prompts/` 
- runs through `createPrompt` with a context that does not produce a user request
- asserts the stale file is gone after invocation

— if reviewers want it.

## Verification

Manual reproducer from #1287 was used to confirm the leak exists on v1.0.67. After applying this patch in a downstream wrapping composite (mirroring the same `rm`-then-`mkdir` shape via shell), the leak no longer manifests.