### PR TITLE
feat: add read_only mode for tag workflows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -121,6 +121,10 @@ inputs:
     description: "Enable commit signing using GitHub's commit signature verification. When false, Claude uses standard git commands"
     required: false
     default: "false"
+  read_only:
+    description: "Prevent Claude from receiving git or GitHub file-operation tools that can commit, push, or delete files"
+    required: false
+    default: "false"
   ssh_signing_key:
     description: "SSH private key for signing commits. When provided, git will be configured to use SSH signing. Takes precedence over use_commit_signing."
     required: false
@@ -296,6 +300,7 @@ runs:
         CLASSIFY_INLINE_COMMENTS: ${{ inputs.classify_inline_comments }}
         DEFAULT_WORKFLOW_TOKEN: ${{ github.token }}
         USE_COMMIT_SIGNING: ${{ inputs.use_commit_signing }}
+        READ_ONLY: ${{ inputs.read_only }}
         SSH_SIGNING_KEY: ${{ inputs.ssh_signing_key }}
         BOT_ID: ${{ inputs.bot_id }}
         BOT_NAME: ${{ inputs.bot_name }}

--- a/src/entrypoints/collect-inputs.ts
+++ b/src/entrypoints/collect-inputs.ts
@@ -30,6 +30,7 @@ export function collectActionInputsPresence(): string {
     use_sticky_comment: "false",
     classify_inline_comments: "true",
     use_commit_signing: "false",
+    read_only: "false",
     ssh_signing_key: "",
   };
 

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -93,6 +93,7 @@ type BaseContext = {
     useStickyComment: boolean;
     classifyInlineComments: boolean;
     useCommitSigning: boolean;
+    readOnly: boolean;
     sshSigningKey: string;
     botId: string;
     botName: string;
@@ -155,6 +156,7 @@ export function parseGitHubContext(): GitHubContext {
       useStickyComment: process.env.USE_STICKY_COMMENT === "true",
       classifyInlineComments: process.env.CLASSIFY_INLINE_COMMENTS !== "false",
       useCommitSigning: process.env.USE_COMMIT_SIGNING === "true",
+      readOnly: process.env.READ_ONLY === "true",
       sshSigningKey: process.env.SSH_SIGNING_KEY || "",
       botId: process.env.BOT_ID ?? String(CLAUDE_APP_BOT_ID),
       botName: process.env.BOT_NAME ?? CLAUDE_BOT_LOGIN,

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -18,6 +18,57 @@ import type { GitHubContext } from "../../github/context";
 import type { Octokits } from "../../github/api/client";
 import { parseAllowedTools } from "../agent/parse-tools";
 
+export function buildTagModeTools({
+  userAllowedMCPTools,
+  gitPushWrapper,
+  useApiCommitSigning,
+  readOnly,
+}: {
+  userAllowedMCPTools: string[];
+  gitPushWrapper: string;
+  useApiCommitSigning: boolean;
+  readOnly: boolean;
+}) {
+  // Build claude_args for tag mode with required tools.
+  // Edit/MultiEdit/Write are intentionally omitted: acceptEdits permission mode (set below)
+  // auto-allows file edits inside $GITHUB_WORKSPACE and denies writes outside (e.g. ~/.bashrc).
+  // Listing them here would grant blanket write access to the whole runner (Asana 1213310082312048).
+  const tagModeTools = [
+    "Glob",
+    "Grep",
+    "LS",
+    "Read",
+    "mcp__github_comment__update_claude_comment",
+    "mcp__github_ci__get_ci_status",
+    "mcp__github_ci__get_workflow_run_details",
+    "mcp__github_ci__download_job_log",
+    ...userAllowedMCPTools,
+  ];
+
+  if (readOnly) {
+    return tagModeTools;
+  }
+
+  // Add git commands when using git CLI (no API commit signing, or SSH signing)
+  // SSH signing still uses git CLI, just with signing enabled
+  if (!useApiCommitSigning) {
+    tagModeTools.push(
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      `Bash(${gitPushWrapper}:*)`,
+      "Bash(git rm:*)",
+    );
+  } else {
+    // When using API commit signing, use MCP file ops tools
+    tagModeTools.push(
+      "mcp__github_file_ops__commit_files",
+      "mcp__github_file_ops__delete_files",
+    );
+  }
+
+  return tagModeTools;
+}
+
 /**
  * Prepares the tag mode execution context.
  *
@@ -115,39 +166,12 @@ export async function prepareTagMode({
   );
 
   const gitPushWrapper = `${process.env.GITHUB_ACTION_PATH}/scripts/git-push.sh`;
-
-  // Build claude_args for tag mode with required tools.
-  // Edit/MultiEdit/Write are intentionally omitted: acceptEdits permission mode (set below)
-  // auto-allows file edits inside $GITHUB_WORKSPACE and denies writes outside (e.g. ~/.bashrc).
-  // Listing them here would grant blanket write access to the whole runner (Asana 1213310082312048).
-  const tagModeTools = [
-    "Glob",
-    "Grep",
-    "LS",
-    "Read",
-    "mcp__github_comment__update_claude_comment",
-    "mcp__github_ci__get_ci_status",
-    "mcp__github_ci__get_workflow_run_details",
-    "mcp__github_ci__download_job_log",
-    ...userAllowedMCPTools,
-  ];
-
-  // Add git commands when using git CLI (no API commit signing, or SSH signing)
-  // SSH signing still uses git CLI, just with signing enabled
-  if (!useApiCommitSigning) {
-    tagModeTools.push(
-      "Bash(git add:*)",
-      "Bash(git commit:*)",
-      `Bash(${gitPushWrapper}:*)`,
-      "Bash(git rm:*)",
-    );
-  } else {
-    // When using API commit signing, use MCP file ops tools
-    tagModeTools.push(
-      "mcp__github_file_ops__commit_files",
-      "mcp__github_file_ops__delete_files",
-    );
-  }
+  const tagModeTools = buildTagModeTools({
+    userAllowedMCPTools,
+    gitPushWrapper,
+    useApiCommitSigning,
+    readOnly: context.inputs.readOnly,
+  });
 
   // Get our GitHub MCP servers configuration
   const ourMcpConfig = await prepareMcpConfig({

--- a/test/github-context.test.ts
+++ b/test/github-context.test.ts
@@ -49,6 +49,7 @@ const ENV_KEYS = [
   "USE_STICKY_COMMENT",
   "CLASSIFY_INLINE_COMMENTS",
   "USE_COMMIT_SIGNING",
+  "READ_ONLY",
   "SSH_SIGNING_KEY",
   "BOT_ID",
   "BOT_NAME",
@@ -102,6 +103,19 @@ function setEvent(eventName: string, payload: unknown) {
 
 describe("parseGitHubContext", () => {
   describe("entity events (one test per equivalence partition)", () => {
+    test("parses read-only input", () => {
+      process.env.READ_ONLY = "true";
+      setEvent("issues", {
+        action: "opened",
+        issue: { number: 42 },
+        repository: repositoryPayload,
+      } as unknown as IssuesEvent);
+
+      const context = parseGitHubContext();
+
+      expect(context.inputs.readOnly).toBe(true);
+    });
+
     test("issues event extracts issue number and isPR false", () => {
       setEvent("issues", {
         action: "opened",

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -34,6 +34,7 @@ describe("prepareMcpConfig", () => {
       useStickyComment: false,
       classifyInlineComments: true,
       useCommitSigning: false,
+      readOnly: false,
       sshSigningKey: "",
       botId: String(CLAUDE_APP_BOT_ID),
       botName: CLAUDE_BOT_LOGIN,

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -21,6 +21,7 @@ const defaultInputs = {
   useStickyComment: false,
   classifyInlineComments: true,
   useCommitSigning: false,
+  readOnly: false,
   sshSigningKey: "",
   botId: String(CLAUDE_APP_BOT_ID),
   botName: CLAUDE_BOT_LOGIN,

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -21,6 +21,7 @@ describe("detectMode with enhanced routing", () => {
       useStickyComment: false,
       classifyInlineComments: true,
       useCommitSigning: false,
+      readOnly: false,
       sshSigningKey: "",
       botId: "123456",
       botName: "claude-bot",

--- a/test/modes/tag.test.ts
+++ b/test/modes/tag.test.ts
@@ -1,8 +1,58 @@
 import { describe, test, expect } from "bun:test";
-import { prepareTagMode } from "../../src/modes/tag";
+import { buildTagModeTools, prepareTagMode } from "../../src/modes/tag";
 
 describe("Tag Mode", () => {
   test("prepareTagMode is exported as a function", () => {
     expect(typeof prepareTagMode).toBe("function");
+  });
+
+  test("buildTagModeTools includes git write tools by default", () => {
+    const tools = buildTagModeTools({
+      userAllowedMCPTools: [],
+      gitPushWrapper: "/action/scripts/git-push.sh",
+      useApiCommitSigning: false,
+      readOnly: false,
+    });
+
+    expect(tools).toContain("Bash(git add:*)");
+    expect(tools).toContain("Bash(git commit:*)");
+    expect(tools).toContain("Bash(/action/scripts/git-push.sh:*)");
+    expect(tools).toContain("Bash(git rm:*)");
+  });
+
+  test("buildTagModeTools includes GitHub file write tools for API commit signing", () => {
+    const tools = buildTagModeTools({
+      userAllowedMCPTools: [],
+      gitPushWrapper: "/action/scripts/git-push.sh",
+      useApiCommitSigning: true,
+      readOnly: false,
+    });
+
+    expect(tools).toContain("mcp__github_file_ops__commit_files");
+    expect(tools).toContain("mcp__github_file_ops__delete_files");
+    expect(tools).not.toContain("Bash(git commit:*)");
+  });
+
+  test("buildTagModeTools omits commit and delete tools in read-only mode", () => {
+    const tools = buildTagModeTools({
+      userAllowedMCPTools: [
+        "mcp__github_inline_comment__create_inline_comment",
+      ],
+      gitPushWrapper: "/action/scripts/git-push.sh",
+      useApiCommitSigning: true,
+      readOnly: true,
+    });
+
+    expect(tools).toContain("Read");
+    expect(tools).toContain("mcp__github_ci__get_ci_status");
+    expect(tools).toContain(
+      "mcp__github_inline_comment__create_inline_comment",
+    );
+    expect(tools).not.toContain("Bash(git add:*)");
+    expect(tools).not.toContain("Bash(git commit:*)");
+    expect(tools).not.toContain("Bash(/action/scripts/git-push.sh:*)");
+    expect(tools).not.toContain("Bash(git rm:*)");
+    expect(tools).not.toContain("mcp__github_file_ops__commit_files");
+    expect(tools).not.toContain("mcp__github_file_ops__delete_files");
   });
 });

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -69,6 +69,7 @@ describe("checkWritePermissions", () => {
       useStickyComment: false,
       classifyInlineComments: true,
       useCommitSigning: false,
+      readOnly: false,
       sshSigningKey: "",
       botId: String(CLAUDE_APP_BOT_ID),
       botName: CLAUDE_BOT_LOGIN,


### PR DESCRIPTION
## Summary

Adds a `read_only` input for tag mode so review-only workflows can prevent Claude from receiving commit, push, or file-deletion tools.

Fixes #1415.

## Root cause

Tag mode always added write-capable tools after parsing user `claude_args`:

- git CLI commit/push/delete tools when `use_commit_signing` is false
- GitHub file-op commit/delete tools when `use_commit_signing` is true

That meant workflows could narrow their own `--allowedTools`, but the action still reintroduced write tools required for autofix workflows. This is surprising and unsafe for security review or comment-only automations.

## Changes

- Adds `read_only` to `action.yml` and exports it as `READ_ONLY`.
- Parses the input into `context.inputs.readOnly`.
- Extracts tag-mode tool construction into `buildTagModeTools`.
- When `read_only: true`, keeps read/comment/CI tools and user-specified GitHub MCP tools, but skips:
  - `Bash(git add:*)`
  - `Bash(git commit:*)`
  - git push wrapper
  - `Bash(git rm:*)`
  - `mcp__github_file_ops__commit_files`
  - `mcp__github_file_ops__delete_files`
- Preserves existing default behavior when `read_only` is unset or false.

## Validation

- `./node_modules/.bin/prettier --check .`
- `bun test test/modes/tag.test.ts test/github-context.test.ts`
- `bun run typecheck`
