### PR TITLE
ci: skip live Claude tests without federation vars

### DIFF
--- a/.github/workflows/test-base-action.yml
+++ b/.github/workflows/test-base-action.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   test-inline-prompt:
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -71,6 +72,7 @@ jobs:
 
   test-prompt-file:
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/test-custom-executables.yml
+++ b/.github/workflows/test-custom-executables.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   test-custom-executables:
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   test-mcp-integration:
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -95,6 +96,7 @@ jobs:
 
   test-mcp-config-flag:
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-settings.yml
+++ b/.github/workflows/test-settings.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   test-settings-inline-allow:
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -66,6 +67,7 @@ jobs:
 
   test-settings-inline-deny:
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -100,6 +102,7 @@ jobs:
 
   test-settings-file-allow:
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -156,6 +159,7 @@ jobs:
 
   test-settings-file-deny:
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/test-structured-output.yml
+++ b/.github/workflows/test-structured-output.yml
@@ -16,6 +16,7 @@ jobs:
   test-basic-types:
     name: Test Basic Type Conversions
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -77,6 +78,7 @@ jobs:
   test-complex-types:
     name: Test Arrays and Objects
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -130,6 +132,7 @@ jobs:
   test-edge-cases:
     name: Test Edge Cases
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -191,6 +194,7 @@ jobs:
   test-name-sanitization:
     name: Test Output Name Sanitization
     runs-on: ubuntu-latest
+    if: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID != '' && vars.ANTHROPIC_ORGANIZATION_ID != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Skip live Claude API self-test jobs when workload identity federation repository variables are unavailable.
- Keep the live tests running for internal runs where `ANTHROPIC_FEDERATION_RULE_ID` and `ANTHROPIC_ORGANIZATION_ID` are configured.

## Why

Fork PR runs do not receive the repository variables required by the live Claude API self-test workflows. Those jobs currently fail during action environment validation before testing the changed code:

- missing `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`; and
- missing workload identity federation variables.

This makes otherwise valid fork PRs look red for a reason contributors cannot fix. The guard lets those jobs skip cleanly when the required federation variables are absent, while preserving the full live test coverage for configured internal runs.

## Validation

- `npx --yes prettier --check .github/workflows/test-base-action.yml .github/workflows/test-custom-executables.yml .github/workflows/test-mcp-servers.yml .github/workflows/test-settings.yml .github/workflows/test-structured-output.yml`
- `git diff --check`
