### PR TITLE
fix(restore): handle symlinked CLAUDE.md paths during config snapshot

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -30,6 +30,25 @@ const SENSITIVE_PATHS = [
 
 const CLAUDE_PR_EXCLUDE_PATTERN = "/.claude-pr/";
 
+function snapshotSensitivePath(src: string, dest: string): void {
+  try {
+    cpSync(src, dest, { recursive: true, dereference: true });
+  } catch (error) {
+    // Symlinks whose targets are absent on the PR head (e.g. `.claude/CLAUDE.md`
+    // -> `../AGENTS.md` when the PR deleted the target) make dereferenced
+    // copies throw ENOENT. Preserve the symlink for the review snapshot instead.
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      cpSync(src, dest, { recursive: true });
+      return;
+    }
+    throw error;
+  }
+}
+
 function ensureClaudePrExcludedFromGit(): void {
   const excludePath = execFileSync(
     "git",
@@ -86,7 +105,7 @@ export function restoreConfigFromBase(baseBranch: string): void {
   rmSync(".claude-pr", { recursive: true, force: true });
   for (const p of SENSITIVE_PATHS) {
     if (existsSync(p)) {
-      cpSync(p, `.claude-pr/${p}`, { recursive: true, dereference: true });
+      snapshotSensitivePath(p, `.claude-pr/${p}`);
     }
   }
   if (existsSync(".claude-pr")) {

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -2,10 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { execFileSync } from "child_process";
 import {
   existsSync,
+  lstatSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "fs";
 import { dirname, isAbsolute, join } from "path";
@@ -121,6 +123,48 @@ describe("restoreConfigFromBase", () => {
     }
   });
 
+  test("restores symlinked CLAUDE.md paths from the PR base branch", () => {
+    setupSymlinkedMainBranch();
+
+    git(["checkout", "pr"]);
+    writeRepoFile(
+      ".claude/settings.json",
+      `${JSON.stringify({ source: "pr-with-symlinks" })}\n`,
+    );
+    git(["add", ".claude/settings.json"]);
+    git(["commit", "-m", "pr updates settings"]);
+
+    restoreConfigFromBase("main");
+
+    expect(lstatRepoFile("CLAUDE.md").isSymbolicLink()).toBe(true);
+    expect(lstatRepoFile(".claude/CLAUDE.md").isSymbolicLink()).toBe(true);
+    expect(readRepoFile("CLAUDE.md").trim()).toBe("shared agent instructions");
+    expect(readRepoFile(".claude/CLAUDE.md").trim()).toBe(
+      "shared agent instructions",
+    );
+    expect(readRepoFile(".claude/settings.json")).toBe(
+      `${JSON.stringify({ source: "base" })}\n`,
+    );
+  });
+
+  test("snapshots symlinked sensitive paths even when the PR head target is missing", () => {
+    setupSymlinkedMainBranch();
+
+    git(["checkout", "pr"]);
+    rmSync(join(repoDir, "AGENTS.md"), { force: true });
+    git(["add", "-A"]);
+    git(["commit", "-m", "pr deletes agents file"]);
+
+    restoreConfigFromBase("main");
+
+    expect(lstatRepoFile(".claude-pr/.claude/CLAUDE.md").isSymbolicLink()).toBe(
+      true,
+    );
+    expect(readRepoFile(".claude/settings.json")).toBe(
+      `${JSON.stringify({ source: "base" })}\n`,
+    );
+  });
+
   test("does not modify an existing .gitignore", () => {
     writeRepoFile(".gitignore", "node_modules\n");
     git(["add", ".gitignore"]);
@@ -154,6 +198,29 @@ describe("restoreConfigFromBase", () => {
 
   function existsRepoFile(path: string): boolean {
     return existsSync(join(repoDir, path));
+  }
+
+  function symlinkRepoFile(path: string, target: string): void {
+    const fullPath = join(repoDir, path);
+    mkdirSync(dirname(fullPath), { recursive: true });
+    symlinkSync(target, fullPath);
+  }
+
+  function lstatRepoFile(path: string) {
+    return lstatSync(join(repoDir, path));
+  }
+
+  function setupSymlinkedMainBranch(): void {
+    git(["checkout", "main"]);
+    rmSync(join(repoDir, "CLAUDE.md"), { force: true });
+    writeRepoFile("AGENTS.md", "shared agent instructions\n");
+    symlinkRepoFile("CLAUDE.md", "AGENTS.md");
+    symlinkRepoFile(".claude/CLAUDE.md", "../AGENTS.md");
+    git(["add", "AGENTS.md", "CLAUDE.md", ".claude/CLAUDE.md"]);
+    git(["commit", "-m", "add symlinked claude files"]);
+    git(["push", "origin", "main"]);
+    git(["branch", "-D", "pr"]);
+    git(["checkout", "-b", "pr"]);
   }
 
   function countClaudePrExcludeEntries(): number {


### PR DESCRIPTION
## Summary

Fixes a crash in `restoreConfigFromBase` when snapshotting PR-authored sensitive paths that include git symlinks (e.g. `.claude/CLAUDE.md` → `../AGENTS.md`).

## Motivation

`cpSync(..., { dereference: true })` throws `ENOENT: statx` when a symlink target is missing on the PR head. This aborts the restore step before trusted base config can be checked out, breaking repos that use symlinked CLAUDE instruction files (#1398).

## Changes

- Add `snapshotSensitivePath()` helper that prefers dereferenced copies (preserving #1186 review snapshots) and falls back to copying the symlink itself on `ENOENT`
- Use the helper when preserving PR paths into `.claude-pr/`
- Add regression tests for symlink restore and broken-symlink snapshot fallback

## Tests

- `bun test test/restore-config.test.ts` — 4 pass
- `bun run typecheck` — pass

## Notes

- Git restore of symlinked paths from `origin/<base>` is unchanged; this only fixes the pre-restore snapshot step that was crashing.
- Reviewed with composer-2.5: APPROVE

Fixes #1398