### PR TITLE
docs(faq): correct rebase FAQ to match actual behavior

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -63,17 +63,14 @@ The GitHub App for Claude doesn't have workflow write access for security reason
 
 ### Why won't Claude rebase my branch?
 
-By default, Claude only uses commit tools for non-destructive changes to the branch. Claude is configured to:
+Claude only creates and pushes commits. It does not merge branches, rebase, force push, or perform other destructive git operations. Specifically, Claude is configured to:
 
 - Never push to branches other than where it was invoked (either its own branch or the PR branch)
 - Never force push or perform destructive operations
 
-You can grant additional tools via the `claude_args` input if needed:
+This restriction is enforced in Claude's system prompt, so it applies even if you grant the underlying git tools (for example `--allowedTools "Bash(git rebase:*)"`). In that case Claude will still decline rebase requests and explain the limitation rather than running the command.
 
-```yaml
-claude_args: |
-  --allowedTools "Bash(git rebase:*)"  # Use with caution
-```
+If you need to rebase, do it yourself locally — or with the Claude Code CLI outside of this action — and push the result.
 
 ### Why won't Claude create a pull request?
 


### PR DESCRIPTION
## Summary

The [**Why won't Claude rebase my branch?**](https://github.com/anthropics/claude-code-action/blob/main/docs/faq.md#why-wont-claude-rebase-my-branch) FAQ entry tells users they can enable rebasing by adding `--allowedTools "Bash(git rebase:*)"` to `claude_args`. This doesn't work in practice.

The system prompt built in [`src/create-prompt/index.ts`](https://github.com/anthropics/claude-code-action/blob/main/src/create-prompt/index.ts) unconditionally lists rebasing under **"What You CANNOT Do"**:

```
- Perform branch operations (cannot merge branches, rebase, or perform other git operations beyond creating and pushing commits)
```

There is no condition on the contents of `--allowedTools`, so Claude follows the system prompt and declines the request even when the git tool is explicitly allowed. As reported in #1286, users (including the reporter) followed the FAQ's guidance and assumed it was working when it was not.

## Change

Docs-only. Update the FAQ to:

- describe the actual behavior (Claude only creates and pushes commits; branch operations are blocked),
- note that granting `Bash(git rebase:*)` does not override this, and
- point users to the real workaround (rebase locally or via the Claude Code CLI, then push).

No code or behavior changes.

Closes #1286