### PR TITLE
fix: enforce allowed_bots check for all bot actors

### DIFF
--- a/src/github/validation/permissions.ts
+++ b/src/github/validation/permissions.ts
@@ -71,7 +71,16 @@ export async function checkWritePermissions(
     // bot signal that doesn't require an API lookup.
     if (actor.endsWith("[bot]")) {
       core.info(`Actor is a GitHub App: ${actor}`);
-      return true;
+      if (isAllowedBot(actor, allowedBots)) {
+        core.info(
+          `Bot actor ${actor} is in allowed_bots list, granting access`,
+        );
+        return true;
+      }
+      core.warning(
+        `Bot actor ${actor} is not in allowed_bots list. Add it to allowed_bots or use '*' to allow all bots.`,
+      );
+      return false;
     }
 
     // For all other actors, resolve the account via the collaborator

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -131,14 +131,60 @@ describe("checkWritePermissions", () => {
     );
   });
 
-  test("should return true for bot user", async () => {
+  test("should return true for bot user when in allowed_bots", async () => {
     const mockOctokit = createMockOctokit("none");
     const context = createContext();
     context.actor = "test-bot[bot]";
+    context.inputs.allowedBots = "test-bot";
 
     const result = await checkWritePermissions(mockOctokit, context);
 
     expect(result).toBe(true);
+    expect(coreInfoSpy).toHaveBeenCalledWith(
+      "Bot actor test-bot[bot] is in allowed_bots list, granting access",
+    );
+  });
+
+  test("should return true for bot user when allowed_bots is '*'", async () => {
+    const mockOctokit = createMockOctokit("none");
+    const context = createContext();
+    context.actor = "test-bot[bot]";
+    context.inputs.allowedBots = "*";
+
+    const result = await checkWritePermissions(mockOctokit, context);
+
+    expect(result).toBe(true);
+    expect(coreInfoSpy).toHaveBeenCalledWith(
+      "Bot actor test-bot[bot] is in allowed_bots list, granting access",
+    );
+  });
+
+  test("should return false for bot user when not in allowed_bots", async () => {
+    const mockOctokit = createMockOctokit("none");
+    const context = createContext();
+    context.actor = "test-bot[bot]";
+    context.inputs.allowedBots = "other-bot";
+
+    const result = await checkWritePermissions(mockOctokit, context);
+
+    expect(result).toBe(false);
+    expect(coreWarningSpy).toHaveBeenCalledWith(
+      "Bot actor test-bot[bot] is not in allowed_bots list. Add it to allowed_bots or use '*' to allow all bots.",
+    );
+  });
+
+  test("should return false for bot user when allowed_bots is empty", async () => {
+    const mockOctokit = createMockOctokit("none");
+    const context = createContext();
+    context.actor = "github-actions[bot]";
+    context.inputs.allowedBots = "";
+
+    const result = await checkWritePermissions(mockOctokit, context);
+
+    expect(result).toBe(false);
+    expect(coreWarningSpy).toHaveBeenCalledWith(
+      "Bot actor github-actions[bot] is not in allowed_bots list. Add it to allowed_bots or use '*' to allow all bots.",
+    );
   });
 
   test("should throw error when permission check fails", async () => {
@@ -285,10 +331,11 @@ describe("checkWritePermissions", () => {
       );
     });
 
-    test("should bypass for bot users even when allowed_non_write_users is set", async () => {
+    test("should check allowed_bots for bot users even when allowed_non_write_users is set", async () => {
       const mockOctokit = createMockOctokit("none");
       const context = createContext();
       context.actor = "test-bot[bot]";
+      context.inputs.allowedBots = "test-bot";
 
       const result = await checkWritePermissions(
         mockOctokit,
@@ -300,6 +347,9 @@ describe("checkWritePermissions", () => {
       expect(result).toBe(true);
       expect(coreInfoSpy).toHaveBeenCalledWith(
         "Actor is a GitHub App: test-bot[bot]",
+      );
+      expect(coreInfoSpy).toHaveBeenCalledWith(
+        "Bot actor test-bot[bot] is in allowed_bots list, granting access",
       );
     });
   });


### PR DESCRIPTION
The permissions check in `src/github/validation/permissions.ts` had a security bypass where actors ending with `[bot]` were automatically granted access without checking the `allowed_bots` input. This meant that `github-actions[bot]` and other accounts could trigger the action even when `allowed_bots` was empty or didn't include them.

The issue manifested when GitHub Actions comments were marked with a reaction but didn't trigger the workflow. This was because the actor passed the permissions check but was then silently rejected elsewhere in the execution flow.

The fix moves the `isAllowedBot` check to apply to all actors with the `[bot]` suffix, not just those that fail the collaborator API lookup. Now actors must be explicitly listed in `allowed_bots` (or use `allowed_bots: '*'` to allow all) before they can trigger the action.

Updated test cases to verify that actors are properly validated against the `allowed_bots` list and will be rejected when not included.

Fixes #591