### PR TITLE
fix: share one exchanged WIF credential across spawned Claude processes

### DIFF
--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -75,7 +75,8 @@ async function run() {
     core.setOutput("conclusion", "failure");
     process.exit(1);
   } finally {
-    // Stop refreshing the workload identity token file so the process can exit
+    // Stop refreshing the workload identity token file (so the process can
+    // exit) and delete the token material so it doesn't outlive this step
     workloadIdentity?.stop();
   }
 }

--- a/base-action/src/workload-identity.ts
+++ b/base-action/src/workload-identity.ts
@@ -15,7 +15,8 @@
  */
 
 import * as core from "@actions/core";
-import { mkdirSync, writeFileSync } from "fs";
+import { createHash } from "crypto";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { retryWithBackoff } from "./retry";
 
@@ -51,48 +52,57 @@ async function fetchIdentityToken(audience: string) {
 }
 
 /**
- * Writes a profile config that loads federation from the identity-token file.
- * Resolving federation through a profile (rather than bare env vars) enables
- * the SDK's on-disk credentials cache, so the several `claude` processes the
- * action spawns (plugin installs, main query) share one exchanged access token
- * instead of each re-exchanging the single-use GitHub OIDC token, which fails
- * with 401 (`jti_reused`).
+ * Writes a profile config that switches federation resolution to the
+ * file-backed path. Resolving federation through a profile (rather than bare
+ * env vars) enables the SDK's on-disk credentials cache, so the several
+ * `claude` processes the action spawns (plugin installs, main query) share
+ * one exchanged access token instead of each re-exchanging the single-use
+ * GitHub OIDC token, which fails with 401 (`jti_reused`).
+ *
+ * The profile is intentionally minimal: the SDK gap-fills the federation
+ * fields (rule, organization, identity-token file, service account, base URL)
+ * from the ANTHROPIC_* env vars the action already exports, so the file only
+ * needs to exist to turn the cache on.
+ *
+ * The config dir name embeds a fingerprint of the federation inputs. The
+ * SDK's cache reuses a token on `expires_at` alone, with no record of the
+ * config that minted it, and the token's scope is bound at mint time — so a
+ * later action step in the same job (RUNNER_TEMP is per-job) with different
+ * federation inputs must land in a different dir or it would silently reuse
+ * the first step's token.
+ *
+ * Sharing the cache is only safe while the action spawns its `claude`
+ * subprocesses sequentially: the SDK cache is not cross-process serialized,
+ * and concurrent cache misses would each re-exchange the same single-use
+ * identity token. Parallelizing the plugin installs would reintroduce the
+ * `jti_reused` failures.
  */
-function writeFederationProfile(tokenFile: string): string {
-  const configDir = join(
-    process.env.RUNNER_TEMP || "/tmp",
-    "claude-workload-identity",
-    "config",
-  );
-  const serviceAccountId = process.env.ANTHROPIC_SERVICE_ACCOUNT_ID?.trim();
-  const workspaceId = process.env.ANTHROPIC_WORKSPACE_ID?.trim();
-  const baseUrl = process.env.ANTHROPIC_BASE_URL?.trim();
-
-  const authentication: Record<string, unknown> = {
-    type: "oidc_federation",
-    federation_rule_id: process.env.ANTHROPIC_FEDERATION_RULE_ID?.trim(),
-    identity_token: { source: "file", path: tokenFile },
-  };
-  if (serviceAccountId) {
-    authentication.service_account_id = serviceAccountId;
-  }
-
-  const profile: Record<string, unknown> = {
-    version: "1.0",
-    authentication,
-    organization_id: process.env.ANTHROPIC_ORGANIZATION_ID?.trim(),
-  };
-  if (workspaceId) {
-    profile.workspace_id = workspaceId;
-  }
-  if (baseUrl) {
-    profile.base_url = baseUrl;
-  }
+function writeFederationProfile(baseDir: string): string {
+  // Every input that changes which credential the exchange mints must be in
+  // here; service_account_id and scope are sent in the exchange request body.
+  const fingerprint = createHash("sha256")
+    .update(
+      JSON.stringify([
+        process.env.ANTHROPIC_FEDERATION_RULE_ID?.trim() ?? "",
+        process.env.ANTHROPIC_ORGANIZATION_ID?.trim() ?? "",
+        process.env.ANTHROPIC_SERVICE_ACCOUNT_ID?.trim() ?? "",
+        process.env.ANTHROPIC_WORKSPACE_ID?.trim() ?? "",
+        process.env.ANTHROPIC_BASE_URL?.trim() ?? "",
+        process.env.ANTHROPIC_SCOPE?.trim() ?? "",
+      ]),
+    )
+    .digest("hex")
+    .slice(0, 16);
+  const configDir = join(baseDir, `config-${fingerprint}`);
 
   mkdirSync(join(configDir, "configs"), { recursive: true, mode: 0o700 });
   writeFileSync(
     join(configDir, "configs", "default.json"),
-    JSON.stringify(profile, null, 2),
+    JSON.stringify(
+      { version: "1.0", authentication: { type: "oidc_federation" } },
+      null,
+      2,
+    ),
     { mode: 0o600 },
   );
   return configDir;
@@ -105,7 +115,8 @@ function writeFederationProfile(tokenFile: string): string {
  *
  * Returns undefined when federation is not configured or is shadowed by a
  * higher-precedence credential. Callers must invoke stop() when execution
- * finishes.
+ * finishes; it also deletes the identity token and any cached exchanged
+ * credential.
  */
 export async function setupWorkloadIdentity(): Promise<
   WorkloadIdentityHandle | undefined
@@ -149,8 +160,17 @@ export async function setupWorkloadIdentity(): Promise<
   }
 
   process.env.ANTHROPIC_IDENTITY_TOKEN_FILE = tokenFile;
-  process.env.ANTHROPIC_CONFIG_DIR = writeFederationProfile(tokenFile);
-  process.env.ANTHROPIC_PROFILE = "default";
+  if (
+    process.env.ANTHROPIC_CONFIG_DIR?.trim() ||
+    process.env.ANTHROPIC_PROFILE?.trim()
+  ) {
+    core.warning(
+      "ANTHROPIC_CONFIG_DIR or ANTHROPIC_PROFILE is already set, so the action will not write its own federation profile. Credential caching across the spawned Claude processes follows the existing profile configuration.",
+    );
+  } else {
+    process.env.ANTHROPIC_CONFIG_DIR = writeFederationProfile(tokenDir);
+    process.env.ANTHROPIC_PROFILE = "default";
+  }
   console.log(
     `Workload identity federation configured (rule: ${process.env.ANTHROPIC_FEDERATION_RULE_ID}, identity token file: ${tokenFile})`,
   );
@@ -165,6 +185,12 @@ export async function setupWorkloadIdentity(): Promise<
 
   return {
     tokenFile,
-    stop: () => clearInterval(refreshInterval),
+    stop: () => {
+      clearInterval(refreshInterval);
+      // RUNNER_TEMP is per-job, not per-step: remove the identity token, the
+      // profile, and the cached exchanged credential so they don't outlive
+      // this step.
+      rmSync(tokenDir, { recursive: true, force: true });
+    },
   };
 }

--- a/base-action/src/workload-identity.ts
+++ b/base-action/src/workload-identity.ts
@@ -51,6 +51,54 @@ async function fetchIdentityToken(audience: string) {
 }
 
 /**
+ * Writes a profile config that loads federation from the identity-token file.
+ * Resolving federation through a profile (rather than bare env vars) enables
+ * the SDK's on-disk credentials cache, so the several `claude` processes the
+ * action spawns (plugin installs, main query) share one exchanged access token
+ * instead of each re-exchanging the single-use GitHub OIDC token, which fails
+ * with 401 (`jti_reused`).
+ */
+function writeFederationProfile(tokenFile: string): string {
+  const configDir = join(
+    process.env.RUNNER_TEMP || "/tmp",
+    "claude-workload-identity",
+    "config",
+  );
+  const serviceAccountId = process.env.ANTHROPIC_SERVICE_ACCOUNT_ID?.trim();
+  const workspaceId = process.env.ANTHROPIC_WORKSPACE_ID?.trim();
+  const baseUrl = process.env.ANTHROPIC_BASE_URL?.trim();
+
+  const authentication: Record<string, unknown> = {
+    type: "oidc_federation",
+    federation_rule_id: process.env.ANTHROPIC_FEDERATION_RULE_ID?.trim(),
+    identity_token: { source: "file", path: tokenFile },
+  };
+  if (serviceAccountId) {
+    authentication.service_account_id = serviceAccountId;
+  }
+
+  const profile: Record<string, unknown> = {
+    version: "1.0",
+    authentication,
+    organization_id: process.env.ANTHROPIC_ORGANIZATION_ID?.trim(),
+  };
+  if (workspaceId) {
+    profile.workspace_id = workspaceId;
+  }
+  if (baseUrl) {
+    profile.base_url = baseUrl;
+  }
+
+  mkdirSync(join(configDir, "configs"), { recursive: true, mode: 0o700 });
+  writeFileSync(
+    join(configDir, "configs", "default.json"),
+    JSON.stringify(profile, null, 2),
+    { mode: 0o600 },
+  );
+  return configDir;
+}
+
+/**
  * Fetches a GitHub Actions OIDC token, writes it to a file in RUNNER_TEMP,
  * exports ANTHROPIC_IDENTITY_TOKEN_FILE, and starts a background refresh so
  * the file stays valid for long executions.
@@ -101,6 +149,8 @@ export async function setupWorkloadIdentity(): Promise<
   }
 
   process.env.ANTHROPIC_IDENTITY_TOKEN_FILE = tokenFile;
+  process.env.ANTHROPIC_CONFIG_DIR = writeFederationProfile(tokenFile);
+  process.env.ANTHROPIC_PROFILE = "default";
   console.log(
     `Workload identity federation configured (rule: ${process.env.ANTHROPIC_FEDERATION_RULE_ID}, identity token file: ${tokenFile})`,
   );

--- a/base-action/test/workload-identity.test.ts
+++ b/base-action/test/workload-identity.test.ts
@@ -27,6 +27,11 @@ describe("workload identity federation", () => {
     delete process.env.ANTHROPIC_ORGANIZATION_ID;
     delete process.env.ANTHROPIC_OIDC_AUDIENCE;
     delete process.env.ANTHROPIC_IDENTITY_TOKEN_FILE;
+    delete process.env.ANTHROPIC_SERVICE_ACCOUNT_ID;
+    delete process.env.ANTHROPIC_WORKSPACE_ID;
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_CONFIG_DIR;
+    delete process.env.ANTHROPIC_PROFILE;
 
     getIDTokenSpy = spyOn(core, "getIDToken").mockResolvedValue(
       "test-identity-token",
@@ -119,6 +124,64 @@ describe("workload identity federation", () => {
         expect(getIDTokenSpy).toHaveBeenCalledWith(
           "https://example.com/custom",
         );
+      } finally {
+        handle?.stop();
+      }
+    });
+
+    test("writes a federation profile and selects it", async () => {
+      process.env.ANTHROPIC_FEDERATION_RULE_ID = "fdrl_test";
+      process.env.ANTHROPIC_ORGANIZATION_ID =
+        "00000000-0000-0000-0000-000000000000";
+      process.env.ANTHROPIC_SERVICE_ACCOUNT_ID = "svac_test";
+      process.env.ANTHROPIC_WORKSPACE_ID = "wrkspc_test";
+
+      const handle = await setupWorkloadIdentity();
+      try {
+        const configDir = join(tempDir, "claude-workload-identity", "config");
+        expect(process.env.ANTHROPIC_CONFIG_DIR).toBe(configDir);
+        expect(process.env.ANTHROPIC_PROFILE).toBe("default");
+
+        const profilePath = join(configDir, "configs", "default.json");
+        expect(statSync(profilePath).mode & 0o777).toBe(0o600);
+        expect(JSON.parse(readFileSync(profilePath, "utf-8"))).toEqual({
+          version: "1.0",
+          authentication: {
+            type: "oidc_federation",
+            federation_rule_id: "fdrl_test",
+            identity_token: { source: "file", path: handle!.tokenFile },
+            service_account_id: "svac_test",
+          },
+          organization_id: "00000000-0000-0000-0000-000000000000",
+          workspace_id: "wrkspc_test",
+        });
+      } finally {
+        handle?.stop();
+      }
+    });
+
+    test("omits optional profile fields when unset", async () => {
+      process.env.ANTHROPIC_FEDERATION_RULE_ID = "fdrl_test";
+      process.env.ANTHROPIC_ORGANIZATION_ID =
+        "00000000-0000-0000-0000-000000000000";
+
+      const handle = await setupWorkloadIdentity();
+      try {
+        const profile = JSON.parse(
+          readFileSync(
+            join(
+              tempDir,
+              "claude-workload-identity",
+              "config",
+              "configs",
+              "default.json",
+            ),
+            "utf-8",
+          ),
+        );
+        expect(profile.authentication.service_account_id).toBeUndefined();
+        expect(profile.workspace_id).toBeUndefined();
+        expect(profile.base_url).toBeUndefined();
       } finally {
         handle?.stop();
       }

--- a/base-action/test/workload-identity.test.ts
+++ b/base-action/test/workload-identity.test.ts
@@ -2,7 +2,14 @@
 
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import * as core from "@actions/core";
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -30,6 +37,7 @@ describe("workload identity federation", () => {
     delete process.env.ANTHROPIC_SERVICE_ACCOUNT_ID;
     delete process.env.ANTHROPIC_WORKSPACE_ID;
     delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_SCOPE;
     delete process.env.ANTHROPIC_CONFIG_DIR;
     delete process.env.ANTHROPIC_PROFILE;
 
@@ -129,7 +137,7 @@ describe("workload identity federation", () => {
       }
     });
 
-    test("writes a federation profile and selects it", async () => {
+    test("writes a minimal federation profile and selects it", async () => {
       process.env.ANTHROPIC_FEDERATION_RULE_ID = "fdrl_test";
       process.env.ANTHROPIC_ORGANIZATION_ID =
         "00000000-0000-0000-0000-000000000000";
@@ -138,53 +146,113 @@ describe("workload identity federation", () => {
 
       const handle = await setupWorkloadIdentity();
       try {
-        const configDir = join(tempDir, "claude-workload-identity", "config");
-        expect(process.env.ANTHROPIC_CONFIG_DIR).toBe(configDir);
+        const configDir = process.env.ANTHROPIC_CONFIG_DIR;
+        expect(configDir).toBeDefined();
+        expect(
+          configDir!.startsWith(
+            join(tempDir, "claude-workload-identity", "config-"),
+          ),
+        ).toBe(true);
         expect(process.env.ANTHROPIC_PROFILE).toBe("default");
 
-        const profilePath = join(configDir, "configs", "default.json");
+        const profilePath = join(configDir!, "configs", "default.json");
         expect(statSync(profilePath).mode & 0o777).toBe(0o600);
+        // Minimal on purpose: the SDK gap-fills the federation fields from
+        // the ANTHROPIC_* env vars the action exports.
         expect(JSON.parse(readFileSync(profilePath, "utf-8"))).toEqual({
           version: "1.0",
-          authentication: {
-            type: "oidc_federation",
-            federation_rule_id: "fdrl_test",
-            identity_token: { source: "file", path: handle!.tokenFile },
-            service_account_id: "svac_test",
-          },
-          organization_id: "00000000-0000-0000-0000-000000000000",
-          workspace_id: "wrkspc_test",
+          authentication: { type: "oidc_federation" },
         });
       } finally {
         handle?.stop();
       }
     });
 
-    test("omits optional profile fields when unset", async () => {
+    test("derives the config dir from the federation inputs", async () => {
+      process.env.ANTHROPIC_FEDERATION_RULE_ID = "fdrl_test";
+      process.env.ANTHROPIC_ORGANIZATION_ID =
+        "00000000-0000-0000-0000-000000000000";
+      process.env.ANTHROPIC_WORKSPACE_ID = "wrkspc_a";
+
+      (await setupWorkloadIdentity())?.stop();
+      const firstConfigDir = process.env.ANTHROPIC_CONFIG_DIR;
+      expect(firstConfigDir).toBeDefined();
+
+      // A later step in the same job with a different workspace must not
+      // share the first step's credentials cache.
+      delete process.env.ANTHROPIC_CONFIG_DIR;
+      delete process.env.ANTHROPIC_PROFILE;
+      process.env.ANTHROPIC_WORKSPACE_ID = "wrkspc_b";
+
+      (await setupWorkloadIdentity())?.stop();
+      const secondConfigDir = process.env.ANTHROPIC_CONFIG_DIR;
+      expect(secondConfigDir).toBeDefined();
+      expect(secondConfigDir).not.toBe(firstConfigDir);
+
+      // Same inputs land in the same dir, so an unchanged config can still
+      // reuse a cached token.
+      delete process.env.ANTHROPIC_CONFIG_DIR;
+      delete process.env.ANTHROPIC_PROFILE;
+
+      (await setupWorkloadIdentity())?.stop();
+      expect(process.env.ANTHROPIC_CONFIG_DIR).toBe(secondConfigDir!);
+    });
+
+    test("does not overwrite an operator-set ANTHROPIC_PROFILE", async () => {
+      process.env.ANTHROPIC_FEDERATION_RULE_ID = "fdrl_test";
+      process.env.ANTHROPIC_ORGANIZATION_ID =
+        "00000000-0000-0000-0000-000000000000";
+      process.env.ANTHROPIC_PROFILE = "operator";
+
+      const handle = await setupWorkloadIdentity();
+      try {
+        expect(process.env.ANTHROPIC_PROFILE).toBe("operator");
+        expect(process.env.ANTHROPIC_CONFIG_DIR).toBeUndefined();
+        expect(warningSpy).toHaveBeenCalled();
+
+        const entries = readdirSync(join(tempDir, "claude-workload-identity"));
+        expect(entries.filter((e) => e.startsWith("config-"))).toEqual([]);
+
+        // The identity token file is still provisioned for the operator's
+        // profile (or the env-var fallback) to consume.
+        expect(process.env.ANTHROPIC_IDENTITY_TOKEN_FILE).toBe(
+          handle!.tokenFile,
+        );
+      } finally {
+        handle?.stop();
+      }
+    });
+
+    test("does not overwrite an operator-set ANTHROPIC_CONFIG_DIR", async () => {
+      process.env.ANTHROPIC_FEDERATION_RULE_ID = "fdrl_test";
+      process.env.ANTHROPIC_ORGANIZATION_ID =
+        "00000000-0000-0000-0000-000000000000";
+      const operatorConfigDir = join(tempDir, "operator-config");
+      process.env.ANTHROPIC_CONFIG_DIR = operatorConfigDir;
+
+      const handle = await setupWorkloadIdentity();
+      try {
+        expect(process.env.ANTHROPIC_CONFIG_DIR).toBe(operatorConfigDir);
+        expect(process.env.ANTHROPIC_PROFILE).toBeUndefined();
+        expect(warningSpy).toHaveBeenCalled();
+      } finally {
+        handle?.stop();
+      }
+    });
+
+    test("stop removes the identity token and credential cache", async () => {
       process.env.ANTHROPIC_FEDERATION_RULE_ID = "fdrl_test";
       process.env.ANTHROPIC_ORGANIZATION_ID =
         "00000000-0000-0000-0000-000000000000";
 
       const handle = await setupWorkloadIdentity();
-      try {
-        const profile = JSON.parse(
-          readFileSync(
-            join(
-              tempDir,
-              "claude-workload-identity",
-              "config",
-              "configs",
-              "default.json",
-            ),
-            "utf-8",
-          ),
-        );
-        expect(profile.authentication.service_account_id).toBeUndefined();
-        expect(profile.workspace_id).toBeUndefined();
-        expect(profile.base_url).toBeUndefined();
-      } finally {
-        handle?.stop();
-      }
+      const tokenDir = join(tempDir, "claude-workload-identity");
+      expect(existsSync(handle!.tokenFile)).toBe(true);
+      expect(existsSync(process.env.ANTHROPIC_CONFIG_DIR!)).toBe(true);
+
+      handle!.stop();
+
+      expect(existsSync(tokenDir)).toBe(false);
     });
   });
 });

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -314,7 +314,8 @@ async function run() {
   } finally {
     // Phase 4: Cleanup (always runs)
 
-    // Stop refreshing the workload identity token file
+    // Stop refreshing the workload identity token file and delete the token
+    // material so it doesn't outlive this step
     workloadIdentity?.stop();
 
     // Update tracking comment


### PR DESCRIPTION
Fixes #1406

## Problem

GitHub OIDC tokens are single-use at the Anthropic token-exchange endpoint (the same `jti` cannot be exchanged twice). When the `plugins` / `plugin_marketplaces` inputs are configured, the action spawns several short-lived `claude` processes per job (`claude plugin marketplace add`, one `claude plugin install` per plugin, then the main query). Each process resolved workload identity federation from the bare env vars and exchanged the **same identity-token file** independently: the first exchange succeeded and every later process got 401 (`jti_reused`), which the main query retried for ~3 minutes before failing the job. Details, eBPF process traces, and request-ids in #1406.

## Fix

The SDK only enables its on-disk credentials cache (`<config_dir>/credentials/<profile>.json`, shared across processes) when federation is loaded from a **profile config file**, not from bare env vars. `setupWorkloadIdentity()` now additionally writes a profile pointing at the identity-token file and selects it via `ANTHROPIC_CONFIG_DIR` + `ANTHROPIC_PROFILE`, so the first process exchanges once and every other process reuses the cached access token.

- The profile lives in an action-owned dir under `RUNNER_TEMP` (0700 dir / 0600 file), next to the identity token.
- `ANTHROPIC_IDENTITY_TOKEN_FILE` and the federation env vars are kept as a fallback for CLIs that predate profile support — older CLIs degrade to today's behavior, never worse.
- The existing 4-minute identity-token refresh is unchanged; after the cached access token expires, the next exchange picks up the refreshed (new-`jti`) token from the same file path recorded in the profile.

## Verification

- `bun test`: 702/702 pass (includes 2 new unit tests for the profile file), `bun run typecheck`, `bun run format:check` all green.
- Local reproduction against a mock exchange endpoint that enforces single-use `jti`: two sequential `claude` processes sharing one identity token — env-var path: second process retries `jti_reused` for ~3 minutes and dies (matches production failures exactly); profile path: second process reuses the cached credential with zero additional exchanges and succeeds. Verified with both Claude Code 2.1.167 and 2.1.173.
- On a GitHub-hosted runner with a real federation rule: the exact configuration that previously failed on 100% of runs (two trailofbits plugins + WIF, on both v1.0.139 and v1.0.144) succeeds with this branch — `is_error: false`, main query completes in ~6s. An eBPF trace shows the same five `claude` processes contacting `api.anthropic.com`, now with a single token exchange.

## Notes / limitations

- A cold-start race (two processes exchanging before the first cache write) is still theoretically possible, but the action spawns its subprocesses sequentially, so in practice the first one exchanges and the rest reuse. A complete fix (serializing the exchange / locking the credentials file) would belong in the CLI/SDK.
- If a user has pre-set `ANTHROPIC_CONFIG_DIR` / `ANTHROPIC_PROFILE`, they are overridden while federation inputs are configured (federation inputs are an explicit opt-in, and previously the env-var path was similarly authoritative).