### PR TITLE
fix: skip self-triggered bot PR runs

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -26,6 +26,7 @@ import type { GitHubContext } from "../github/context";
 import { detectMode } from "../modes/detector";
 import { prepareTagMode } from "../modes/tag";
 import { prepareAgentMode } from "../modes/agent";
+import { SelfTriggeringBotSkipError } from "../github/validation/actor";
 import { checkContainsTrigger } from "../github/validation/trigger";
 import { restoreConfigFromBase } from "../github/operations/restore-config";
 import { validateBranchName } from "../github/operations/branch";
@@ -43,6 +44,10 @@ import { preparePrompt } from "../../base-action/src/prepare-prompt";
 import { runClaude } from "../../base-action/src/run-claude";
 import type { ClaudeRunResult } from "../../base-action/src/run-claude-sdk";
 import { setExecutionFileOutputIfPresent } from "../../base-action/src/execution-file";
+
+type PrepareResult =
+  | Awaited<ReturnType<typeof prepareTagMode>>
+  | Awaited<ReturnType<typeof prepareAgentMode>>;
 
 /**
  * Install Claude Code CLI, handling retry logic and custom executable paths.
@@ -215,10 +220,21 @@ async function run() {
     console.log(
       `Preparing with mode: ${modeName} for event: ${context.eventName}`,
     );
-    const prepareResult =
-      modeName === "tag"
-        ? await prepareTagMode({ context, octokit, githubToken })
-        : await prepareAgentMode({ context, octokit, githubToken });
+    let prepareResult: PrepareResult;
+    try {
+      prepareResult =
+        modeName === "tag"
+          ? await prepareTagMode({ context, octokit, githubToken })
+          : await prepareAgentMode({ context, octokit, githubToken });
+    } catch (error) {
+      if (error instanceof SelfTriggeringBotSkipError) {
+        console.log(error.message);
+        core.setOutput("github_token", githubToken);
+        core.setOutput("conclusion", "skipped");
+        return;
+      }
+      throw error;
+    }
 
     commentId = prepareResult.commentId;
     claudeBranch = prepareResult.branchInfo.claudeBranch;

--- a/src/github/validation/actor.ts
+++ b/src/github/validation/actor.ts
@@ -8,6 +8,15 @@
 import type { Octokit } from "@octokit/rest";
 import type { GitHubContext } from "../context";
 
+export class SelfTriggeringBotSkipError extends Error {
+  constructor(actor: string) {
+    super(
+      `Workflow triggered by ${actor}'s own pull_request synchronize event; skipping to avoid a bot feedback loop.`,
+    );
+    this.name = "SelfTriggeringBotSkipError";
+  }
+}
+
 function isAllowedBot(actor: string, allowedBots: string): boolean {
   const trimmed = allowedBots.trim();
   if (trimmed === "*") return true;
@@ -25,6 +34,24 @@ function isAllowedBot(actor: string, allowedBots: string): boolean {
 
   const normalizedActor = actor.toLowerCase().replace(/\[bot\]$/, "");
   return allowedList.includes(normalizedActor);
+}
+
+function normalizeBotName(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/\[bot\]$/, "");
+}
+
+function isConfiguredBotPullRequestSync(
+  actor: string,
+  githubContext: GitHubContext,
+): boolean {
+  return (
+    githubContext.eventName === "pull_request" &&
+    githubContext.eventAction === "synchronize" &&
+    normalizeBotName(actor) === normalizeBotName(githubContext.inputs.botName)
+  );
 }
 
 export async function checkHumanActor(
@@ -57,6 +84,9 @@ export async function checkHumanActor(
         );
         return;
       }
+      if (isConfiguredBotPullRequestSync(actor, githubContext)) {
+        throw new SelfTriggeringBotSkipError(actor);
+      }
       const botName = actor.toLowerCase().replace(/\[bot\]$/, "");
       throw new Error(
         `Workflow initiated by non-human actor: ${botName} (actor not found on GitHub). Add bot to allowed_bots list or use '*' to allow all bots.`,
@@ -74,6 +104,9 @@ export async function checkHumanActor(
         `Actor ${actor} is in allowed_bots list, skipping human actor check`,
       );
       return;
+    }
+    if (isConfiguredBotPullRequestSync(actor, githubContext)) {
+      throw new SelfTriggeringBotSkipError(actor);
     }
     const botName = actor.toLowerCase().replace(/\[bot\]$/, "");
     throw new Error(

--- a/test/actor.test.ts
+++ b/test/actor.test.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env bun
 
 import { describe, test, expect } from "bun:test";
-import { checkHumanActor } from "../src/github/validation/actor";
+import {
+  checkHumanActor,
+  SelfTriggeringBotSkipError,
+} from "../src/github/validation/actor";
 import type { Octokit } from "@octokit/rest";
 import { createMockContext } from "./mockContext";
 
@@ -37,6 +40,44 @@ describe("checkHumanActor", () => {
     await expect(checkHumanActor(mockOctokit, context)).rejects.toThrow(
       "Workflow initiated by non-human actor: test-bot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.",
     );
+  });
+
+  test("should skip configured bot pull_request synchronize events", async () => {
+    const mockOctokit = createMockOctokit("Bot");
+    const context = createMockContext({
+      eventName: "pull_request",
+      eventAction: "synchronize",
+      isPR: true,
+    });
+    context.actor = "claude[bot]";
+    context.inputs.allowedBots = "";
+
+    let error: unknown;
+    try {
+      await checkHumanActor(mockOctokit, context);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(SelfTriggeringBotSkipError);
+    expect((error as Error).message).toContain(
+      "skipping to avoid a bot feedback loop",
+    );
+  });
+
+  test("should honor explicit allowed_bots for configured bot pull_request synchronize events", async () => {
+    const mockOctokit = createMockOctokit("Bot");
+    const context = createMockContext({
+      eventName: "pull_request",
+      eventAction: "synchronize",
+      isPR: true,
+    });
+    context.actor = "claude[bot]";
+    context.inputs.allowedBots = "claude";
+
+    await expect(
+      checkHumanActor(mockOctokit, context),
+    ).resolves.toBeUndefined();
   });
 
   test("should pass for bot actor when all bots allowed", async () => {


### PR DESCRIPTION
## Summary
- skip `pull_request` `synchronize` runs triggered by the configured action bot instead of failing actor validation
- keep the existing `allowed_bots` behavior for users who explicitly opt into running bot-triggered workflows
- add regression coverage for the self-triggered bot skip and explicit allow-list path

Fixes #1299.

## Validation
- `bun test test/actor.test.ts test/modes/agent.test.ts`
- `bun test test/modes/tag.test.ts`
- `bun run typecheck`
- `npx prettier --check src/github/validation/actor.ts src/entrypoints/run.ts test/actor.test.ts`
- `git diff --check`