### PR TITLE
feat: expose final_message step output for defense-in-depth review workflows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -182,6 +182,9 @@ outputs:
   session_id:
     description: "The Claude Code session ID that can be used with --resume to continue this conversation"
     value: ${{ steps.run.outputs.session_id }}
+  final_message:
+    description: "Claude's final assistant text response, extracted from the last message in the stream. Useful for read-only review workflows that want to capture Claude's response in a sandboxed AI job and post it from a separate, more-privileged job (defense-in-depth). Empty when Claude's last action was a tool call rather than text."
+    value: ${{ steps.run.outputs.final_message }}
 
 runs:
   using: "composite"

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -85,6 +85,9 @@ outputs:
   session_id:
     description: "The Claude Code session ID that can be used with --resume to continue this conversation"
     value: ${{ steps.run_claude.outputs.session_id }}
+  final_message:
+    description: "Claude's final assistant text response, extracted from the last message in the stream. Useful for read-only review workflows that want to capture Claude's response in a sandboxed AI job and post it from a separate, more-privileged job (defense-in-depth). Empty when Claude's last action was a tool call rather than text."
+    value: ${{ steps.run_claude.outputs.final_message }}
 
 runs:
   using: "composite"

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -62,6 +62,9 @@ async function run() {
     if (result.structuredOutput) {
       core.setOutput("structured_output", result.structuredOutput);
     }
+    if (result.finalMessage) {
+      core.setOutput("final_message", result.finalMessage);
+    }
   } catch (error) {
     setExecutionFileOutputIfPresent();
     core.setFailed(`Action failed with error: ${error}`);

--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -15,6 +15,14 @@ export type ClaudeRunResult = {
   sessionId?: string;
   conclusion: "success" | "failure";
   structuredOutput?: string;
+  /**
+   * Claude's final assistant text response, extracted from the last
+   * `type: "assistant"` message in the stream. Useful for read-only
+   * review workflows that capture the response in a sandboxed AI job
+   * and post it from a separate, more-privileged job (defense-in-depth).
+   * Undefined when Claude's last action was a tool call (no text).
+   */
+  finalMessage?: string;
 };
 
 /** Filename for the user request file, written by prompt generation */
@@ -130,6 +138,48 @@ function sanitizeSdkOutput(
 }
 
 /**
+ * Extract the final assistant text response from the message stream.
+ *
+ * Walks `messages` backward to find the last `type: "assistant"` message
+ * and joins all of its `type: "text"` content blocks with newlines.
+ *
+ * Returns `undefined` when there are no assistant messages, or when the
+ * last assistant message contains only tool_use blocks (no text). This is
+ * intentional: when the agent's last action was a tool call rather than
+ * speech, there is no "final message" to surface.
+ *
+ * Mirrors the text-extraction logic in src/entrypoints/format-turns.ts so
+ * the output here matches what users see in the Step Summary.
+ */
+export function extractFinalAssistantMessage(
+  messages: SDKMessage[],
+): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg || msg.type !== "assistant") continue;
+    if (!("message" in msg) || !msg.message) continue;
+
+    const content = (msg.message as { content?: unknown }).content;
+    if (!Array.isArray(content)) return undefined;
+
+    const textParts: string[] = [];
+    for (const block of content) {
+      if (
+        block != null &&
+        typeof block === "object" &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string"
+      ) {
+        textParts.push((block as { text: string }).text);
+      }
+    }
+
+    return textParts.length > 0 ? textParts.join("\n") : undefined;
+  }
+  return undefined;
+}
+
+/**
  * Run Claude using the Agent SDK
  */
 export async function runClaudeWithSdk(
@@ -234,6 +284,15 @@ export async function runClaudeWithSdk(
           : "unknown error"
       }`,
     );
+  }
+
+  // Extract Claude's final assistant text response for downstream steps.
+  // See ClaudeRunResult.finalMessage for the rationale (defense-in-depth
+  // review workflows that post from a separate, more-privileged job).
+  const finalMessage = extractFinalAssistantMessage(messages);
+  if (finalMessage) {
+    result.finalMessage = finalMessage;
+    core.info(`Set final_message (${finalMessage.length} chars)`);
   }
 
   return result;

--- a/base-action/test/run-claude-sdk.test.ts
+++ b/base-action/test/run-claude-sdk.test.ts
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
+import { extractFinalAssistantMessage } from "../src/run-claude-sdk";
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 
 describe("runClaudeWithSdk", () => {
   const originalRunnerTemp = process.env.RUNNER_TEMP;
@@ -62,5 +64,181 @@ describe("runClaudeWithSdk", () => {
       consoleErrorSpy.mockRestore();
       consoleLogSpy.mockRestore();
     }
+  });
+});
+
+/**
+ * Helper to cast plain test fixtures to SDKMessage[].
+ * The real SDK types are unions with many discriminator fields; tests only
+ * need to match the shape that `extractFinalAssistantMessage` reads.
+ */
+const asMessages = (fixtures: unknown[]): SDKMessage[] =>
+  fixtures as SDKMessage[];
+
+describe("extractFinalAssistantMessage", () => {
+  test("returns undefined for an empty message stream", () => {
+    expect(extractFinalAssistantMessage(asMessages([]))).toBeUndefined();
+  });
+
+  test("returns undefined when there are no assistant messages", () => {
+    const messages = asMessages([
+      { type: "system", subtype: "init", session_id: "abc", tools: [] },
+      {
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      },
+      { type: "result", subtype: "success", is_error: false },
+    ]);
+
+    expect(extractFinalAssistantMessage(messages)).toBeUndefined();
+  });
+
+  test("returns text from a single assistant message", () => {
+    const messages = asMessages([
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Here is my review." }],
+        },
+      },
+    ]);
+
+    expect(extractFinalAssistantMessage(messages)).toBe("Here is my review.");
+  });
+
+  test("joins multiple text blocks in a single assistant message with newlines", () => {
+    const messages = asMessages([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "First paragraph." },
+            { type: "text", text: "Second paragraph." },
+          ],
+        },
+      },
+    ]);
+
+    expect(extractFinalAssistantMessage(messages)).toBe(
+      "First paragraph.\nSecond paragraph.",
+    );
+  });
+
+  test("ignores tool_use blocks and returns only text content", () => {
+    const messages = asMessages([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "Let me check the diff." },
+            {
+              type: "tool_use",
+              id: "tool_1",
+              name: "Read",
+              input: { path: "diff.txt" },
+            },
+            { type: "text", text: "Looks good overall." },
+          ],
+        },
+      },
+    ]);
+
+    expect(extractFinalAssistantMessage(messages)).toBe(
+      "Let me check the diff.\nLooks good overall.",
+    );
+  });
+
+  test("returns undefined when the last assistant message has only tool_use blocks", () => {
+    const messages = asMessages([
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "tool_1",
+              name: "Read",
+              input: { path: "x" },
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(extractFinalAssistantMessage(messages)).toBeUndefined();
+  });
+
+  test("does NOT walk back to earlier assistants when the last has only tool_use", () => {
+    // Intentional behavior: "final message" means the literal last assistant's
+    // text response, not any earlier text the agent said. If the last assistant
+    // turn is a tool call, we surface undefined rather than digging further.
+    const messages = asMessages([
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Earlier thoughts." }],
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "tool_1",
+              name: "Read",
+              input: { path: "x" },
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(extractFinalAssistantMessage(messages)).toBeUndefined();
+  });
+
+  test("finds the last assistant when followed by a result message", () => {
+    const messages = asMessages([
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "All done." }],
+        },
+      },
+      { type: "result", subtype: "success", is_error: false },
+    ]);
+
+    expect(extractFinalAssistantMessage(messages)).toBe("All done.");
+  });
+
+  test("returns the LAST assistant's text when multiple assistant messages exist", () => {
+    const messages = asMessages([
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "First reply." }] },
+      },
+      {
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: "ok" }] },
+      },
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Final reply." }] },
+      },
+    ]);
+
+    expect(extractFinalAssistantMessage(messages)).toBe("Final reply.");
+  });
+
+  test("returns undefined when assistant message has non-array content", () => {
+    // Defensive: malformed SDK output shouldn't crash extraction.
+    const messages = asMessages([
+      {
+        type: "assistant",
+        message: { content: "not an array" },
+      },
+    ]);
+
+    expect(extractFinalAssistantMessage(messages)).toBeUndefined();
   });
 });

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -301,6 +301,9 @@ async function run() {
     if (claudeResult.structuredOutput) {
       core.setOutput("structured_output", claudeResult.structuredOutput);
     }
+    if (claudeResult.finalMessage) {
+      core.setOutput("final_message", claudeResult.finalMessage);
+    }
     core.setOutput("conclusion", claudeResult.conclusion);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
Closes #1317.

Adds a `final_message` step output containing the agent's final text response, pulled from the last message in the SDK stream.

The use case the issue describes is read-only review workflows: run the AI job with `contents: read` only, then post the response from a separate job that has `pull-requests: write`. Right now you can't really do that. The only way to get the response text is to parse `execution_file`, which has no documented format. The `openai/codex-action` repo solves it with a `final-message` output, which is what the issue references.

## Usage

```yaml
- uses: anthropics/claude-code-action@vX
  id: review
  with:
    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

- name: Post review
  env:
    REVIEW: ${{ steps.review.outputs.final_message }}
  run: gh pr review --comment --body "$REVIEW"
```

## A note on naming

The issue uses `final-message` (kebab-case) because that's what codex-action uses. I went with `final_message` (snake_case) to match the other outputs in this repo (`execution_file`, `structured_output`, `session_id`). Easy to swap if you'd rather match codex-action.

## How it works

A small helper called `extractFinalAssistantMessage` in `base-action/src/run-claude-sdk.ts` walks the message stream backwards, finds the last assistant message, and joins its text blocks. If the last action was a tool call (no text), the output is undefined. The intent is that "final message" should mean what the agent actually said.

Wired through both layers (the standalone base-action and the parent action). Added 10 unit tests for the edge cases: empty stream, multiple text blocks, text + tool_use mixed, tool-only last message, malformed content.

## Checks

Ran `bun test` (10 new pass, no regressions), `bun run typecheck`, and `bun run format:check`.