### PR TITLE
fix(sanitizer): match attribute quotes by type to avoid mangling content

### DIFF
--- a/src/github/utils/sanitizer.ts
+++ b/src/github/utils/sanitizer.ts
@@ -20,15 +20,23 @@ export function stripMarkdownLinkTitles(content: string): string {
 }
 
 export function stripHiddenAttributes(content: string): string {
-  content = content.replace(/\salt\s*=\s*["'][^"']*["']/gi, "");
+  // Quoted values are matched per quote type so that a value containing the
+  // other quote character (e.g. an apostrophe inside a double-quoted value)
+  // does not terminate the match early and mangle surrounding content (#1366).
+  content = content.replace(/\salt\s*=\s*"[^"]*"/gi, "");
+  content = content.replace(/\salt\s*=\s*'[^']*'/gi, "");
   content = content.replace(/\salt\s*=\s*[^\s>]+/gi, "");
-  content = content.replace(/\stitle\s*=\s*["'][^"']*["']/gi, "");
+  content = content.replace(/\stitle\s*=\s*"[^"]*"/gi, "");
+  content = content.replace(/\stitle\s*=\s*'[^']*'/gi, "");
   content = content.replace(/\stitle\s*=\s*[^\s>]+/gi, "");
-  content = content.replace(/\saria-label\s*=\s*["'][^"']*["']/gi, "");
+  content = content.replace(/\saria-label\s*=\s*"[^"]*"/gi, "");
+  content = content.replace(/\saria-label\s*=\s*'[^']*'/gi, "");
   content = content.replace(/\saria-label\s*=\s*[^\s>]+/gi, "");
-  content = content.replace(/\sdata-[a-zA-Z0-9-]+\s*=\s*["'][^"']*["']/gi, "");
+  content = content.replace(/\sdata-[a-zA-Z0-9-]+\s*=\s*"[^"]*"/gi, "");
+  content = content.replace(/\sdata-[a-zA-Z0-9-]+\s*=\s*'[^']*'/gi, "");
   content = content.replace(/\sdata-[a-zA-Z0-9-]+\s*=\s*[^\s>]+/gi, "");
-  content = content.replace(/\splaceholder\s*=\s*["'][^"']*["']/gi, "");
+  content = content.replace(/\splaceholder\s*=\s*"[^"]*"/gi, "");
+  content = content.replace(/\splaceholder\s*=\s*'[^']*'/gi, "");
   content = content.replace(/\splaceholder\s*=\s*[^\s>]+/gi, "");
   return content;
 }

--- a/test/sanitizer.test.ts
+++ b/test/sanitizer.test.ts
@@ -131,6 +131,21 @@ describe("stripHiddenAttributes", () => {
       ),
     ).toBe('<img src="pic.jpg" class="image">');
   });
+
+  it("should not corrupt content when an attribute value contains the other quote type", () => {
+    // Regression for #1366: an apostrophe inside a double-quoted attribute
+    // (or a double quote inside a single-quoted attribute) must not cause the
+    // closing quote to be mismatched, which previously mangled later text.
+    expect(
+      stripHiddenAttributes(`<Tooltip title="We'll do it" placement="top">`),
+    ).toBe('<Tooltip placement="top">');
+    expect(
+      stripHiddenAttributes(`<img alt="Bob's avatar" src="pic.jpg">`),
+    ).toBe('<img src="pic.jpg">');
+    expect(stripHiddenAttributes(`<div title='say "hi"'>Content</div>`)).toBe(
+      "<div>Content</div>",
+    );
+  });
 });
 
 describe("normalizeHtmlEntities", () => {


### PR DESCRIPTION
## Summary

`stripHiddenAttributes` in `src/github/utils/sanitizer.ts` strips hidden HTML attributes (`alt`, `title`, `aria-label`, `data-*`, `placeholder`) using the pattern `["'][^"']*["']` for the quoted form. That character class matches an opening quote of **either** type and stops at the **first** quote of **either** type. When an attribute value contains the *other* quote character, the match ends early and the wrong span is removed, corrupting surrounding content.

Example:

```
<Tooltip title="We'll do it" placement="top">
```

becomes

```
<Tooltipll do it" placement="top">
```

The apostrophe in `We'll` is treated as the closing quote, so ` title="We'` is deleted instead of the whole attribute.

This surfaces through the `github_inline_comment` MCP tool (#1366): when a `suggestion` block contains a code line with quotes, the body is mangled before it's posted. It also affects any user/issue/PR content passed through `sanitizeContent`.

## Fix

Match each quoted form per quote type — `"[^"]*"` and `'[^']*'` — instead of the quote-agnostic class, so a value may freely contain the other quote character. This mirrors how `stripMarkdownLinkTitles` already handles the two quote types in this same file. The unquoted fallback (`[^\s>]+`) is unchanged.

## Security note

`stripHiddenAttributes` is a prompt-injection defense (it removes instructions hidden in attributes like `alt`/`title`/`aria-label`), so this change is intentionally conservative on that axis: it only changes *which span* is matched, never what is eligible to be stripped. Every attribute removed before is still removed — the old pattern was strictly narrower (`[^"']*` stops at the first quote of either type, whereas `"[^"]*"` / `'[^']*'` span the full quoted value). The fix prevents valid content from being mangled; it does not let hidden attributes survive.

## Testing

- Added a regression test in `test/sanitizer.test.ts` covering an apostrophe inside a double-quoted value and a double quote inside a single-quoted value. It fails on `main` (reproduces the corruption) and passes with this change.
- `bun test` — 701 pass / 0 fail
- `bun run typecheck` — clean
- `bun run format:check` — clean

Closes #1366