### PR TITLE
fix(parse-sdk-options): prevent shell-quote from collapsing unquoted Bash(X:*) rules to bare Bash

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -24,6 +24,35 @@ const ACCUMULATING_FLAGS = new Set([
 // Delimiter used to join accumulated flag values
 const ACCUMULATE_DELIMITER = "\x00";
 
+// shell-quote treats ()|&;<> as control operators and splits adjacent text
+// around them into separate tokens (returned as `{op}` objects, which we then
+// dropped). For CLI args these must be literal characters — e.g. unquoted
+// `--allowedTools Bash(gh:*)` was being mangled into bare `Bash`, silently
+// widening a scoped permission rule to Bash(*). We escape each metachar to a
+// Unicode private-use codepoint before parsing and restore it afterward,
+// keeping shell-quote's quote/whitespace handling intact.
+const SHELL_META_PAIRS: [string, string][] = [
+  ["(", ""],
+  [")", ""],
+  ["|", ""],
+  ["&", ""],
+  [";", ""],
+  ["<", ""],
+  [">", ""],
+];
+const SHELL_META_ESCAPE = new Map(SHELL_META_PAIRS);
+const SHELL_META_UNESCAPE = new Map(SHELL_META_PAIRS.map(([k, v]) => [v, k]));
+const SHELL_META_ESCAPE_RE = /[()|&;<>]/g;
+const SHELL_META_UNESCAPE_RE = /[-]/g;
+
+function escapeShellMeta(s: string): string {
+  return s.replace(SHELL_META_ESCAPE_RE, (c) => SHELL_META_ESCAPE.get(c)!);
+}
+
+function unescapeShellMeta(s: string): string {
+  return s.replace(SHELL_META_UNESCAPE_RE, (c) => SHELL_META_UNESCAPE.get(c)!);
+}
+
 type McpConfig = {
   mcpServers?: Record<string, unknown>;
 };
@@ -106,9 +135,19 @@ function parseClaudeArgsToExtraArgs(
   if (!claudeArgs?.trim()) return {};
 
   const result: Record<string, string | null> = {};
-  const args = parseShellArgs(stripShellComments(claudeArgs)).filter(
-    (arg): arg is string => typeof arg === "string",
-  );
+  const args = parseShellArgs(escapeShellMeta(stripShellComments(claudeArgs)))
+    .map((arg) => {
+      if (typeof arg === "string") return unescapeShellMeta(arg);
+      // With control metachars escaped above, the only non-string shell-quote
+      // can still emit is a glob op (bareword containing *, ?, or [). Its
+      // `pattern` field is the verbatim token text — use it as-is so values
+      // like `Bash(cmd:*)` and `Read(path/**)` round-trip intact.
+      if (typeof arg === "object" && arg !== null && "pattern" in arg) {
+        return unescapeShellMeta((arg as { pattern: string }).pattern);
+      }
+      return undefined;
+    })
+    .filter((arg): arg is string => typeof arg === "string");
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -137,6 +137,110 @@ describe("parseSdkOptions", () => {
       ]);
     });
 
+    test("should preserve unquoted Bash(cmd:*) rules instead of collapsing to bare Bash", () => {
+      // Regression: shell-quote tokenizes unquoted `(`/`)` as control ops and
+      // `*` as a glob, which were filtered out — collapsing scoped rules like
+      // `Bash(gh:*)` into bare `Bash` (= Bash(*), unrestricted shell).
+      const options: ClaudeOptions = {
+        claudeArgs: "--allowedTools View,Bash(gh:*),Bash(cat:*)",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.allowedTools).toEqual([
+        "View",
+        "Bash(gh:*)",
+        "Bash(cat:*)",
+      ]);
+      expect(result.sdkOptions.allowedTools).not.toContain("Bash");
+    });
+
+    test("should preserve unquoted space-separated Bash(cmd:*) rules", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--allowed-tools Bash(gh:*) Bash(cat:*) Read(//tmp/**)",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.allowedTools).toEqual([
+        "Bash(gh:*)",
+        "Bash(cat:*)",
+        "Read(//tmp/**)",
+      ]);
+      expect(result.sdkOptions.allowedTools).not.toContain("Bash");
+    });
+
+    test("should preserve unquoted Tool(content) rules without glob chars", () => {
+      const options: ClaudeOptions = {
+        claudeArgs:
+          "--allowedTools Read(~/file),WebFetch(domain:example.com),Edit",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.allowedTools).toEqual([
+        "Read(~/file)",
+        "WebFetch(domain:example.com)",
+        "Edit",
+      ]);
+    });
+
+    test("should still preserve quoted Bash(cmd:*) rules (no regression)", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: '--allowedTools "Bash(gh:*),Bash(cat:*)"',
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.allowedTools).toEqual([
+        "Bash(gh:*)",
+        "Bash(cat:*)",
+      ]);
+    });
+
+    test("should merge quoted tag-mode tools with unquoted user tools without widening", () => {
+      // Real-world shape: the action's tag mode wraps its own --allowedTools in
+      // double quotes, then appends the user's claude_args (typically unquoted
+      // in workflow YAML). Both halves must round-trip.
+      const options: ClaudeOptions = {
+        claudeArgs:
+          '--permission-mode acceptEdits --allowedTools "Glob,Grep,Read,Bash(git add:*),Bash(git commit:*)" ' +
+          "--model claude-opus-4-7\n" +
+          "--allowedTools View,Bash(gh:*),Bash(printf:*),Bash(cat:*)",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.allowedTools).toEqual([
+        "Glob",
+        "Grep",
+        "Read",
+        "Bash(git add:*)",
+        "Bash(git commit:*)",
+        "View",
+        "Bash(gh:*)",
+        "Bash(printf:*)",
+        "Bash(cat:*)",
+      ]);
+      expect(result.sdkOptions.allowedTools).not.toContain("Bash");
+    });
+
+    test("should preserve unquoted disallowedTools rules without widening", () => {
+      // Same bug class on the deny side: a scoped deny collapsing to bare
+      // `Bash` would block all shell instead of the intended prefix.
+      const options: ClaudeOptions = {
+        claudeArgs: "--disallowedTools Bash(rm:*),Bash(sudo:*)",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.disallowedTools).toEqual([
+        "Bash(rm:*)",
+        "Bash(sudo:*)",
+      ]);
+      expect(result.sdkOptions.disallowedTools).not.toContain("Bash");
+    });
+
     test("should handle mixed camelCase and hyphenated allowedTools flags", () => {
       const options: ClaudeOptions = {
         claudeArgs: '--allowedTools "Edit,Read" --allowed-tools "Write,Glob"',


### PR DESCRIPTION
## Bug

`parseClaudeArgsToExtraArgs` uses `shell-quote`'s `parse()` to tokenize the `claude_args` input, then filters to string entries only. But `shell-quote` is a full shell-command parser: unquoted `(` / `)` are returned as `{op: '('}` / `{op: ')'}` control-operator objects, and any bareword containing `*` is returned as `{op: 'glob', pattern: '…'}`. All of these were dropped by the string-only filter.

Result: an unquoted `--allowedTools Bash(gh:*),Bash(cat:*)` collapses to bare `"Bash"` — which Claude Code interprets as `Bash(*)`, i.e. **unrestricted shell**.

### Repro

```js
import { parse } from "shell-quote";
parse("--allowedTools View,Bash(gh:*),Bash(cat:*)")
// → ["--allowedTools", "View,Bash", {op:"("}, {op:"glob",pattern:"gh:*"},
//    {op:")"}, ",Bash", {op:"("}, {op:"glob",pattern:"cat:*"}, {op:")"}]
```

After the existing `.filter(typeof arg === "string")` → `["--allowedTools", "View,Bash", ",Bash"]` → split/dedup → `["View", "Bash"]`.

### Before / after (`parseSdkOptions`)

Input (exact shape the action builds in tag mode — its own quoted `--allowedTools` + user's unquoted YAML `claude_args`):
```
--permission-mode acceptEdits --allowedTools "Glob,Grep,Read,Bash(git add:*),Bash(git commit:*)" --model claude-opus-4-7
--allowedTools View,Bash(gh:*),Bash(printf:*),Bash(cat:*)
```

| | `sdkOptions.allowedTools` |
|---|---|
| **before** | `[…, "Bash(git add:*)", "Bash(git commit:*)", "View", "GlobTool", "GrepTool", "Bash"]` |
| **after** | `[…, "Bash(git add:*)", "Bash(git commit:*)", "View", "Bash(gh:*)", "Bash(printf:*)", "Bash(cat:*)"]` |

## Security impact

This is **silent permission widening**. Any workflow that passes scoped `Bash(X:*)` / `Read(X)` / `WebFetch(X)` rules in `claude_args` without wrapping the value in quotes gets the tool-level wildcard instead of the scoped rule. Because `Bash(*)` subsumes every `Bash(X:*)`, the session behaves as intended — the user never observes a denial that would reveal the scoping was lost.

Found via Claude Code session telemetry. The same collapse happens on `--disallowedTools` (scoped deny → blanket deny), which is a usability bug rather than a widening.

## Fix

`claude_args` is a CLI argument string, not a shell command — we want shell-quote's quote/whitespace handling, not its operator/glob detection. shell-quote has no option to disable operator parsing, and it does not preserve adjacency (so post-hoc reconstruction of `{op}` runs is lossy). Instead:

1. Before `parse()`, replace the seven shell control metachars `( ) | & ; < >` with Unicode private-use codepoints (U+E000–U+E006). shell-quote then treats them as ordinary word characters and never splits on them.
2. After `parse()`, map glob ops back to their `.pattern` (the verbatim token text) and restore the placeholders.

Quoted values, escaped values, whitespace tokenization, comment stripping, and `--mcp-config` JSON handling are all unchanged.

## Tests

Six regression tests added to `base-action/test/parse-sdk-options.test.ts` covering:
- unquoted comma-joined `Bash(X:*)` rules
- unquoted space-separated `Bash(X:*)` rules
- unquoted `Tool(content)` with no glob chars
- quoted `Bash(X:*)` (no-regression)
- the real-world tag-mode-quoted + user-unquoted mixed case
- `--disallowedTools` path

All 5 applicable tests fail on `main`, pass with this change. Full suite: `base-action` 133 pass / 0 fail, root 706 pass / 0 fail, typecheck clean, prettier clean.

> [!NOTE]
> `bun install` on `main` currently fails because `@anthropic-ai/claude-agent-sdk@0.3.150` (pinned in 787c5a0) is not yet published to npm; I ran the suite locally against `0.3.149`. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
