### PR TITLE
Make comment-logic owner/repo parsing host-agnostic for GHE

### DIFF
--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -157,10 +157,18 @@ export function updateCommentBody(input: CommentUpdateInput): string {
 
     // If we don't have a URL yet but have a branch name, construct it
     if (!branchUrl && finalBranchName) {
-      // Extract owner/repo from jobUrl
-      const repoMatch = jobUrl.match(/github\.com\/([^\/]+)\/([^\/]+)\//);
-      if (repoMatch) {
-        branchUrl = `${GITHUB_SERVER_URL}/${repoMatch[1]}/${repoMatch[2]}/tree/${finalBranchName}`;
+      // Extract owner/repo from jobUrl. jobUrl is built from GITHUB_SERVER_URL,
+      // so on GitHub Enterprise the host is not github.com — parse via URL
+      // instead of hardcoding the host.
+      try {
+        const parsedJobUrl = new URL(jobUrl);
+        const segments = parsedJobUrl.pathname.split("/").filter(Boolean);
+        if (segments.length >= 2 && segments[0] && segments[1]) {
+          branchUrl = `${GITHUB_SERVER_URL}/${segments[0]}/${segments[1]}/tree/${finalBranchName}`;
+        }
+      } catch {
+        // jobUrl was not parseable — leave branchUrl empty so the branch
+        // appears as plain text rather than a broken link.
       }
     }
 

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -139,6 +139,26 @@ describe("updateCommentBody", () => {
       );
       expect(result).not.toContain("View branch");
     });
+
+    it("parses owner/repo from jobUrl on non-github.com hosts", () => {
+      // jobUrl is built from GITHUB_SERVER_URL, which on a self-hosted GitHub
+      // Enterprise instance is not github.com. Owner/repo must still be
+      // extracted so the branch link is not lost.
+      const input = {
+        ...baseInput,
+        jobUrl: "https://ghe.example.com/my-org/my-repo/actions/runs/456",
+        branchName: "claude/issue-1",
+      };
+
+      const result = updateCommentBody(input);
+      // GITHUB_SERVER_URL is captured at module import; the test does not
+      // change it. Asserting that the branch appears as a clickable link
+      // confirms the path parsing succeeded — previously the github.com-only
+      // regex would fail to match and the branch would degrade to plain text.
+      expect(result).toMatch(
+        /• \[`claude\/issue-1`\]\(https:\/\/[^/]+\/my-org\/my-repo\/tree\/claude\/issue-1\)/,
+      );
+    });
   });
 
   describe("PR link", () => {


### PR DESCRIPTION
## Summary
`src/github/operations/comment-logic.ts:161` extracts owner/repo from `jobUrl` with a regex hardcoded to `github.com`. Because `jobUrl` is built from `GITHUB_SERVER_URL`, the match silently fails on GitHub Enterprise hosts, and the branch link inside the tracking comment falls back to plain text instead of a hyperlink.

## Change
- Replaced the regex with `new URL(jobUrl)` + path-segment parsing — host-agnostic, behavior on `github.com` preserved.
- Wrapped in `try/catch` so malformed input fails closed (same UX as the regex no-match path).
- Added regression test `branch link > parses owner/repo from jobUrl on non-github.com hosts` in `test/comment-logic.test.ts`.

## Verification
- `npx tsc --noEmit`: clean
- `bun run typecheck`: clean
- `bun test test/comment-logic.test.ts`: 26 pass / 0 fail
- Full `bun test`: 699 pass / 2 fail — both pre-existing `restoreConfigFromBase` failures caused by sandbox SSH-signing rejection, unrelated to this change.
