### PR TITLE
feat: add exclude_dynamic_sections input for cross-session prompt caching

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -157,6 +157,10 @@ inputs:
     description: "Show full JSON output from Claude Code. WARNING: This outputs ALL Claude messages including tool execution results which may contain secrets, API keys, or other sensitive information. These logs are publicly visible in GitHub Actions. Only enable for debugging in non-sensitive environments."
     required: false
     default: "false"
+  exclude_dynamic_sections:
+    description: "When true, strips per-user dynamic content (working directory, git status, auto-memory path) from the system prompt so it stays cacheable across sessions and users. The stripped content is re-injected as the first user message so the model still has full context. Enables cross-run prompt cache hits in CI fleets. Has no effect when a custom system_prompt is set."
+    required: false
+    default: "false"
   plugins:
     description: "Newline-separated list of Claude Code plugin names to install (e.g., 'code-review@claude-code-plugins\nfeature-dev@claude-code-plugins')"
     required: false
@@ -298,6 +302,7 @@ runs:
         INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        EXCLUDE_DYNAMIC_SECTIONS: ${{ inputs.exclude_dynamic_sections }}
         DISPLAY_REPORT: ${{ inputs.display_report }}
         INPUT_PLUGINS: ${{ inputs.plugins }}
         INPUT_PLUGIN_MARKETPLACES: ${{ inputs.plugin_marketplaces }}

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -45,6 +45,7 @@ async function run() {
       mcpConfig: process.env.INPUT_MCP_CONFIG,
       systemPrompt: process.env.INPUT_SYSTEM_PROMPT,
       appendSystemPrompt: process.env.INPUT_APPEND_SYSTEM_PROMPT,
+      excludeDynamicSections: process.env.INPUT_EXCLUDE_DYNAMIC_SECTIONS === "true",
       fallbackModel: process.env.INPUT_FALLBACK_MODEL,
       model: process.env.ANTHROPIC_MODEL,
       pathToClaudeCodeExecutable: claudeExecutable,

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -244,12 +244,14 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
       type: "preset",
       preset: "claude_code",
       append: options.appendSystemPrompt,
+      excludeDynamicSections: options.excludeDynamicSections,
     };
   } else {
     // Default to claude_code preset when no custom prompt is specified
     systemPrompt = {
       type: "preset",
       preset: "claude_code",
+      excludeDynamicSections: options.excludeDynamicSections,
     };
   }
 

--- a/base-action/src/run-claude.ts
+++ b/base-action/src/run-claude.ts
@@ -12,6 +12,7 @@ export type ClaudeOptions = {
   mcpConfig?: string;
   systemPrompt?: string;
   appendSystemPrompt?: string;
+  excludeDynamicSections?: boolean;
   fallbackModel?: string;
   showFullOutput?: string;
 };

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -283,6 +283,7 @@ async function run() {
     const claudeResult: ClaudeRunResult = await runClaude(promptConfig.path, {
       claudeArgs: prepareResult.claudeArgs,
       appendSystemPrompt: process.env.APPEND_SYSTEM_PROMPT,
+      excludeDynamicSections: process.env.EXCLUDE_DYNAMIC_SECTIONS === "true",
       model: process.env.ANTHROPIC_MODEL,
       pathToClaudeCodeExecutable: claudeExecutable,
       showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,


### PR DESCRIPTION
## Summary

The Agent SDK (`@anthropic-ai/claude-agent-sdk`) supports `excludeDynamicSections: true` on the `claude_code` system prompt preset. When enabled, per-user dynamic content — working directory, git status, auto-memory path — is stripped from the cached system prompt prefix and re-injected as the first user message. This keeps the system prompt byte-for-byte identical across sessions, enabling prompt cache hits between independent runs that share the same prompt.

This is particularly valuable in CI fleet use cases (GitHub Actions workflows, PR validation bots) where many unrelated runs share the same prompt and would otherwise get a cache miss on every invocation due to the dynamic working-directory/git-status sections.

This PR wires that existing SDK option up to an action input.

## Changes

- **`action.yml`**: adds `exclude_dynamic_sections` boolean input (default `false`) and passes it as `EXCLUDE_DYNAMIC_SECTIONS` env var
- **`base-action/src/run-claude.ts`**: adds `excludeDynamicSections?: boolean` to `ClaudeOptions`
- **`base-action/src/parse-sdk-options.ts`**: passes the option into the `claude_code` preset system prompt object
- **`src/entrypoints/run.ts`**: reads `EXCLUDE_DYNAMIC_SECTIONS` env var and passes it through
- **`base-action/src/index.ts`**: same for standalone base-action usage (`INPUT_EXCLUDE_DYNAMIC_SECTIONS`)

## Usage

```yaml
- uses: anthropics/claude-code-action@v1
  with:
    exclude_dynamic_sections: "true"
    # ... other inputs
```

## Notes

- Has no effect when a custom `system_prompt` is set (matches SDK behaviour — `excludeDynamicSections` only applies to the `claude_code` preset)
- The stripped content (working directory, git status, auto-memory path) is still available to the model; it just arrives in the first user message instead of the system prompt
- No behaviour change when the input is omitted or set to `false`