### PR TITLE
chore: bump pinned Bun to 1.3.14

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -175,7 +175,7 @@ runs:
       if: inputs.path_to_bun_executable == ''
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
       with:
-        bun-version: 1.3.6
+        bun-version: 1.3.14
         token: ${{ inputs.github_token || github.token }}
 
     - name: Setup Custom Bun Path

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -99,7 +99,7 @@ runs:
       if: inputs.path_to_bun_executable == ''
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
       with:
-        bun-version: 1.3.6
+        bun-version: 1.3.14
 
     - name: Setup Custom Bun Path
       if: inputs.path_to_bun_executable != ''

--- a/src/github/validation/actor.ts
+++ b/src/github/validation/actor.ts
@@ -60,9 +60,7 @@ export async function checkHumanActor(
       (error.message.includes("Not Found") ||
         error.message.includes("is not a user"))
     ) {
-      const botName = githubContext.actor
-        .toLowerCase()
-        .replace(/\[bot\]$/, "");
+      const botName = githubContext.actor.toLowerCase().replace(/\[bot\]$/, "");
       throw new Error(
         `Workflow initiated by non-human actor: ${botName} (actor not found on GitHub). Add bot to allowed_bots list or use '*' to allow all bots.`,
       );

--- a/src/github/validation/permissions.ts
+++ b/src/github/validation/permissions.ts
@@ -102,10 +102,7 @@ export async function checkWritePermissions(
     // Handle 404 errors for non-user actors (e.g. GitHub Apps like Copilot
     // whose GITHUB_ACTOR doesn't end with [bot]).
     // The collaborator permission API only works for user accounts.
-    if (
-      error instanceof Error &&
-      error.message.includes("is not a user")
-    ) {
+    if (error instanceof Error && error.message.includes("is not a user")) {
       core.info(
         `Actor ${actor} is not a GitHub user (likely a GitHub App). Checking allowed_bots...`,
       );

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -309,17 +309,18 @@ describe("checkWritePermissions", () => {
     // end with [bot] and is not a valid GitHub user, so the collaborator
     // permission API returns 404 with "is not a user".
 
-    const createMockOctokitThat404s = () => ({
-      repos: {
-        getCollaboratorPermissionLevel: async () => {
-          const err = new Error(
-            "HttpError: Copilot is not a user - https://docs.github.com/rest/collaborators/collaborators#get-repository-permissions-for-a-user",
-          );
-          (err as any).status = 404;
-          throw err;
+    const createMockOctokitThat404s = () =>
+      ({
+        repos: {
+          getCollaboratorPermissionLevel: async () => {
+            const err = new Error(
+              "HttpError: Copilot is not a user - https://docs.github.com/rest/collaborators/collaborators#get-repository-permissions-for-a-user",
+            );
+            (err as any).status = 404;
+            throw err;
+          },
         },
-      },
-    } as any);
+      }) as any;
 
     test("should return true for non-[bot] actor in allowed_bots (pre-API check)", async () => {
       // The allowed_bots check should happen BEFORE calling the API,


### PR DESCRIPTION
## Summary

Bumps the pinned Bun runtime from **1.3.6** to **1.3.14** in both `action.yml` and `base-action/action.yml`. The `oven-sh/setup-bun` action SHA (v2.2.0) is unchanged.

## Why

Bun 1.3.6 shipped an upstream `cpSync`/symlink regression that produces an action-breaking `ENOENT` crash, and is also implicated in a recurring `Internal error: directory mismatch for ... tsconfig.json` failure. The upstream fix landed in Bun 1.3.14 (the latest stable 1.3.x release).

This change:

- Should resolve #1311 at the root (the `cpSync`/symlink `ENOENT` crash).
- Is the most likely lever on the "directory mismatch for ... tsconfig.json" reports (#1266, #1295, #1234) — likely addresses them, though not guaranteed since those reports may have multiple contributing factors.

## Scope

The Bun bump itself is just the two pinned `bun-version:` values — no dependency, lockfile, or other source changes. `@types/bun` was left as-is — typecheck and the test suite pass without bumping it.

This PR also folds in a small prettier fix (separate `style:` commit) for `src/github/validation/actor.ts`, `src/github/validation/permissions.ts`, and `test/permissions.test.ts`. These files landed unformatted via the #1144 merge and were already failing `format:check` on `main`. Including the fix here keeps this PR's CI green and merging it restores `main`'s format check to passing.
