### PR TITLE
fix: URL-encode branch names in GitHub API calls

### DIFF
--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -16,6 +16,7 @@ import type { ParsedGitHubContext } from "../github/context";
 import { GITHUB_SERVER_URL } from "../github/api/config";
 import { checkAndCommitOrDeleteBranch } from "../github/operations/branch-cleanup";
 import { updateClaudeComment } from "../github/operations/comments/update-claude-comment";
+import { encodeBranchNameForAPI } from "../github/operations/branch";
 
 export type UpdateCommentLinkParams = {
   commentId: number;
@@ -136,7 +137,7 @@ export async function updateCommentLink(
           await octokit.rest.repos.compareCommitsWithBasehead({
             owner,
             repo,
-            basehead: `${baseBranch}...${claudeBranch}`,
+            basehead: `${encodeBranchNameForAPI(baseBranch)}...${encodeBranchNameForAPI(claudeBranch)}`,
           });
 
         // If there are changes (commits or file changes), add the PR URL

--- a/src/github/operations/branch-cleanup.ts
+++ b/src/github/operations/branch-cleanup.ts
@@ -1,6 +1,7 @@
 import type { Octokits } from "../api/client";
 import { GITHUB_SERVER_URL } from "../api/config";
 import { $ } from "bun";
+import { encodeBranchNameForAPI } from "./branch";
 
 export async function checkAndCommitOrDeleteBranch(
   octokit: Octokits,
@@ -20,7 +21,7 @@ export async function checkAndCommitOrDeleteBranch(
       await octokit.rest.repos.getBranch({
         owner,
         repo,
-        branch: claudeBranch,
+        branch: encodeBranchNameForAPI(claudeBranch),
       });
       branchExistsRemotely = true;
     } catch (error: any) {
@@ -45,7 +46,7 @@ export async function checkAndCommitOrDeleteBranch(
         await octokit.rest.repos.compareCommitsWithBasehead({
           owner,
           repo,
-          basehead: `${baseBranch}...${claudeBranch}`,
+          basehead: `${encodeBranchNameForAPI(baseBranch)}...${encodeBranchNameForAPI(claudeBranch)}`,
         });
 
       // If there are no commits, check for uncommitted changes if not using commit signing
@@ -119,7 +120,7 @@ export async function checkAndCommitOrDeleteBranch(
       await octokit.rest.git.deleteRef({
         owner,
         repo,
-        ref: `heads/${claudeBranch}`,
+        ref: `heads/${encodeBranchNameForAPI(claudeBranch)}`,
       });
       console.log(`✅ Deleted empty branch: ${claudeBranch}`);
     } catch (deleteError) {

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -115,6 +115,18 @@ export function validateBranchName(branchName: string): void {
 }
 
 /**
+ * Encodes a branch name for use in GitHub API URLs.
+ * The GitHub API expects branch names in URL paths to be properly encoded.
+ * Special characters like # (fragment separator) must be percent-encoded.
+ *
+ * @param branchName - The branch name to encode
+ * @returns The URL-encoded branch name
+ */
+export function encodeBranchNameForAPI(branchName: string): string {
+  return encodeURIComponent(branchName);
+}
+
+/**
  * Executes a git command safely using execFileSync to avoid shell interpolation.
  *
  * Security: execFileSync passes arguments directly to the git binary without
@@ -228,7 +240,7 @@ export async function setupBranch(
     const sourceBranchRef = await octokits.rest.git.getRef({
       owner,
       repo,
-      ref: `heads/${sourceBranch}`,
+      ref: `heads/${encodeBranchNameForAPI(sourceBranch)}`,
     });
 
     sourceSHA = sourceBranchRef.data.object.sha;

--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -54,6 +54,14 @@ const server = new McpServer({
   version: "0.0.1",
 });
 
+/**
+ * Encodes a branch name for use in GitHub API URLs.
+ * Special characters like # (fragment separator) must be percent-encoded.
+ */
+function encodeBranchNameForAPI(branchName: string): string {
+  return encodeURIComponent(branchName);
+}
+
 // Helper function to get or create branch reference
 async function getOrCreateBranchRef(
   owner: string,
@@ -62,7 +70,7 @@ async function getOrCreateBranchRef(
   githubToken: string,
 ): Promise<string> {
   // Try to get the branch reference
-  const refUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`;
+  const refUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${encodeBranchNameForAPI(branch)}`;
   const refResponse = await fetch(refUrl, {
     headers: {
       Accept: "application/vnd.github+json",
@@ -83,7 +91,7 @@ async function getOrCreateBranchRef(
   const baseBranch = process.env.BASE_BRANCH!;
 
   // Get the SHA of the base branch
-  const baseRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${baseBranch}`;
+  const baseRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${encodeBranchNameForAPI(baseBranch)}`;
   const baseRefResponse = await fetch(baseRefUrl, {
     headers: {
       Accept: "application/vnd.github+json",
@@ -115,7 +123,7 @@ async function getOrCreateBranchRef(
     const defaultBranch = repoData.default_branch;
 
     // Try default branch
-    const defaultRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${defaultBranch}`;
+    const defaultRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${encodeBranchNameForAPI(defaultBranch)}`;
     const defaultRefResponse = await fetch(defaultRefUrl, {
       headers: {
         Accept: "application/vnd.github+json",
@@ -365,7 +373,7 @@ server.tool(
       const newCommitData = (await newCommitResponse.json()) as GitHubNewCommit;
 
       // 6. Update the reference to point to the new commit
-      const updateRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`;
+      const updateRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${encodeBranchNameForAPI(branch)}`;
 
       // We're seeing intermittent 403 "Resource not accessible by integration" errors
       // on certain repos when updating git references. These appear to be transient
@@ -580,7 +588,7 @@ server.tool(
       const newCommitData = (await newCommitResponse.json()) as GitHubNewCommit;
 
       // 6. Update the reference to point to the new commit
-      const updateRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`;
+      const updateRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${encodeBranchNameForAPI(branch)}`;
 
       // We're seeing intermittent 403 "Resource not accessible by integration" errors
       // on certain repos when updating git references. These appear to be transient


### PR DESCRIPTION
Branch names containing special characters like # were failing when used in GitHub API calls because these characters have special meaning in URLs. The API would interpret # as a fragment separator, truncating the branch name and causing 404 errors. This fix introduces `encodeBranchNameForAPI` that wraps `encodeURIComponent` to properly percent-encode branch names before they are used in API paths. The function is applied in `branch.ts`, `branch-cleanup.ts`, `update-comment-link.ts`, and `github-file-ops-server.ts` wherever branch names are inserted into API URLs. Operations like getting branch refs, comparing commits, deleting branches, and updating refs now handle special characters correctly.

Fixes #1314
