### PR TITLE
Preserve outgoing suggestion comment bodies

### DIFF
--- a/src/github/utils/sanitizer.ts
+++ b/src/github/utils/sanitizer.ts
@@ -62,6 +62,12 @@ export function sanitizeContent(content: string): string {
   return content;
 }
 
+export function sanitizeOutgoingCommentContent(content: string): string {
+  content = stripInvisibleCharacters(content);
+  content = redactGitHubTokens(content);
+  return content;
+}
+
 export function redactGitHubTokens(content: string): string {
   // GitHub Personal Access Tokens (classic): ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX (40 chars)
   content = content.replace(

--- a/src/mcp/github-comment-server.ts
+++ b/src/mcp/github-comment-server.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { GITHUB_API_URL } from "../github/api/config";
 import { Octokit } from "@octokit/rest";
 import { updateClaudeComment } from "../github/operations/comments/update-claude-comment";
-import { sanitizeContent } from "../github/utils/sanitizer";
+import { sanitizeOutgoingCommentContent } from "../github/utils/sanitizer";
 
 // Get repository information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -55,7 +55,7 @@ server.tool(
       const isPullRequestReviewComment =
         eventName === "pull_request_review_comment";
 
-      const sanitizedBody = sanitizeContent(body);
+      const sanitizedBody = sanitizeOutgoingCommentContent(body);
 
       const result = await updateClaudeComment(octokit, {
         owner,

--- a/src/mcp/github-inline-comment-server.ts
+++ b/src/mcp/github-inline-comment-server.ts
@@ -4,7 +4,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { appendFileSync } from "fs";
 import { z } from "zod";
 import { createOctokit } from "../github/api/client";
-import { sanitizeContent } from "../github/utils/sanitizer";
+import { sanitizeOutgoingCommentContent } from "../github/utils/sanitizer";
 
 // Get repository and PR information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -97,8 +97,8 @@ server.tool(
       const repo = REPO_NAME;
       const pull_number = parseInt(PR_NUMBER, 10);
 
-      // Sanitize the comment body to remove any potential GitHub tokens
-      const sanitizedBody = sanitizeContent(body);
+      // Preserve review suggestions exactly while still redacting accidental tokens.
+      const sanitizedBody = sanitizeOutgoingCommentContent(body);
 
       // Validate that either line or both startLine and line are provided
       if (!line && !startLine) {

--- a/test/sanitizer.test.ts
+++ b/test/sanitizer.test.ts
@@ -6,6 +6,7 @@ import {
   stripHiddenAttributes,
   normalizeHtmlEntities,
   sanitizeContent,
+  sanitizeOutgoingCommentContent,
   stripHtmlComments,
   redactGitHubTokens,
 } from "../src/github/utils/sanitizer";
@@ -240,6 +241,30 @@ describe("sanitizeContent", () => {
     expect(sanitized).toContain("Hidden message");
     expect(sanitized).not.toContain('title="');
     expect(sanitized).toContain("<div>Test</div>");
+  });
+});
+
+describe("sanitizeOutgoingCommentContent", () => {
+  it("preserves suggestion blocks with quoted attributes", () => {
+    const body = `**Drop the trailing full-stop.**
+
+\`\`\`suggestion
+          <Tooltip title="We'll do the thing" placement="top" class="inline-flex items-center">
+\`\`\`
+`;
+
+    expect(sanitizeOutgoingCommentContent(body)).toBe(body);
+  });
+
+  it("redacts tokens without stripping visible suggestion text", () => {
+    const token = "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";
+    const body = `\`\`\`suggestion
+<Tooltip title="We'll do the thing" data-token="${token}">
+\`\`\``;
+
+    expect(sanitizeOutgoingCommentContent(body)).toBe(`\`\`\`suggestion
+<Tooltip title="We'll do the thing" data-token="[REDACTED_GITHUB_TOKEN]">
+\`\`\``);
   });
 });
 


### PR DESCRIPTION
## Summary

- add a narrower sanitizer for outgoing GitHub comments that redacts tokens without stripping visible Markdown or HTML attributes
- use it for inline review comments and Claude comment updates
- add regression coverage for suggestion blocks containing quoted attributes and apostrophes

Fixes #1366.

## Validation

- `npx tsc --noEmit`
- `npx prettier --check src/github/utils/sanitizer.ts src/mcp/github-comment-server.ts src/mcp/github-inline-comment-server.ts test/sanitizer.test.ts`

## Note

I could not run `bun test test/sanitizer.test.ts` in this environment because `bun` is not installed. I installed npm dependencies with `--legacy-peer-deps --no-package-lock --ignore-scripts` only to run TypeScript and Prettier checks locally.