### PR TITLE
Include labels in formatContext() output for issues and PRs

### DIFF
--- a/src/github/api/queries/github.ts
+++ b/src/github/api/queries/github.ts
@@ -25,7 +25,7 @@ export const PR_QUERY = `
         additions
         deletions
         state
-        labels(first: 1) {
+        labels(first: 100) {
           nodes {
             name
           }
@@ -113,7 +113,7 @@ export const ISSUE_QUERY = `
         updatedAt
         lastEditedAt
         state
-        labels(first: 1) {
+        labels(first: 100) {
           nodes {
             name
           }

--- a/src/github/data/formatter.ts
+++ b/src/github/data/formatter.ts
@@ -8,6 +8,11 @@ import type {
 import type { GitHubFileWithSHA } from "./fetcher";
 import { sanitizeContent } from "../utils/sanitizer";
 
+function formatLabels(labelNodes: Array<{ name: string }>): string {
+  if (labelNodes.length === 0) return "none";
+  return labelNodes.map((l) => l.name).join(", ");
+}
+
 export function formatContext(
   contextData: GitHubPullRequest | GitHubIssue,
   isPR: boolean,
@@ -19,6 +24,7 @@ export function formatContext(
 PR Author: ${prData.author.login}
 PR Branch: ${prData.headRefName} -> ${prData.baseRefName}
 PR State: ${prData.state}
+PR Labels: ${formatLabels(prData.labels.nodes)}
 PR Additions: ${prData.additions}
 PR Deletions: ${prData.deletions}
 Total Commits: ${prData.commits.totalCount}
@@ -28,7 +34,8 @@ Changed Files: ${prData.files.nodes.length} files`;
     const sanitizedTitle = sanitizeContent(issueData.title);
     return `Issue Title: ${sanitizedTitle}
 Issue Author: ${issueData.author.login}
-Issue State: ${issueData.state}`;
+Issue State: ${issueData.state}
+Issue Labels: ${formatLabels(issueData.labels.nodes)}`;
   }
 }
 

--- a/test/data-formatter.test.ts
+++ b/test/data-formatter.test.ts
@@ -54,6 +54,53 @@ describe("formatContext", () => {
 PR Author: test-user
 PR Branch: feature/test -> main
 PR State: OPEN
+PR Labels: none
+PR Additions: 50
+PR Deletions: 30
+Total Commits: 3
+Changed Files: 2 files`,
+    );
+  });
+
+  test("formats PR context with labels", () => {
+    const prData: GitHubPullRequest = {
+      title: "Test PR",
+      body: "PR body",
+      author: { login: "test-user" },
+      baseRefName: "main",
+      headRefName: "feature/test",
+      headRefOid: "abc123",
+      isCrossRepository: false,
+      headRepository: { owner: { login: "testowner" }, name: "testrepo" },
+      createdAt: "2023-01-01T00:00:00Z",
+      additions: 50,
+      deletions: 30,
+      state: "OPEN",
+      labels: {
+        nodes: [{ name: "bug" }, { name: "enhancement" }],
+      },
+      commits: {
+        totalCount: 3,
+        nodes: [],
+      },
+      files: {
+        nodes: [{} as GitHubFile, {} as GitHubFile],
+      },
+      comments: {
+        nodes: [],
+      },
+      reviews: {
+        nodes: [],
+      },
+    };
+
+    const result = formatContext(prData, true);
+    expect(result).toBe(
+      `PR Title: Test PR
+PR Author: test-user
+PR Branch: feature/test -> main
+PR State: OPEN
+PR Labels: bug, enhancement
 PR Additions: 50
 PR Deletions: 30
 Total Commits: 3
@@ -80,7 +127,36 @@ Changed Files: 2 files`,
     expect(result).toBe(
       `Issue Title: Test Issue
 Issue Author: test-user
-Issue State: OPEN`,
+Issue State: OPEN
+Issue Labels: none`,
+    );
+  });
+
+  test("formats Issue context with labels", () => {
+    const issueData: GitHubIssue = {
+      title: "Test Issue",
+      body: "Issue body",
+      author: { login: "test-user" },
+      createdAt: "2023-01-01T00:00:00Z",
+      state: "OPEN",
+      labels: {
+        nodes: [
+          { name: "architecture" },
+          { name: "agent-sdk" },
+          { name: "drift:functional" },
+        ],
+      },
+      comments: {
+        nodes: [],
+      },
+    };
+
+    const result = formatContext(issueData, false);
+    expect(result).toBe(
+      `Issue Title: Test Issue
+Issue Author: test-user
+Issue State: OPEN
+Issue Labels: architecture, agent-sdk, drift:functional`,
     );
   });
 });


### PR DESCRIPTION
## Summary

The \`<formatted_context>\` block sent to the agent currently omits labels for both issues and pull requests, even though the GraphQL queries already fetch them. This causes agents to confidently report "no labels" on issues that have labels — a real foot-gun for workflows that route on label state (e.g., drift-fix routing on \`drift:*\` labels).

This PR fixes both halves of the gap:

1. **\`formatContext()\` now emits a \`Labels:\` line** for both PR and Issue branches, in line with existing fields (Title, Author, State). Emits \`none\` when there are no labels rather than omitting the line — explicit > silent.
2. **GraphQL queries bumped from \`labels(first: 1)\` → \`labels(first: 100)\`** in both \`PULL_REQUEST_QUERY\` and \`ISSUE_QUERY\`. The previous cap meant only one label would ever surface even after the formatter fix. \`first: 100\` matches the convention used for \`comments(first: 100)\` and \`commits(first: 100)\` in the same queries.

## Discovery context

Found while setting up an internal seed-framework repo that uses this action for drift-watcher routing. The agent was repeatedly asserting \"no labels\" on a labeled issue. I asked it to inspect this action's source code from \`/home/runner/work/_actions/anthropics/claude-code-action/v1/\` — it identified \`formatContext()\` and the GraphQL pagination cap on its own. A satisfying full-loop debugging session.

After this fix lands, the workaround in our workflow (telling the agent to explicitly fetch labels via \`gh issue view --json labels\` in the system prompt) can be removed.

## Test plan

- [x] \`bun test\` — 667 pass / 0 fail (was 665; added 2 new tests covering the \"with labels\" case for both PR and Issue branches)
- [x] \`bun run typecheck\` — clean
- [x] \`bun run format:check\` — clean
- [x] Updated existing \`formatContext\` tests to expect the new \`Labels: none\` line

## Output sample

Before, for a labeled issue:

\`\`\`
Issue Title: My Issue
Issue Author: someone
Issue State: OPEN
\`\`\`

After:

\`\`\`
Issue Title: My Issue
Issue Author: someone
Issue State: OPEN
Issue Labels: architecture, agent-sdk, drift:functional
\`\`\`

For unlabeled issues:

\`\`\`
Issue Title: My Issue
Issue Author: someone
Issue State: OPEN
Issue Labels: none
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)