### PR TITLE
fix(examples): update workflow permissions for proper operation

### DIFF
--- a/examples/claude-code-review.yml
+++ b/examples/claude-code-review.yml
@@ -1,0 +1,26 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  code-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/examples/pr-review-comprehensive.yml
+++ b/examples/pr-review-comprehensive.yml
@@ -11,8 +11,9 @@ jobs:
   review-with-tracking:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository

--- a/examples/pr-review-filtered-authors.yml
+++ b/examples/pr-review-filtered-authors.yml
@@ -13,8 +13,9 @@ jobs:
       github.event.pull_request.user.login == 'external-contributor'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository

--- a/examples/pr-review-filtered-paths.yml
+++ b/examples/pr-review-filtered-paths.yml
@@ -14,8 +14,9 @@ jobs:
   claude-review-paths:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The example workflow files had insufficient permissions that would prevent the action from functioning correctly. The workflows need write access to contents, pull-requests, and issues to perform code reviews and post comments. Updated pr-review-comprehensive.yml, pr-review-filtered-authors.yml, and pr-review-filtered-paths.yml to change permissions from read to write where needed. Also added a new code-review.yml example that demonstrates using the /code-review command with proper permissions configured from the start.

Fixes #1383