### PR TITLE
fix: default to first-party model alias when none specified (#1416)

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -53,6 +53,50 @@ function unescapeShellMeta(s: string): string {
   return s.replace(SHELL_META_UNESCAPE_RE, (c) => SHELL_META_UNESCAPE.get(c)!);
 }
 
+// Default model alias for the first-party Anthropic API when the caller
+// specifies no model anywhere. An alias (resolved server-side to the current
+// snapshot) is used instead of a dated model id so the action never inherits
+// the SDK/CLI's bundled default, which can point at a retired model and return
+// a 404 not_found_error. See issue #1416.
+const DEFAULT_FIRST_PARTY_MODEL = "sonnet";
+
+/**
+ * Whether a non-first-party provider is configured. Bedrock/Vertex/Foundry use
+ * provider-specific model id formats for which a first-party alias is invalid,
+ * so we must not inject a default for them.
+ */
+function isThirdPartyProvider(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
+    env.CLAUDE_CODE_USE_BEDROCK ||
+      env.CLAUDE_CODE_USE_VERTEX ||
+      env.CLAUDE_CODE_USE_FOUNDRY,
+  );
+}
+
+/**
+ * Resolve the model passed to the SDK.
+ * Precedence: explicit `options.model` > `--model` in claudeArgs (extraArgs) >
+ * first-party default alias. Returns undefined when a model is already supplied
+ * via claudeArgs (so the CLI flag wins) or when a third-party provider is in use
+ * (so the provider resolves its own default).
+ */
+function resolveModel(
+  optionModel: string | undefined,
+  extraArgs: Record<string, string | null>,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const explicit = optionModel?.trim();
+  if (explicit) return explicit;
+
+  // A --model in claudeArgs is preserved in extraArgs and passed to the CLI;
+  // don't also set sdkOptions.model or it would be specified twice.
+  if (extraArgs["model"]) return undefined;
+
+  if (isThirdPartyProvider(env)) return undefined;
+
+  return DEFAULT_FIRST_PARTY_MODEL;
+}
+
 type McpConfig = {
   mcpServers?: Record<string, unknown>;
 };
@@ -295,7 +339,7 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   // Build SDK options - use merged tools from both direct options and claudeArgs
   const sdkOptions: SdkOptions = {
     // Direct options from ClaudeOptions inputs
-    model: options.model,
+    model: resolveModel(options.model, extraArgs, process.env),
     maxTurns: options.maxTurns ? parseInt(options.maxTurns, 10) : undefined,
     allowedTools:
       mergedAllowedTools.length > 0 ? mergedAllowedTools : undefined,

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -526,4 +526,88 @@ describe("parseSdkOptions", () => {
       }
     });
   });
+
+  describe("model defaulting", () => {
+    // Guard against leaking provider env vars between tests.
+    function withEnv(env: Record<string, string | undefined>, fn: () => void) {
+      const originalEnv = { ...process.env };
+      delete process.env.CLAUDE_CODE_USE_BEDROCK;
+      delete process.env.CLAUDE_CODE_USE_VERTEX;
+      delete process.env.CLAUDE_CODE_USE_FOUNDRY;
+      Object.assign(process.env, env);
+      try {
+        fn();
+      } finally {
+        process.env = originalEnv;
+      }
+    }
+
+    test("should default to the first-party alias when no model is specified", () => {
+      // Regression for #1416: with no model anywhere, the action used to pass
+      // model: undefined and inherit the SDK/CLI's retired default (404).
+      withEnv({}, () => {
+        const result = parseSdkOptions({});
+        expect(result.sdkOptions.model).toBe("sonnet");
+      });
+    });
+
+    test("should preserve an explicit options.model", () => {
+      withEnv({}, () => {
+        const result = parseSdkOptions({ model: "claude-opus-4-7" });
+        expect(result.sdkOptions.model).toBe("claude-opus-4-7");
+      });
+    });
+
+    test("should trim whitespace from an explicit options.model", () => {
+      withEnv({}, () => {
+        const result = parseSdkOptions({ model: "  claude-opus-4-7  " });
+        expect(result.sdkOptions.model).toBe("claude-opus-4-7");
+      });
+    });
+
+    test("should not set sdkOptions.model when --model is provided via claudeArgs", () => {
+      // The CLI flag in extraArgs wins; setting model here too would specify it twice.
+      withEnv({}, () => {
+        const result = parseSdkOptions({
+          claudeArgs: "--model claude-sonnet-4-6",
+        });
+        expect(result.sdkOptions.model).toBeUndefined();
+        expect(result.sdkOptions.extraArgs?.["model"]).toBe(
+          "claude-sonnet-4-6",
+        );
+      });
+    });
+
+    test("should not inject a default for Bedrock", () => {
+      withEnv({ CLAUDE_CODE_USE_BEDROCK: "1" }, () => {
+        const result = parseSdkOptions({});
+        expect(result.sdkOptions.model).toBeUndefined();
+      });
+    });
+
+    test("should not inject a default for Vertex", () => {
+      withEnv({ CLAUDE_CODE_USE_VERTEX: "1" }, () => {
+        const result = parseSdkOptions({});
+        expect(result.sdkOptions.model).toBeUndefined();
+      });
+    });
+
+    test("should not inject a default for Foundry", () => {
+      withEnv({ CLAUDE_CODE_USE_FOUNDRY: "1" }, () => {
+        const result = parseSdkOptions({});
+        expect(result.sdkOptions.model).toBeUndefined();
+      });
+    });
+
+    test("should preserve an explicit model even for third-party providers", () => {
+      withEnv({ CLAUDE_CODE_USE_BEDROCK: "1" }, () => {
+        const result = parseSdkOptions({
+          model: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        });
+        expect(result.sdkOptions.model).toBe(
+          "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1416

## Problem

When no model is specified, the action passes `model: undefined` all the way through to the Agent SDK, so the SDK/CLI falls back to its **own bundled default model**. In the currently-pinned version that resolves to the retired `claude-sonnet-4-20250514`, producing:

```
API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}}
```

Nothing in this repo hardcodes the bad id — it's inherited from the pinned SDK/CLI default, so it broke silently when that snapshot was retired server-side. With an OAuth token the 404 retries until the job timeout, so the run never completes. Every consumer currently has to add `--model` to their workflow by hand to avoid it.

## How I solved it

Flow that produced the bug:
- `action.yml` defines no `model` input and never exports `ANTHROPIC_MODEL`.
- `src/entrypoints/run.ts` → `runClaude(..., { model: process.env.ANTHROPIC_MODEL })` → `undefined`
- `base-action/src/parse-sdk-options.ts` → `sdkOptions.model = options.model` (undefined)
- `base-action/src/run-claude-sdk.ts` → `query({ options })` → SDK supplies its stale default

The fix sets an explicit default in `parseSdkOptions` via a new `resolveModel()` helper. Key decisions:

- **Use a model alias (`"sonnet"`), not a dated snapshot.** The alias resolves server-side to the current model, so the action can't rot the same way a pinned id did.
- **Preserve precedence.** Explicit `options.model` wins → then `--model` in `claudeArgs` (kept in `extraArgs` and passed to the CLI, so we deliberately return `undefined` to avoid specifying the model twice) → then the default alias.
- **Gate to the first-party provider.** The default is skipped when `CLAUDE_CODE_USE_BEDROCK` / `CLAUDE_CODE_USE_VERTEX` / `CLAUDE_CODE_USE_FOUNDRY` is set, since `"sonnet"` isn't a valid Bedrock/Vertex/Foundry model id — those providers resolve their own default.

After this, users no longer need per-repo `--model` workarounds.

## Tests

Added a `model defaulting` suite in `base-action/test/parse-sdk-options.test.ts` (env-isolated to avoid provider-var leakage):
- no model → defaults to `"sonnet"`
- explicit `options.model` preserved (and trimmed)
- `--model` in `claudeArgs` still overrides; `sdkOptions.model` stays undefined
- Bedrock / Vertex / Foundry → no alias injected
- explicit model preserved even for third-party providers

All 761 tests pass; `tsc --noEmit` and `prettier --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)