### PR TITLE
feat: add agent user_request input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: "Instructions for Claude. Can be a direct prompt or custom template."
     required: false
     default: ""
+  user_request:
+    description: "Optional user request appended after prompt context in agent mode. Use this for slash commands that must be processed by Claude Code."
+    required: false
+    default: ""
   settings:
     description: "Claude Code settings as JSON string or path to settings JSON file"
     required: false
@@ -278,6 +282,7 @@ runs:
         # Prepare inputs
         MODE: ${{ inputs.mode }}
         PROMPT: ${{ inputs.prompt }}
+        USER_REQUEST: ${{ inputs.user_request }}
         TRIGGER_PHRASE: ${{ inputs.trigger_phrase }}
         ASSIGNEE_TRIGGER: ${{ inputs.assignee_trigger }}
         LABEL_TRIGGER: ${{ inputs.label_trigger }}

--- a/src/entrypoints/collect-inputs.ts
+++ b/src/entrypoints/collect-inputs.ts
@@ -15,6 +15,7 @@ export function collectActionInputsPresence(): string {
     custom_instructions: "",
     direct_prompt: "",
     override_prompt: "",
+    user_request: "",
     additional_permissions: "",
     claude_env: "",
     settings: "",

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -84,6 +84,7 @@ type BaseContext = {
   actor: string;
   inputs: {
     prompt: string;
+    userRequest: string;
     triggerPhrase: string;
     assigneeTrigger: string;
     labelTrigger: string;
@@ -146,6 +147,7 @@ export function parseGitHubContext(): GitHubContext {
     actor: context.actor,
     inputs: {
       prompt: process.env.PROMPT || "",
+      userRequest: process.env.USER_REQUEST || "",
       triggerPhrase: process.env.TRIGGER_PHRASE ?? "@claude",
       assigneeTrigger: process.env.ASSIGNEE_TRIGGER ?? "",
       labelTrigger: process.env.LABEL_TRIGGER ?? "",

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -9,6 +9,8 @@ import { checkHumanActor } from "../../github/validation/actor";
 import type { GitHubContext } from "../../github/context";
 import type { Octokits } from "../../github/api/client";
 
+const USER_REQUEST_FILENAME = "claude-user-request.txt";
+
 /**
  * Prepares the agent mode execution context.
  *
@@ -77,6 +79,13 @@ export async function prepareAgentMode({
     `Repository: ${context.repository.owner}/${context.repository.repo}`;
 
   await writeFile(`${promptDir}/claude-prompt.txt`, promptContent);
+
+  if (context.inputs.userRequest) {
+    await writeFile(
+      `${promptDir}/${USER_REQUEST_FILENAME}`,
+      context.inputs.userRequest,
+    );
+  }
 
   // Parse allowed tools from user's claude_args
   const userClaudeArgs = process.env.CLAUDE_ARGS || "";

--- a/test/github-context.test.ts
+++ b/test/github-context.test.ts
@@ -40,6 +40,7 @@ import { createMockContext, createMockAutomationContext } from "./mockContext";
 const ENV_KEYS = [
   "GITHUB_RUN_ID",
   "PROMPT",
+  "USER_REQUEST",
   "TRIGGER_PHRASE",
   "ASSIGNEE_TRIGGER",
   "LABEL_TRIGGER",
@@ -339,6 +340,7 @@ describe("parseGitHubContext", () => {
       const { inputs } = parseGitHubContext();
 
       expect(inputs.prompt).toBe("");
+      expect(inputs.userRequest).toBe("");
       expect(inputs.triggerPhrase).toBe("@claude");
       expect(inputs.assigneeTrigger).toBe("");
       expect(inputs.labelTrigger).toBe("");
@@ -361,6 +363,8 @@ describe("parseGitHubContext", () => {
 
     test("inputs reflect the env vars set by action.yml", () => {
       process.env.PROMPT = "do something";
+      process.env.USER_REQUEST =
+        "/review https://github.com/example/repo/pull/1";
       process.env.TRIGGER_PHRASE = "/claude";
       process.env.ASSIGNEE_TRIGGER = "@claude-bot";
       process.env.LABEL_TRIGGER = "claude-task";
@@ -389,6 +393,9 @@ describe("parseGitHubContext", () => {
       const { inputs } = parseGitHubContext();
 
       expect(inputs.prompt).toBe("do something");
+      expect(inputs.userRequest).toBe(
+        "/review https://github.com/example/repo/pull/1",
+      );
       expect(inputs.triggerPhrase).toBe("/claude");
       expect(inputs.assigneeTrigger).toBe("@claude-bot");
       expect(inputs.labelTrigger).toBe("claude-task");

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -27,6 +27,7 @@ describe("prepareMcpConfig", () => {
     isPR: false,
     inputs: {
       prompt: "",
+      userRequest: "",
       triggerPhrase: "@claude",
       assigneeTrigger: "",
       labelTrigger: "",

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -14,6 +14,7 @@ import { CLAUDE_APP_BOT_ID, CLAUDE_BOT_LOGIN } from "../src/github/constants";
 
 const defaultInputs = {
   prompt: "",
+  userRequest: "",
   triggerPhrase: "/claude",
   assigneeTrigger: "",
   labelTrigger: "",

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -7,6 +7,9 @@ import {
   spyOn,
   mock,
 } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
 import { prepareAgentMode } from "../../src/modes/agent";
 import { createMockAutomationContext } from "../mockContext";
 import * as core from "@actions/core";
@@ -16,6 +19,7 @@ describe("Agent Mode", () => {
   let exportVariableSpy: any;
   let setOutputSpy: any;
   let configureGitAuthSpy: any;
+  let tempDir: string | undefined;
 
   beforeEach(() => {
     exportVariableSpy = spyOn(core, "exportVariable").mockImplementation(
@@ -31,13 +35,18 @@ describe("Agent Mode", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     exportVariableSpy?.mockClear();
     setOutputSpy?.mockClear();
     configureGitAuthSpy?.mockClear();
     exportVariableSpy?.mockRestore();
     setOutputSpy?.mockRestore();
     configureGitAuthSpy?.mockRestore();
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+    delete process.env.RUNNER_TEMP;
   });
 
   test("prepareAgentMode is exported as a function", () => {
@@ -256,5 +265,55 @@ describe("Agent Mode", () => {
     // should not include any MCP config
     // Should be empty or just whitespace when no MCP servers are included
     expect(result.claudeArgs).not.toContain("--mcp-config");
+  });
+
+  test("prepare writes user_request after clearing stale prompt files", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "agent-mode-"));
+    process.env.RUNNER_TEMP = tempDir;
+
+    const promptDir = join(tempDir, "claude-prompts");
+    await mkdir(promptDir, { recursive: true });
+    await writeFile(
+      join(promptDir, "claude-user-request.txt"),
+      "stale request",
+    );
+
+    const contextWithUserRequest = createMockAutomationContext({
+      eventName: "workflow_dispatch",
+      inputs: {
+        prompt: "Follow the user request.",
+        userRequest: "/kyosei https://github.com/test-owner/test-repo/pull/1",
+      },
+    });
+
+    const mockOctokit = {
+      rest: {
+        users: {
+          getAuthenticated: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345, type: "User" },
+            }),
+          ),
+          getByUsername: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345, type: "User" },
+            }),
+          ),
+        },
+      },
+    } as any;
+
+    await prepareAgentMode({
+      context: contextWithUserRequest,
+      octokit: mockOctokit,
+      githubToken: "test-token",
+    });
+
+    await expect(
+      readFile(join(promptDir, "claude-prompt.txt"), "utf-8"),
+    ).resolves.toBe("Follow the user request.");
+    await expect(
+      readFile(join(promptDir, "claude-user-request.txt"), "utf-8"),
+    ).resolves.toBe("/kyosei https://github.com/test-owner/test-repo/pull/1");
   });
 });

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -14,6 +14,7 @@ describe("detectMode with enhanced routing", () => {
     actor: "test-user",
     inputs: {
       prompt: "",
+      userRequest: "",
       triggerPhrase: "@claude",
       assigneeTrigger: "",
       labelTrigger: "",

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -62,6 +62,7 @@ describe("checkWritePermissions", () => {
     isPR: false,
     inputs: {
       prompt: "",
+      userRequest: "",
       triggerPhrase: "@claude",
       assigneeTrigger: "",
       labelTrigger: "",


### PR DESCRIPTION
## Summary

Adds a first-class `user_request` input for agent mode and writes it to `claude-user-request.txt` after prompt-dir cleanup.

Fixes #1427.

## Root cause

Agent mode currently clears `${RUNNER_TEMP}/claude-prompts` before writing `claude-prompt.txt`. That correctly removes stale prompt files, but it also deletes `claude-user-request.txt` files that composite actions intentionally pre-write before invoking this action.

The base SDK runner already supports `claude-user-request.txt`: when it exists alongside the prompt file, it sends a multi-block user message so Claude Code can process slash commands from the user request. After the cleanup change, downstream composite actions no longer had a supported point to provide that file.

## Changes

- Adds `user_request` to the top-level action inputs.
- Exports it as `USER_REQUEST` and parses it into `context.inputs.userRequest`.
- In agent mode, writes `claude-user-request.txt` after stale prompt files are cleared.
- Keeps existing prompt cleanup behavior, so stale files from prior invocations are still removed.
- Adds a regression test that starts with a stale user request file, runs agent mode, and verifies the new request replaces it.

## Validation

- `./node_modules/.bin/prettier --check .`
- `bun test test/modes/agent.test.ts test/github-context.test.ts base-action/test/run-claude-sdk.test.ts`
- `bun run typecheck`
