### PR TITLE
fix(image-downloader): detect image type from magic bytes, not URL extension

### DIFF
--- a/src/github/utils/image-downloader.ts
+++ b/src/github/utils/image-downloader.ts
@@ -192,10 +192,6 @@ export async function downloadCommentImages(
           continue;
         }
 
-        const fileExtension = getImageExtension(originalUrl);
-        const filename = `image-${Date.now()}-${i}${fileExtension}`;
-        const localPath = path.join(downloadsDir, filename);
-
         try {
           console.log(`Downloading ${originalUrl}...`);
 
@@ -208,6 +204,19 @@ export async function downloadCommentImages(
 
           const arrayBuffer = await imageResponse.arrayBuffer();
           const buffer = Buffer.from(arrayBuffer);
+
+          // GitHub user-attachment URLs (/user-attachments/assets/<uuid>) carry
+          // no file extension, so the URL-based guess silently falls back to
+          // ".png". When the bytes are actually JPEG/GIF/WebP, the saved file is
+          // mislabeled and the Read tool sends a base64 image with the wrong
+          // media_type, which the Anthropic API rejects (400 invalid_request).
+          // Detect the real type from the magic bytes and only fall back to the
+          // URL extension when the signature is unrecognized.
+          const fileExtension =
+            detectImageExtensionFromBuffer(buffer) ??
+            getImageExtension(originalUrl);
+          const filename = `image-${Date.now()}-${i}${fileExtension}`;
+          const localPath = path.join(downloadsDir, filename);
 
           await fs.writeFile(localPath, buffer);
           console.log(`✓ Saved: ${localPath}`);
@@ -243,4 +252,57 @@ function getImageExtension(url: string): string {
 
   const match = filename.match(/\.(png|jpg|jpeg|gif|webp|svg)$/i);
   return match ? match[0] : ".png";
+}
+
+/**
+ * Determine an image's file extension from its magic bytes, independent of the
+ * (often extensionless) source URL. Returns undefined when the signature is not
+ * a format we can confidently identify, so the caller can fall back to the
+ * URL-based extension. Covers the raster formats the Anthropic API accepts.
+ */
+function detectImageExtensionFromBuffer(buffer: Buffer): string | undefined {
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47
+  ) {
+    return ".png";
+  }
+  // JPEG: FF D8 FF
+  if (
+    buffer.length >= 3 &&
+    buffer[0] === 0xff &&
+    buffer[1] === 0xd8 &&
+    buffer[2] === 0xff
+  ) {
+    return ".jpg";
+  }
+  // GIF: "GIF8" (47 49 46 38)
+  if (
+    buffer.length >= 6 &&
+    buffer[0] === 0x47 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x38
+  ) {
+    return ".gif";
+  }
+  // WebP: "RIFF" (52 49 46 46) .... "WEBP" (57 45 42 50) at offset 8
+  if (
+    buffer.length >= 12 &&
+    buffer[0] === 0x52 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x46 &&
+    buffer[8] === 0x57 &&
+    buffer[9] === 0x45 &&
+    buffer[10] === 0x42 &&
+    buffer[11] === 0x50
+  ) {
+    return ".webp";
+  }
+  return undefined;
 }

--- a/test/image-downloader.test.ts
+++ b/test/image-downloader.test.ts
@@ -158,6 +158,55 @@ describe("downloadCommentImages", () => {
     );
   });
 
+  test("should save a JPEG from an extensionless URL with a .jpg extension", async () => {
+    // Regression for the case where a JPEG screenshot is pasted into an issue.
+    // GitHub serves it from /user-attachments/assets/<uuid> (no extension), so
+    // the URL-based guess used to default to ".png" while the bytes are JPEG —
+    // producing a mislabeled file that the Anthropic API rejected with a 400.
+    const mockOctokit = createMockOctokit();
+    const imageUrl =
+      "https://github.com/user-attachments/assets/f871c23e-a84d-4f1f-b9a0-86626c63f161";
+    const signedUrl =
+      "https://private-user-images.githubusercontent.com/screenshot?jwt=token";
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.get = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl}">`,
+      },
+    });
+
+    // JPEG magic bytes: FF D8 FF, then arbitrary padding.
+    const jpegBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => jpegBytes.buffer,
+    } as Response);
+
+    const comments: CommentWithImages[] = [
+      {
+        type: "issue_body",
+        issueNumber: "143",
+        body: `![Screenshot_20260607_204205_Chrome.jpg](${imageUrl})`,
+      },
+    ];
+
+    const result = await downloadCommentImages(
+      mockOctokit,
+      "owner",
+      "repo",
+      comments,
+    );
+
+    expect(fsWriteFileSpy).toHaveBeenCalledWith(
+      "/tmp/github-images/image-1704067200000-0.jpg",
+      Buffer.from(jpegBytes.buffer),
+    );
+    expect(result.get(imageUrl)).toBe(
+      "/tmp/github-images/image-1704067200000-0.jpg",
+    );
+  });
+
   test("should handle review comments", async () => {
     const mockOctokit = createMockOctokit();
     const imageUrl =


### PR DESCRIPTION
## Problem

When an image is **pasted** into an issue/PR/comment, GitHub serves it from an attachment URL with **no file extension**, e.g.:

```
https://github.com/user-attachments/assets/f871c23e-a84d-4f1f-b9a0-86626c63f161
```

`getImageExtension()` in `src/github/utils/image-downloader.ts` derives the extension from this URL and falls back to `.png` when there's no match:

```ts
const match = filename.match(/\.(png|jpg|jpeg|gif|webp|svg)$/i);
return match ? match[0] : ".png";   // extensionless attachment → always ".png"
```

So a **JPEG** screenshot is downloaded and saved as `image-….png`. When Claude then `Read`s that file, the media type is inferred from the `.png` extension, and the request sends JPEG bytes labeled `image/png`. The Anthropic API validates magic bytes against the declared `media_type` and rejects the whole turn:

```
API Error: 400 invalid_request_error
messages.N.content.0.tool_result.content.0.image.source.base64:
The image was specified using the image/png media type,
but the image appears to be a image/jpeg image
```

This kills any run where a user pastes a JPEG/GIF/WebP screenshot — a very common case (mobile/Chrome screenshots are frequently JPEG). The alt text often even carries the real extension (`![Screenshot_….jpg](…)`), but the URL doesn't.

## Fix

Sniff the real format from the downloaded buffer's **magic bytes** and only fall back to the URL-based extension when the signature is unrecognized:

- PNG `89 50 4E 47`
- JPEG `FF D8 FF`
- GIF `47 49 46 38` (`GIF8`)
- WebP `52 49 46 46 … 57 45 42 50` (`RIFF…WEBP`)

The extension is now computed **after** download (we need the bytes), so the file is saved with the correct extension and downstream media-type inference matches the actual content.

## Notes

- Backwards compatible: unrecognized signatures still fall back to `getImageExtension(url)`, so existing behavior is unchanged for anything not covered above.
- This is a composite (bun) action that runs the TS source directly — no bundle to rebuild.

## Testing

- `bun run typecheck` — clean
- `bun test test/image-downloader.test.ts` — **20 pass / 0 fail** (added a regression test: a JPEG served from an extensionless `/user-attachments/assets/<uuid>` URL is saved as `.jpg`)