### PR TITLE
fix: warn on yaml list markers in claude args

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -1,3 +1,4 @@
+import * as core from "@actions/core";
 import { parse as parseShellArgs } from "shell-quote";
 import type { ClaudeOptions } from "./run-claude";
 import type { Options as SdkOptions } from "@anthropic-ai/claude-agent-sdk";
@@ -106,6 +107,7 @@ function parseClaudeArgsToExtraArgs(
   if (!claudeArgs?.trim()) return {};
 
   const result: Record<string, string | null> = {};
+  let warnedAboutYamlListMarker = false;
   const args = parseShellArgs(stripShellComments(claudeArgs)).filter(
     (arg): arg is string => typeof arg === "string",
   );
@@ -124,6 +126,15 @@ function parseClaudeArgsToExtraArgs(
           const values: string[] = [];
           while (i + 1 < args.length && !args[i + 1]?.startsWith("--")) {
             i++;
+            if (args[i] === "-") {
+              if (!warnedAboutYamlListMarker) {
+                core.warning(
+                  "Detected '-' list markers in claude_args. Remove '-' list markers when using a multiline string; pass Claude CLI flags and values directly.",
+                );
+                warnedAboutYamlListMarker = true;
+              }
+              continue;
+            }
             values.push(args[i]!);
           }
           const joinedValues = values.join(ACCUMULATE_DELIMITER);

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -1,10 +1,18 @@
 #!/usr/bin/env bun
 
-import { describe, test, expect } from "bun:test";
+import * as core from "@actions/core";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { parseSdkOptions } from "../src/parse-sdk-options";
 import type { ClaudeOptions } from "../src/run-claude";
 
 describe("parseSdkOptions", () => {
+  let warningSpy: ReturnType<typeof spyOn> | undefined;
+
+  afterEach(() => {
+    warningSpy?.mockRestore();
+    warningSpy = undefined;
+  });
+
   describe("allowedTools merging", () => {
     test("should extract allowedTools from claudeArgs", () => {
       const options: ClaudeOptions = {
@@ -149,6 +157,27 @@ describe("parseSdkOptions", () => {
       expect(result.sdkOptions.allowedTools).toContain("Read");
       expect(result.sdkOptions.allowedTools).toContain("Write");
       expect(result.sdkOptions.allowedTools).toContain("Glob");
+    });
+
+    test("should warn and ignore YAML list markers in multiline allowed-tools", () => {
+      warningSpy = spyOn(core, "warning").mockImplementation(() => {});
+      const options: ClaudeOptions = {
+        claudeArgs: `
+          --allowed-tools
+          - 'Bash(pnpm install)'
+          - 'Bash(pnpm test)'
+        `,
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.allowedTools).toEqual([
+        "Bash(pnpm install)",
+        "Bash(pnpm test)",
+      ]);
+      expect(warningSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Remove '-' list markers"),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- warn when claude_args contains '-' YAML list markers inside an accumulated flag value
- ignore those marker tokens so they are not passed as allowed tools
- add parser coverage for the multiline allowed-tools mistake from #242

Part of #242. This intentionally avoids the settings JSON parsing path because #1273 already covers that area.

## Testing
- bun test ./test/parse-sdk-options.test.ts
- bun test
- bun run typecheck
- bun run format:check
- git diff --check