### PR TITLE
Drop --tsconfig-override from Bun invocations to avoid runtime crash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -241,9 +241,13 @@ runs:
       id: run
       shell: bash
       run: |
+        # Do NOT pass --tsconfig-override here. It triggers a Bun runtime bug
+        # ("Internal error: directory mismatch for directory .../tsconfig.json")
+        # that aborts the run with exit code 1. Bun already auto-discovers the
+        # action's own tsconfig.json by walking up from the entry file, so the
+        # override is redundant. See oven-sh/bun#25730.
         bun --no-env-file \
           --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
-          --tsconfig-override="${GITHUB_ACTION_PATH}/tsconfig.json" \
           run ${GITHUB_ACTION_PATH}/src/entrypoints/run.ts
       env:
         # Prepare inputs
@@ -378,9 +382,9 @@ runs:
       run: |
         BUN_BIN="${GITHUB_ACTION_PATH}/bin/bun"
         [ -x "$BUN_BIN" ] || BUN_BIN="bun"
+        # No --tsconfig-override: see the "Run Claude Code Action" step above.
         "$BUN_BIN" --no-env-file \
           --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
-          --tsconfig-override="${GITHUB_ACTION_PATH}/tsconfig.json" \
           run ${GITHUB_ACTION_PATH}/src/entrypoints/cleanup-ssh-signing.ts
 
     - name: Post buffered inline comments
@@ -395,9 +399,9 @@ runs:
       run: |
         BUN_BIN="${GITHUB_ACTION_PATH}/bin/bun"
         [ -x "$BUN_BIN" ] || BUN_BIN="bun"
+        # No --tsconfig-override: see the "Run Claude Code Action" step above.
         "$BUN_BIN" --no-env-file \
           --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
-          --tsconfig-override="${GITHUB_ACTION_PATH}/tsconfig.json" \
           run ${GITHUB_ACTION_PATH}/src/entrypoints/post-buffered-inline-comments.ts
 
     - name: Revoke app token

--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -395,7 +395,7 @@ function getCommitInstructions(
   useCommitSigning: boolean,
 ): string {
   const coAuthorLine =
-    ((githubData.triggerDisplayName ?? context.triggerUsername) !== "Unknown")
+    (githubData.triggerDisplayName ?? context.triggerUsername) !== "Unknown"
       ? `Co-authored-by: ${githubData.triggerDisplayName ?? context.triggerUsername} <${context.triggerUsername}@users.noreply.github.com>`
       : "";
 


### PR DESCRIPTION
## Summary

Removes the `--tsconfig-override` flag from the three `bun run` invocations in `action.yml`.

## Problem

Passing `--tsconfig-override` to `bun run` triggers a Bun runtime bug that logs:

    Internal error: directory mismatch for directory
    ".../claude-code-action/<ref>/tsconfig.json", fd 4.
    You don't need to do anything, but this indicates a bug.

For some users this is a harmless stderr warning; for others it aborts the action with exit code 1 before any work is done. The same SHA can succeed on one run and fail on the next.

Upstream tracking: oven-sh/bun#25730

## Why dropping the flag is safe

Bun auto-discovers `tsconfig.json` by walking up the directory tree from the **entry file** (not from CWD). All three entrypoints live under `${GITHUB_ACTION_PATH}/src/entrypoints/`, so the walk always lands on the action's own `tsconfig.json`. The user's workspace tsconfig is never an ancestor of the `_actions/` checkout, so it cannot interfere.

`base-action/action.yml` already invokes `bun run` without this flag — this brings the main `action.yml` in line.

## Verification

Reproduced with Bun 1.3.11:
- With `--tsconfig-override` → emits the "directory mismatch" error
- Without it → clean, and tsconfig still resolves correctly (verified with a hostile workspace tsconfig in CWD)

Fixes #1266
Fixes #1246
Fixes #1205