### PR TITLE
fix: configure git auth before tag branch setup

### DIFF
--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -62,10 +62,7 @@ export async function prepareTagMode({
     excludeCommentsByActor: context.inputs.excludeCommentsByActor,
   });
 
-  // Setup branch
-  const branchInfo = await setupBranch(octokit, githubData, context);
-
-  // Configure git authentication
+  // Configure git authentication before setupBranch, which may fetch from origin.
   // SSH signing takes precedence if provided
   const useSshSigning = !!context.inputs.sshSigningKey;
   const useApiCommitSigning = context.inputs.useCommitSigning && !useSshSigning;
@@ -99,6 +96,9 @@ export async function prepareTagMode({
       throw error;
     }
   }
+
+  // Setup branch
+  const branchInfo = await setupBranch(octokit, githubData, context);
 
   // Create prompt file
   await createPrompt(

--- a/test/modes/tag.test.ts
+++ b/test/modes/tag.test.ts
@@ -1,8 +1,78 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { prepareTagMode } from "../../src/modes/tag";
+import { mockIssueCommentContext } from "../mockContext";
+import * as actorValidation from "../../src/github/validation/actor";
+import * as comments from "../../src/github/operations/comments/create-initial";
+import * as dataFetcher from "../../src/github/data/fetcher";
+import * as branchOps from "../../src/github/operations/branch";
+import * as gitConfig from "../../src/github/operations/git-config";
+import * as prompt from "../../src/create-prompt";
+import * as mcp from "../../src/mcp/install-mcp-server";
 
 describe("Tag Mode", () => {
+  let spies: { mockRestore: () => void }[] = [];
+
+  beforeEach(() => {
+    delete process.env.CLAUDE_ARGS;
+  });
+
+  afterEach(() => {
+    for (const spy of spies) {
+      spy.mockRestore();
+    }
+    spies = [];
+    delete process.env.CLAUDE_ARGS;
+  });
+
   test("prepareTagMode is exported as a function", () => {
     expect(typeof prepareTagMode).toBe("function");
+  });
+
+  test("configures git auth before branch setup fetches from origin", async () => {
+    const calls: string[] = [];
+
+    spies.push(
+      spyOn(actorValidation, "checkHumanActor").mockImplementation(
+        async () => {},
+      ),
+      spyOn(comments, "createInitialComment").mockImplementation(
+        async () => ({ id: 123 }) as any,
+      ),
+      spyOn(dataFetcher, "fetchGitHubData").mockImplementation(async () => ({
+        contextData: {
+          title: "Issue title",
+          body: "",
+          labels: { nodes: [] },
+        } as any,
+        comments: [],
+        changedFiles: [],
+        changedFilesWithSHA: [],
+        reviewData: null,
+        imageUrlMap: new Map(),
+      })),
+      spyOn(gitConfig, "configureGitAuth").mockImplementation(async () => {
+        calls.push("auth");
+      }),
+      spyOn(branchOps, "setupBranch").mockImplementation(async () => {
+        calls.push("branch");
+        return {
+          baseBranch: "main",
+          claudeBranch: "claude/issue-1",
+          currentBranch: "claude/issue-1",
+        };
+      }),
+      spyOn(prompt, "createPrompt").mockImplementation(async () => {}),
+      spyOn(mcp, "prepareMcpConfig").mockImplementation(async () =>
+        JSON.stringify({ mcpServers: {} }),
+      ),
+    );
+
+    await prepareTagMode({
+      context: mockIssueCommentContext,
+      octokit: {} as any,
+      githubToken: "test-token",
+    });
+
+    expect(calls).toEqual(["auth", "branch"]);
   });
 });


### PR DESCRIPTION
## Summary
- configure tag-mode git authentication before `setupBranch()` performs any `git fetch origin ...`
- keep the existing signing/API-signing branch behavior otherwise unchanged
- add a regression test that asserts auth setup runs before branch setup

Fixes #1236.

## Validation
- `bun test test/modes/tag.test.ts`
- `bun run typecheck`
- `npx prettier --check src/modes/tag/index.ts test/modes/tag.test.ts`

Note: full `bun test` was attempted locally on Windows after installing dependencies via npm fallback because `bun install` failed with `EINVAL: Invalid argument (NtSetInformationFile())`; the full suite has existing Windows-specific symlink/path/0600-mode/image fixture failures unrelated to this tag-mode change. The targeted test and typecheck pass locally.