### PR TITLE
Security: Add -- delimiter and validateBranchName in agent modeFix fetch command to include baseBranch correctly

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -113,7 +113,7 @@ export function restoreConfigFromBase(baseBranch: string): void {
   // fetch.recurseSubmodules config. Defense-in-depth alongside the delete above.
   execFileSync(
     "git",
-    ["fetch", "origin", baseBranch, "--depth=1", "--no-recurse-submodules"],
+    ["fetch", "origin", "--depth=1", "--no-recurse-submodules", "--", baseBranch],
     {
       stdio: "inherit",
       env: process.env,

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -5,6 +5,7 @@ import {
   configureGitAuth,
   setupSshSigning,
 } from "../../github/operations/git-config";
+import { validateBranchName } from "../../github/operations/branch";
 import { checkHumanActor } from "../../github/validation/actor";
 import type { GitHubContext } from "../../github/context";
 import type { Octokits } from "../../github/api/client";
@@ -85,8 +86,9 @@ export async function prepareAgentMode({
 
   // Check for branch info from environment variables (useful for auto-fix workflows)
   const claudeBranch = process.env.CLAUDE_BRANCH || undefined;
-  const defaultBranch = context.repository.default_branch || "main";
   const baseBranch = context.inputs.baseBranch || defaultBranch;
+  validateBranchName(baseBranch);
+  
 
   // Detect current branch from GitHub environment
   const currentBranch =


### PR DESCRIPTION
Defense-in-depth security hardening fixes:

- Add -- positional delimiter in restoreConfigFromBase to prevent 
  git option injection via baseBranch (CWE-88)
- Add validateBranchName() in agent mode for consistency with tag mode

Related: HackerOne report #3784661