### PR TITLE
fix: preserve symlinks in .config/ during restore to prevent ENOENT on dangling links

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -86,7 +86,7 @@ export function restoreConfigFromBase(baseBranch: string): void {
   rmSync(".claude-pr", { recursive: true, force: true });
   for (const p of SENSITIVE_PATHS) {
     if (existsSync(p)) {
-      cpSync(p, `.claude-pr/${p}`, { recursive: true, dereference: true });
+      cpSync(p, `.claude-pr/${p}`, { recursive: true, dereference: false });
     }
   }
   if (existsSync(".claude-pr")) {

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -134,6 +134,27 @@ describe("restoreConfigFromBase", () => {
     expect(countClaudePrExcludeEntries()).toBe(1);
   });
 
+  test("handles dangling symlinks in .claude/ without crashing", () => {
+    const skillsDir = join(repoDir, ".claude/skills");
+    mkdirSync(skillsDir, { recursive: true });
+
+    // Create a symlink pointing to a non-existent file (simulating a dependency
+    // directory that hasn't been installed yet)
+    execFileSync("ln", ["-s", "../../vendor/package/.claude/skills/check", join(skillsDir, "check")], {
+      cwd: repoDir,
+      stdio: "pipe",
+    });
+
+    git(["add", ".claude/skills/check"]);
+    git(["commit", "-m", "add dangling symlink"]);
+
+    // This should not throw ENOENT
+    expect(() => restoreConfigFromBase("main")).not.toThrow();
+
+    // Verify the symlink was preserved in .claude-pr/
+    expect(existsRepoFile(".claude-pr/.claude/skills/check")).toBe(true);
+  });
+
   function git(args: string[]): string {
     return execFileSync("git", args, {
       cwd: repoDir,


### PR DESCRIPTION
The `restoreConfigFromBase` function crashes with ENOENT when `.config/` contains symlinks pointing to files that don't exist yet (e.g., symlinks into dependency directories before installation).

The root cause is on line 89 of `src/github/operations/restore-config.ts`, where `cpSync` is called with `dereference: true`. This option forces Node.js to follow symlinks and stat their targets, causing the copy operation to fail when the target doesn't exist.

The fix changes `dereference: true` to `dereference: false`, which preserves symlinks as-is without attempting to resolve them. This allows dangling symlinks in `.config/` to be copied to `.config-pr/` and later restored from the base branch without crashing. The symlinks can resolve naturally after dependency installation later in the workflow.

A regression test was added to verify that dangling symlinks in `.config/skills/` no longer cause the restore step to crash.

Fixes #1321