### PR TITLE
fix(agent): preserve pre-written claude-user-request.txt in agent mode

### DIFF
--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -64,12 +64,11 @@ export async function prepareAgentMode({
     }
   }
 
-  // Create prompt directory. Clear any stale files from a prior invocation first —
-  // see src/create-prompt/index.ts for context (non-ephemeral self-hosted runners
-  // do not reliably honor the RUNNER_TEMP cleanup contract).
+  // Create prompt directory. Only remove the prompt file this mode writes — composite
+  // workflows may pre-write claude-user-request.txt in an earlier step (see #1427).
   const promptDir = `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts`;
-  await rm(promptDir, { recursive: true, force: true });
   await mkdir(promptDir, { recursive: true });
+  await rm(`${promptDir}/claude-prompt.txt`, { force: true });
 
   // Write the prompt file - use the user's prompt directly
   const promptContent =

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -7,6 +7,7 @@ import {
   spyOn,
   mock,
 } from "bun:test";
+import { mkdir, readFile, rm, writeFile } from "fs/promises";
 import { prepareAgentMode } from "../../src/modes/agent";
 import { createMockAutomationContext } from "../mockContext";
 import * as core from "@actions/core";
@@ -219,6 +220,45 @@ describe("Agent Mode", () => {
         githubToken: "test-token",
       }),
     ).resolves.toBeDefined();
+  });
+
+  test("prepare preserves pre-written claude-user-request.txt (#1427)", async () => {
+    const contextWithPrompts = createMockAutomationContext({
+      eventName: "workflow_dispatch",
+    });
+    contextWithPrompts.inputs.prompt = "Follow the user request.";
+
+    const promptDir = `${process.env.RUNNER_TEMP || "/tmp"}/claude-prompts`;
+    await mkdir(promptDir, { recursive: true });
+    const userRequestPath = `${promptDir}/claude-user-request.txt`;
+    await writeFile(userRequestPath, "/kyosei https://example.com/pr/1");
+
+    const mockOctokit = {
+      rest: {
+        users: {
+          getAuthenticated: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345, type: "User" },
+            }),
+          ),
+          getByUsername: mock(() =>
+            Promise.resolve({
+              data: { login: "test-user", id: 12345, type: "User" },
+            }),
+          ),
+        },
+      },
+    } as any;
+
+    await prepareAgentMode({
+      context: contextWithPrompts,
+      octokit: mockOctokit,
+      githubToken: "test-token",
+    });
+
+    const preserved = await readFile(userRequestPath, "utf-8");
+    expect(preserved).toBe("/kyosei https://example.com/pr/1");
+    await rm(promptDir, { recursive: true, force: true });
   });
 
   test("prepare creates prompt file with correct content", async () => {


### PR DESCRIPTION
## Summary

Agent mode no longer wipes the entire `claude-prompts` directory. It only removes `claude-prompt.txt`, the file agent mode owns and rewrites.

## Motivation

Fixes #1427. Composite workflows can pre-write `claude-user-request.txt` in an earlier step so the SDK takes the multi-block path and processes slash commands. PR #1288 added an unconditional `rm -rf` on the prompt directory, which deleted that pre-written file before the SDK ran.

## Changes

- `prepareAgentMode`: replace directory `rm -rf` with targeted removal of `claude-prompt.txt` only
- Add regression test ensuring a pre-written `claude-user-request.txt` survives agent prepare

## Tests

- `bun test test/modes/agent.test.ts` — 7/7 passed
- `bun run typecheck` — passed
- `bun run format:check` — passed
- composer-2.5 review: **APPROVE**

## Notes

Tag mode still performs full directory cleanup in `create-prompt` (it writes both files). Agent mode intentionally preserves `claude-user-request.txt` for composite workflows. On non-ephemeral self-hosted runners without a pre-write step, a stale user-request file could theoretically persist if `RUNNER_TEMP` is not cleared between jobs — same class of concern noted in #1287, traded off here to unblock composite slash-command workflows.