### PR TITLE
fix(install): verify claude binary exists after install (#1290)

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -92,12 +92,23 @@ async function installClaudeCode(): Promise<string> {
       console.log("Claude Code installed successfully");
       // Add to PATH
       const homeBin = `${process.env.HOME}/.local/bin`;
+      const claudePath = `${homeBin}/claude`;
+      // Verify the binary was actually placed on disk. The installer can
+      // exit 0 while emitting warnings and skipping binary placement (e.g.
+      // when ~/.local/bin does not exist), which later surfaces as an opaque
+      // ENOENT during posix_spawn in installPlugins/addMarketplace. Fail
+      // fast here with a clear, retryable error instead.
+      if (!existsSync(claudePath)) {
+        throw new Error(
+          `Claude Code installer exited 0 but binary was not placed at ${claudePath}`,
+        );
+      }
       const githubPath = process.env.GITHUB_PATH;
       if (githubPath) {
         await appendFile(githubPath, `${homeBin}\n`);
       }
       process.env.PATH = `${homeBin}:${process.env.PATH}`;
-      return `${homeBin}/claude`;
+      return claudePath;
     } catch (error) {
       if (attempt === 3) {
         throw new Error(


### PR DESCRIPTION
## Summary

Fixes #1290.

`installClaudeCode()` in `src/entrypoints/run.ts` pipes `curl ... | bash` and trusts the installer's exit code. As documented in #1290, the installer can exit 0 while emitting warnings and skipping binary placement (e.g. when `~/.local/bin` does not exist):

```
⚠ Setup notes:
  ● installMethod is native, but directory /home/runner/.local/bin does not exist
  ● installMethod is native, but claude command not found at /home/runner/.local/bin/claude
✔ Claude Code successfully installed!
```

The action then unconditionally returns `${HOME}/.local/bin/claude` and hands that bogus path to `installPlugins()` / `addMarketplace()`, surfacing later as an opaque `ENOENT: ... posix_spawn '/home/runner/.local/bin/claude'`.

## Change

Add an `existsSync(claudePath)` guard before returning. If the binary is missing, throw inside the attempt loop, which:

1. Triggers the existing 3-attempt retry (helpful for transient installer flakes).
2. On final failure, surfaces a clear, attributable error message instead of the opaque downstream ENOENT.

`existsSync` is already imported at the top of the file, so no new imports. No happy-path or `PATH_TO_CLAUDE_CODE_EXECUTABLE` behavior change.

This corresponds to suggestion #2 from the issue.

## Test plan

- [x] `bun run typecheck` clean (`tsc --noEmit`, strict mode).
- [x] `bun test` → 700 pass / 0 fail / 1496 expect() calls / 39 files.
- [ ] Manual repro on a runner where `~/.local/bin` is missing: previously fails with opaque ENOENT in `addMarketplace`; with this patch, fails fast with the new error message after 3 attempts.

Closes #1290.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>