### PR TITLE
Support IRSA credentials for Bedrock

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -340,6 +340,10 @@ runs:
         AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
         AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
         AWS_BEARER_TOKEN_BEDROCK: ${{ env.AWS_BEARER_TOKEN_BEDROCK }}
+        # IRSA credentials (resolved by the AWS SDK credential chain)
+        AWS_ROLE_ARN: ${{ env.AWS_ROLE_ARN }}
+        AWS_WEB_IDENTITY_TOKEN_FILE: ${{ env.AWS_WEB_IDENTITY_TOKEN_FILE }}
+        AWS_ROLE_SESSION_NAME: ${{ env.AWS_ROLE_SESSION_NAME }}
         ANTHROPIC_BEDROCK_BASE_URL: ${{ env.ANTHROPIC_BEDROCK_BASE_URL || (env.AWS_REGION && format('https://bedrock-runtime.{0}.amazonaws.com', env.AWS_REGION)) }}
 
         # GCP configuration

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -214,6 +214,10 @@ runs:
         AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
         AWS_SESSION_TOKEN: ${{ env.AWS_SESSION_TOKEN }}
         AWS_BEARER_TOKEN_BEDROCK: ${{ env.AWS_BEARER_TOKEN_BEDROCK }}
+        # IRSA credentials (resolved by the AWS SDK credential chain)
+        AWS_ROLE_ARN: ${{ env.AWS_ROLE_ARN }}
+        AWS_WEB_IDENTITY_TOKEN_FILE: ${{ env.AWS_WEB_IDENTITY_TOKEN_FILE }}
+        AWS_ROLE_SESSION_NAME: ${{ env.AWS_ROLE_SESSION_NAME }}
         ANTHROPIC_BEDROCK_BASE_URL: ${{ env.ANTHROPIC_BEDROCK_BASE_URL || (env.AWS_REGION && format('https://bedrock-runtime.{0}.amazonaws.com', env.AWS_REGION)) }}
 
         # GCP configuration

--- a/base-action/src/validate-env.ts
+++ b/base-action/src/validate-env.ts
@@ -44,19 +44,25 @@ export function validateEnvironmentVariables() {
     const awsAccessKeyId = process.env.AWS_ACCESS_KEY_ID;
     const awsSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
     const awsBearerToken = process.env.AWS_BEARER_TOKEN_BEDROCK;
+    const awsRoleArn = process.env.AWS_ROLE_ARN;
+    const awsWebIdentityTokenFile = process.env.AWS_WEB_IDENTITY_TOKEN_FILE;
 
     // AWS_REGION is always required for Bedrock
     if (!awsRegion) {
       errors.push("AWS_REGION is required when using AWS Bedrock.");
     }
 
-    // Either bearer token OR access key credentials must be provided
+    // Credentials can come from a bearer token, static access keys, or IRSA
+    // (IAM Roles for Service Accounts), where AWS_ROLE_ARN and
+    // AWS_WEB_IDENTITY_TOKEN_FILE are injected into the environment and the AWS
+    // SDK resolves them automatically via the default credential provider chain.
     const hasAccessKeyCredentials = awsAccessKeyId && awsSecretAccessKey;
     const hasBearerToken = awsBearerToken;
+    const hasWebIdentity = awsRoleArn && awsWebIdentityTokenFile;
 
-    if (!hasAccessKeyCredentials && !hasBearerToken) {
+    if (!hasAccessKeyCredentials && !hasBearerToken && !hasWebIdentity) {
       errors.push(
-        "Either AWS_BEARER_TOKEN_BEDROCK or both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required when using AWS Bedrock.",
+        "AWS Bedrock requires one of: AWS_BEARER_TOKEN_BEDROCK, both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or IRSA credentials (AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE).",
       );
     }
   } else if (useVertex) {

--- a/base-action/test/validate-env.test.ts
+++ b/base-action/test/validate-env.test.ts
@@ -21,6 +21,9 @@ describe("validateEnvironmentVariables", () => {
     delete process.env.AWS_SECRET_ACCESS_KEY;
     delete process.env.AWS_SESSION_TOKEN;
     delete process.env.AWS_BEARER_TOKEN_BEDROCK;
+    delete process.env.AWS_ROLE_ARN;
+    delete process.env.AWS_WEB_IDENTITY_TOKEN_FILE;
+    delete process.env.AWS_ROLE_SESSION_NAME;
     delete process.env.ANTHROPIC_BEDROCK_BASE_URL;
     delete process.env.ANTHROPIC_VERTEX_PROJECT_ID;
     delete process.env.CLOUD_ML_REGION;
@@ -129,7 +132,7 @@ describe("validateEnvironmentVariables", () => {
       process.env.AWS_SECRET_ACCESS_KEY = "test-secret-key";
 
       expect(() => validateEnvironmentVariables()).toThrow(
-        "Either AWS_BEARER_TOKEN_BEDROCK or both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required when using AWS Bedrock.",
+        "AWS Bedrock requires one of: AWS_BEARER_TOKEN_BEDROCK, both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or IRSA credentials (AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE).",
       );
     });
 
@@ -139,7 +142,7 @@ describe("validateEnvironmentVariables", () => {
       process.env.AWS_ACCESS_KEY_ID = "test-access-key";
 
       expect(() => validateEnvironmentVariables()).toThrow(
-        "Either AWS_BEARER_TOKEN_BEDROCK or both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required when using AWS Bedrock.",
+        "AWS Bedrock requires one of: AWS_BEARER_TOKEN_BEDROCK, both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or IRSA credentials (AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE).",
       );
     });
 
@@ -166,7 +169,7 @@ describe("validateEnvironmentVariables", () => {
       process.env.AWS_REGION = "us-east-1";
 
       expect(() => validateEnvironmentVariables()).toThrow(
-        "Either AWS_BEARER_TOKEN_BEDROCK or both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required when using AWS Bedrock.",
+        "AWS Bedrock requires one of: AWS_BEARER_TOKEN_BEDROCK, both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or IRSA credentials (AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE).",
       );
     });
 
@@ -174,7 +177,38 @@ describe("validateEnvironmentVariables", () => {
       process.env.CLAUDE_CODE_USE_BEDROCK = "1";
 
       expect(() => validateEnvironmentVariables()).toThrow(
-        /AWS_REGION is required when using AWS Bedrock.*Either AWS_BEARER_TOKEN_BEDROCK or both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required when using AWS Bedrock/s,
+        /AWS_REGION is required when using AWS Bedrock.*AWS Bedrock requires one of: AWS_BEARER_TOKEN_BEDROCK, both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or IRSA credentials \(AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE\)/s,
+      );
+    });
+
+    test("should pass with IRSA credentials instead of access keys", () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      process.env.AWS_REGION = "us-east-1";
+      process.env.AWS_ROLE_ARN = "arn:aws:iam::123456789012:role/bedrock-role";
+      process.env.AWS_WEB_IDENTITY_TOKEN_FILE =
+        "/var/run/secrets/eks.amazonaws.com/serviceaccount/token";
+
+      expect(() => validateEnvironmentVariables()).not.toThrow();
+    });
+
+    test("should fail when only AWS_ROLE_ARN is provided without web identity token file", () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      process.env.AWS_REGION = "us-east-1";
+      process.env.AWS_ROLE_ARN = "arn:aws:iam::123456789012:role/bedrock-role";
+
+      expect(() => validateEnvironmentVariables()).toThrow(
+        "AWS Bedrock requires one of: AWS_BEARER_TOKEN_BEDROCK, both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or IRSA credentials (AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE).",
+      );
+    });
+
+    test("should fail when only AWS_WEB_IDENTITY_TOKEN_FILE is provided without role ARN", () => {
+      process.env.CLAUDE_CODE_USE_BEDROCK = "1";
+      process.env.AWS_REGION = "us-east-1";
+      process.env.AWS_WEB_IDENTITY_TOKEN_FILE =
+        "/var/run/secrets/eks.amazonaws.com/serviceaccount/token";
+
+      expect(() => validateEnvironmentVariables()).toThrow(
+        "AWS Bedrock requires one of: AWS_BEARER_TOKEN_BEDROCK, both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or IRSA credentials (AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE).",
       );
     });
   });
@@ -356,7 +390,7 @@ describe("validateEnvironmentVariables", () => {
         "  - AWS_REGION is required when using AWS Bedrock.",
       );
       expect(error!.message).toContain(
-        "  - Either AWS_BEARER_TOKEN_BEDROCK or both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required when using AWS Bedrock.",
+        "  - AWS Bedrock requires one of: AWS_BEARER_TOKEN_BEDROCK, both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or IRSA credentials (AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE).",
       );
     });
   });

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -81,6 +81,23 @@ AWS Bedrock, GCP Vertex AI, and Microsoft Foundry all support OIDC authenticatio
     id-token: write # Required for OIDC
 ```
 
+### IRSA (IAM Roles for Service Accounts)
+
+If you run the action on self-hosted runners in Amazon EKS, you can use [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) instead of a bearer token or static access keys. EKS injects `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` into the pod, and the AWS SDK resolves credentials from them automatically — no `aws-actions/configure-aws-credentials` step is required.
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    use_bedrock: "true"
+    claude_args: |
+      --model anthropic.claude-4-0-sonnet-20250805-v1:0
+    # ... other inputs
+  env:
+    AWS_REGION: us-west-2
+```
+
+`AWS_REGION` is still required. The action forwards the IRSA environment variables (`AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`, and `AWS_ROLE_SESSION_NAME`) to Claude Code; ensure the service account's IAM role is granted `bedrock:InvokeModel` (and `bedrock:InvokeModelWithResponseStream`) on the Claude models you use.
+
 ```yaml
 # For GCP Vertex AI with OIDC
 - name: Authenticate to Google Cloud


### PR DESCRIPTION
## Summary

Adds support for [IRSA (IAM Roles for Service Accounts)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) as a Bedrock credential source, so the action works on self-hosted runners in Amazon EKS without a bearer token or long-lived access keys.

Fixes #1439.

## Problem

On EKS, the canonical way to reach Bedrock securely is IRSA: the pod identity webhook injects `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`, and the AWS SDK resolves credentials from them automatically. Two things blocked this today:

1. `validateEnvironmentVariables()` rejected Bedrock unless `AWS_BEARER_TOKEN_BEDROCK` or static `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` were set — IRSA provides neither.
2. `action.yml`'s run-step `env:` block didn't forward the IRSA variables. Because a composite action's step env does not inherit the calling workflow's job-level `env:`, IRSA vars set there never reached Claude Code.

## Changes

- **`base-action/src/validate-env.ts`**: accept IRSA (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`) as a valid Bedrock credential source alongside the bearer token and access keys, and update the error message accordingly.
- **`action.yml`** and **`base-action/action.yml`**: forward `AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`, and `AWS_ROLE_SESSION_NAME` to the Claude Code step.
- **`docs/cloud-providers.md`**: document IRSA setup for self-hosted EKS runners.
- Tests covering the new IRSA path (pass with both vars; fail with only one) and updated assertions for the new error message.

## Validation

- `bun test` (base-action: 149 pass; root: 756 pass), `bun run typecheck`, and `prettier --check` all pass.
- Confirmed the bundled `@anthropic-ai/claude-code@2.1.196` CLI resolves IRSA: it ships `@anthropic-ai/bedrock-sdk` with `@aws-sdk/credential-provider-node` (`fromNodeProviderChain`) and `@aws-sdk/credential-provider-web-identity` (`fromTokenFile` → `AssumeRoleWithWebIdentity`), which is exactly the IRSA path used when no static credentials are supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)