### PR TITLE
feat: expose taskBudget SDK option as task_budget action input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -105,6 +105,10 @@ inputs:
     description: "Additional arguments to pass directly to Claude CLI"
     required: false
     default: ""
+  task_budget:
+    description: "API-side token budget (total tokens). When set, the model is made aware of its remaining budget and can pace its tool use accordingly. Maps to the SDK taskBudget.total option (@alpha)."
+    required: false
+    default: ""
   additional_permissions:
     description: "Additional GitHub permissions to request (e.g., 'actions: read')"
     required: false
@@ -298,6 +302,7 @@ runs:
         INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}
+        INPUT_TASK_BUDGET: ${{ inputs.task_budget }}
         DISPLAY_REPORT: ${{ inputs.display_report }}
         INPUT_PLUGINS: ${{ inputs.plugins }}
         INPUT_PLUGIN_MARKETPLACES: ${{ inputs.plugin_marketplaces }}

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "Additional arguments to pass directly to Claude CLI (e.g., '--max-turns 3 --mcp-config /path/to/config.json')"
     required: false
     default: ""
+  task_budget:
+    description: "API-side token budget (total tokens). When set, the model is made aware of its remaining budget and can pace its tool use accordingly. Maps to the SDK taskBudget.total option (@alpha)."
+    required: false
+    default: ""
 
   # Authentication settings
   anthropic_api_key:
@@ -166,6 +170,7 @@ runs:
         INPUT_PROMPT_FILE: ${{ inputs.prompt_file }}
         INPUT_SETTINGS: ${{ inputs.settings }}
         INPUT_CLAUDE_ARGS: ${{ inputs.claude_args }}
+        INPUT_TASK_BUDGET: ${{ inputs.task_budget }}
         INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE: ${{ inputs.path_to_claude_code_executable }}
         INPUT_PATH_TO_BUN_EXECUTABLE: ${{ inputs.path_to_bun_executable }}
         INPUT_SHOW_FULL_OUTPUT: ${{ inputs.show_full_output }}

--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -42,6 +42,7 @@ async function run() {
       allowedTools: process.env.INPUT_ALLOWED_TOOLS,
       disallowedTools: process.env.INPUT_DISALLOWED_TOOLS,
       maxTurns: process.env.INPUT_MAX_TURNS,
+      taskBudget: process.env.INPUT_TASK_BUDGET,
       mcpConfig: process.env.INPUT_MCP_CONFIG,
       systemPrompt: process.env.INPUT_SYSTEM_PROMPT,
       appendSystemPrompt: process.env.INPUT_APPEND_SYSTEM_PROMPT,

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -258,6 +258,9 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
     // Direct options from ClaudeOptions inputs
     model: options.model,
     maxTurns: options.maxTurns ? parseInt(options.maxTurns, 10) : undefined,
+    taskBudget: options.taskBudget
+      ? { total: parseInt(options.taskBudget, 10) }
+      : undefined,
     allowedTools:
       mergedAllowedTools.length > 0 ? mergedAllowedTools : undefined,
     disallowedTools:

--- a/base-action/src/run-claude.ts
+++ b/base-action/src/run-claude.ts
@@ -9,6 +9,7 @@ export type ClaudeOptions = {
   allowedTools?: string;
   disallowedTools?: string;
   maxTurns?: string;
+  taskBudget?: string;
   mcpConfig?: string;
   systemPrompt?: string;
   appendSystemPrompt?: string;

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -286,6 +286,7 @@ async function run() {
       model: process.env.ANTHROPIC_MODEL,
       pathToClaudeCodeExecutable: claudeExecutable,
       showFullOutput: process.env.INPUT_SHOW_FULL_OUTPUT,
+      taskBudget: process.env.INPUT_TASK_BUDGET,
     });
 
     claudeSuccess = claudeResult.conclusion === "success";


### PR DESCRIPTION
## Summary

Closes #1329.

The SDK has supported `taskBudget` since v0.2.84 but there was no way to set it from the action layer — passing `--task-budget` via `claude_args` was silently ignored because the CLI doesn't recognise that flag.

- Added `task_budget` input to both `action.yml` and `base-action/action.yml`
- Added `taskBudget?: string` to `ClaudeOptions` in `base-action/src/run-claude.ts`
- Wired it through `parseSdkOptions` as `sdkOptions.taskBudget = { total: parseInt(...) }` (same pattern as `maxTurns`)
- Passed `INPUT_TASK_BUDGET` env var from both action entrypoints (`base-action/src/index.ts` and `src/entrypoints/run.ts`)

## Test plan

- [ ] Set `task_budget: 200000` in a workflow using this action and confirm the SDK receives `taskBudget: { total: 200000 }` (visible in step debug output with `show_full_output: true`)
- [x] Omitting `task_budget` leaves the field `undefined` — no change in existing behaviour
- [x] Passing a non-numeric value is handled the same way as `maxTurns` (`parseInt` produces `NaN`, SDK rejects it at runtime)