### PR TITLE
Use workload identity federation for Claude auth in CI workflows

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,7 +20,12 @@ jobs:
       - name: PR Review with Progress Tracking
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authenticate to the Claude API via Workload Identity Federation
+          # (the workflow's OIDC token is exchanged for a short-lived access
+          # token) instead of a static API key. See docs/setup.md.
+          anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
 
           prompt: "/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}"
           claude_args: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,12 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@main
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authenticate to the Claude API via Workload Identity Federation
+          # (the workflow's OIDC token is exchanged for a short-lived access
+          # token) instead of a static API key. See docs/setup.md.
+          anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
           claude_args: |
             --allowedTools "Bash(bun install),Bash(bun test:*),Bash(bun run format),Bash(bun typecheck)"
             --model "claude-opus-4-7"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -11,6 +11,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+      # Required to mint the OIDC token that is exchanged for a Claude API
+      # access token (Workload Identity Federation).
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -24,6 +27,11 @@ jobs:
           CLAUDE_CODE_SCRIPT_CAPS: '{"edit-issue-labels.sh":2}'
         with:
           prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ github.event.issue.number }}"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authenticate to the Claude API via Workload Identity Federation
+          # (the workflow's OIDC token is exchanged for a short-lived access
+          # token) instead of a static API key. See docs/setup.md.
+          anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
           allowed_non_write_users: "*" # Required for issue triage workflow, if users without repo write access create issues
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Switches this repository's own Claude automation workflows from the static `ANTHROPIC_API_KEY` secret to [Workload Identity Federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation): the workflow's GitHub OIDC token is exchanged for a short-lived Claude API access token at runtime, so no long-lived API key needs to be stored in the repository.

| Workflow | Change |
| --- | --- |
| `claude.yml` | `anthropic_api_key` → federation inputs |
| `claude-review.yml` | `anthropic_api_key` → federation inputs |
| `issue-triage.yml` | `anthropic_api_key` → federation inputs, plus `id-token: write` (the other two already request it) |

This is the same feature this action ships for its users (#1338, `docs/setup.md#workload-identity-federation`) — dogfooding it on our own CI.

## How it activates

The federation rule, organization, and service account IDs are read from repository **variables** (`vars.ANTHROPIC_FEDERATION_RULE_ID`, `vars.ANTHROPIC_ORGANIZATION_ID`, `vars.ANTHROPIC_SERVICE_ACCOUNT_ID`). These are identifiers, not credentials. Until a repo admin sets them, the action fails fast at env validation with a clear "authentication required" message — so this PR is safe to merge ahead of that, and switching over is a settings change rather than another PR.

The `ANTHROPIC_API_KEY` secret is intentionally left in place until the federated path has produced green runs; rollback is reverting this PR.

## Behavior notes

- `claude-review.yml` runs on `pull_request`. Fork PRs don't receive `id-token: write` (GitHub withholds it the same way it withholds secrets), so reviews continue to run only for same-repo PRs — identical to today's behavior with the secret.
- The e2e test workflows (`test-base-action.yml`, `test-settings.yml`, etc.) are deliberately **not** migrated here: they exercise the `anthropic_api_key` input of the base action itself and need their own treatment.