### PR TITLE
Fix prettier formatting in create-prompt

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -395,7 +395,7 @@ function getCommitInstructions(
   useCommitSigning: boolean,
 ): string {
   const coAuthorLine =
-    ((githubData.triggerDisplayName ?? context.triggerUsername) !== "Unknown")
+    (githubData.triggerDisplayName ?? context.triggerUsername) !== "Unknown"
       ? `Co-authored-by: ${githubData.triggerDisplayName ?? context.triggerUsername} <${context.triggerUsername}@users.noreply.github.com>`
       : "";
 


### PR DESCRIPTION
## Summary
- Remove redundant parentheses in `getCommitInstructions` to satisfy prettier (`bun run format:check` was failing on main).

## Test plan
- [ ] `bun run format:check` passes