### PR TITLE
fix: fall back to inherited env for auth when inputs are empty

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -307,8 +307,8 @@ runs:
         NODE_VERSION: ${{ env.NODE_VERSION }}
 
         # Provider configuration
-        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
-        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key || env.ANTHROPIC_API_KEY }}
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token || env.CLAUDE_CODE_OAUTH_TOKEN }}
         ANTHROPIC_FEDERATION_RULE_ID: ${{ inputs.anthropic_federation_rule_id }}
         ANTHROPIC_ORGANIZATION_ID: ${{ inputs.anthropic_organization_id }}
         ANTHROPIC_SERVICE_ACCOUNT_ID: ${{ inputs.anthropic_service_account_id }}


### PR DESCRIPTION
The "Run Claude Code Action" step maps the auth inputs into env unconditionally:

    ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
    CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token }}

When the input is empty — whether because the caller supplied auth via the step `env:` block (as reported in #676) or because the `with:` value resolves empty in some runner/secret configurations — this assignment overwrites the inherited env value with an empty string. validate-env then fails with the misleading "Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required" error even though the caller did provide a token.

Fall back to the inherited env var when the input is empty, mirroring the existing `${{ env.X }}` pattern already used a few lines below for ANTHROPIC_BASE_URL / ANTHROPIC_CUSTOM_HEADERS. The input still takes precedence; nothing changes for workflows that pass auth via `with:`.

Fixes #676