### PR TITLE
fix(github): avoid fork PR branch checkout collisions

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -184,8 +184,12 @@ export async function setupBranch(
       validateBranchName(branchName);
 
       // For cross-repository (fork) PRs, fetch via the pull ref since the
-      // branch only exists on the fork's remote, not on origin.
+      // branch only exists on the fork's remote, not on origin. Fetch into a
+      // namespaced remote-tracking ref so a fork branch named like the checked
+      // out local branch (for example "main") cannot collide with refs/heads/*.
       if (prData.isCrossRepository) {
+        const pullHeadRef = `refs/remotes/pull/${entityNumber}/head`;
+
         console.log(
           `PR #${entityNumber} is from a fork, fetching via refs/pull/${entityNumber}/head...`,
         );
@@ -193,14 +197,15 @@ export async function setupBranch(
           "fetch",
           "origin",
           `--depth=${fetchDepth}`,
-          `pull/${entityNumber}/head:${branchName}`,
+          `+pull/${entityNumber}/head:${pullHeadRef}`,
         ]);
+        execGit(["checkout", "--detach", pullHeadRef, "--"]);
       } else {
         // Execute git commands to checkout PR branch (dynamic depth based on PR size)
         // Using execFileSync instead of shell template literals for security
         execGit(["fetch", "origin", `--depth=${fetchDepth}`, branchName]);
+        execGit(["checkout", branchName, "--"]);
       }
-      execGit(["checkout", branchName, "--"]);
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);
 

--- a/test/setup-branch.test.ts
+++ b/test/setup-branch.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { execFileSync } from "child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { setupBranch } from "../src/github/operations/branch";
+import type { ParsedGitHubContext } from "../src/github/context";
+import type { Octokits } from "../src/github/api/client";
+import type { FetchDataResult } from "../src/github/data/fetcher";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+describe("setupBranch", () => {
+  let tempDir: string | undefined;
+  const originalCwd = process.cwd();
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  test("checks out fork PRs without fetching into a colliding local branch", async () => {
+    const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+    tempDir = mkdtempSync(join(tmpdir(), "setup-branch-"));
+
+    try {
+      const remoteDir = join(tempDir, "origin.git");
+      const sourceDir = join(tempDir, "source");
+      const runnerDir = join(tempDir, "runner");
+
+      git(tempDir, ["init", "--bare", "--initial-branch=main", remoteDir]);
+      git(tempDir, ["init", "--initial-branch=main", sourceDir]);
+      git(sourceDir, ["config", "user.email", "test@example.com"]);
+      git(sourceDir, ["config", "user.name", "Test User"]);
+      git(sourceDir, ["remote", "add", "origin", remoteDir]);
+
+      writeFileSync(join(sourceDir, "README.md"), "base\n");
+      git(sourceDir, ["add", "README.md"]);
+      git(sourceDir, ["commit", "-m", "base"]);
+      git(sourceDir, ["push", "origin", "HEAD:refs/heads/main"]);
+
+      writeFileSync(join(sourceDir, "README.md"), "fork pr\n");
+      git(sourceDir, ["commit", "-am", "fork pr"]);
+      const pullHeadSha = git(sourceDir, ["rev-parse", "HEAD"]);
+      git(sourceDir, ["push", "origin", "HEAD:refs/pull/38/head"]);
+
+      git(tempDir, ["clone", remoteDir, runnerDir]);
+      expect(git(runnerDir, ["branch", "--show-current"])).toBe("main");
+      process.chdir(runnerDir);
+
+      const result = await setupBranch(
+        {} as Octokits,
+        {
+          contextData: {
+            state: "OPEN",
+            headRefName: "main",
+            baseRefName: "main",
+            isCrossRepository: true,
+            commits: { totalCount: 1 },
+            title: "Fork PR from main",
+          },
+          comments: [],
+          changedFiles: [],
+          changedFilesWithSHA: [],
+          reviewData: null,
+          imageUrlMap: new Map(),
+        } as unknown as FetchDataResult,
+        {
+          repository: {
+            owner: "anthropics",
+            repo: "claude-code-action",
+            full_name: "anthropics/claude-code-action",
+          },
+          entityNumber: 38,
+          isPR: true,
+          inputs: {
+            prompt: "",
+            triggerPhrase: "@claude",
+            assigneeTrigger: "",
+            labelTrigger: "",
+            branchPrefix: "claude/",
+            useStickyComment: false,
+            classifyInlineComments: false,
+            useCommitSigning: false,
+            sshSigningKey: "",
+            botId: "41898282",
+            botName: "claude[bot]",
+            allowedBots: "",
+            allowedNonWriteUsers: "",
+            trackProgress: false,
+            includeFixLinks: false,
+            includeCommentsByActor: "",
+            excludeCommentsByActor: "",
+          },
+        } as unknown as ParsedGitHubContext,
+      );
+
+      expect(result).toEqual({ baseBranch: "main", currentBranch: "main" });
+      expect(git(runnerDir, ["rev-parse", "HEAD"])).toBe(pullHeadSha);
+      expect(git(runnerDir, ["branch", "--show-current"])).toBe("");
+      expect(git(runnerDir, ["rev-parse", "refs/heads/main"])).not.toBe(
+        pullHeadSha,
+      );
+      expect(git(runnerDir, ["rev-parse", "refs/remotes/pull/38/head"])).toBe(
+        pullHeadSha,
+      );
+    } finally {
+      consoleLogSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Fetch fork PR heads into a namespaced remote-tracking ref instead of `refs/heads/<headRefName>`.
- Check out fork PR heads detached so `their-fork:main -> upstream:main` cannot collide with the runner's checked-out `main` branch.
- Add a real-git regression test covering issue #1423.

Fixes #1423

## Screenshots
No visual change.

## Testing
- `bun test test/setup-branch.test.ts`
- `bun run typecheck`
- `bun run format:check`

## Risk
- Low: same-repository PR checkout is unchanged; cross-repository PR checkout now uses the existing GitHub pull ref without updating local branches.

## Notes
- This is distinct from #1219/#1218: that change made fork PRs fetchable from `refs/pull/N/head`; this change avoids writing that fetched commit into a checked-out local branch.

## AI Review Report
- Verified the current `setupBranch` fork path still fetched `pull/N/head:<headRefName>` before this patch.
- Added a regression test that starts on local `main`, exposes a fork PR ref also named `main`, and verifies HEAD detaches at the PR ref while `refs/heads/main` stays unchanged.

## Security Audit
- Git commands still use `execFileSync` argv arrays, not shell interpolation.
- The new destination ref is derived from the numeric PR entity number, not from user-controlled branch text.