### PR TITLE
fix: support push event in automation context

### DIFF
--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -6,6 +6,7 @@ import type {
   PullRequestEvent,
   PullRequestReviewEvent,
   PullRequestReviewCommentEvent,
+  PushEvent,
   WorkflowRunEvent,
 } from "@octokit/webhooks-types";
 import { CLAUDE_APP_BOT_ID, CLAUDE_BOT_LOGIN } from "./constants";
@@ -65,6 +66,7 @@ const AUTOMATION_EVENT_NAMES = [
   "repository_dispatch",
   "schedule",
   "workflow_run",
+  "push",
 ] as const;
 
 // Derive types from constants for better maintainability
@@ -118,14 +120,15 @@ export type ParsedGitHubContext = BaseContext & {
   isPR: boolean;
 };
 
-// Context for automation events (workflow_dispatch, repository_dispatch, schedule, workflow_run)
+// Context for automation events (workflow_dispatch, repository_dispatch, schedule, workflow_run, push)
 export type AutomationContext = BaseContext & {
   eventName: AutomationEventName;
   payload:
     | WorkflowDispatchEvent
     | RepositoryDispatchEvent
     | ScheduleEvent
-    | WorkflowRunEvent;
+    | WorkflowRunEvent
+    | PushEvent;
 };
 
 // Union type for all contexts
@@ -245,6 +248,13 @@ export function parseGitHubContext(): GitHubContext {
         ...commonFields,
         eventName: "workflow_run",
         payload: context.payload as unknown as WorkflowRunEvent,
+      };
+    }
+    case "push": {
+      return {
+        ...commonFields,
+        eventName: "push",
+        payload: context.payload as unknown as PushEvent,
       };
     }
     default:

--- a/test/github-context.test.ts
+++ b/test/github-context.test.ts
@@ -297,6 +297,23 @@ describe("parseGitHubContext", () => {
       expect(context.eventName).toBe("workflow_run");
       expect(isAutomationContext(context)).toBe(true);
     });
+
+    test("push produces an automation context", () => {
+      setEvent("push", {
+        ref: "refs/heads/main",
+        before: "0000000000000000000000000000000000000000",
+        after: "1111111111111111111111111111111111111111",
+        repository: repositoryPayload,
+        pusher: { name: "test-actor", email: "test-actor@example.com" },
+      });
+
+      const context = parseGitHubContext();
+
+      expect(context.eventName).toBe("push");
+      expect(isAutomationContext(context)).toBe(true);
+      expect("entityNumber" in context).toBe(false);
+      expect("isPR" in context).toBe(false);
+    });
   });
 
   describe("invalid partition", () => {
@@ -442,6 +459,9 @@ describe("type guards", () => {
   const workflowDispatchContext = createMockAutomationContext({
     eventName: "workflow_dispatch",
   });
+  const pushContext = createMockAutomationContext({
+    eventName: "push",
+  });
 
   test("isIssuesEvent accepts only issues events", () => {
     expect(isIssuesEvent(issuesContext)).toBe(true);
@@ -496,9 +516,10 @@ describe("type guards", () => {
     expect(isEntityContext(reviewContext)).toBe(true);
     expect(isEntityContext(reviewCommentContext)).toBe(true);
     expect(isEntityContext(workflowDispatchContext)).toBe(false);
+    expect(isEntityContext(pushContext)).toBe(false);
   });
 
-  test("isAutomationContext accepts the four automation events", () => {
+  test("isAutomationContext accepts the five automation events", () => {
     expect(isAutomationContext(workflowDispatchContext)).toBe(true);
     expect(
       isAutomationContext(
@@ -515,6 +536,7 @@ describe("type guards", () => {
         createMockAutomationContext({ eventName: "workflow_run" }),
       ),
     ).toBe(true);
+    expect(isAutomationContext(pushContext)).toBe(true);
     expect(isAutomationContext(issuesContext)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Adds `push` to the list of supported GitHub event types so the action can be driven from `on: push:` workflows (e.g. post-merge automation that regenerates artifacts after a merge to `main`).

Before this change, `parseGitHubContext()` threw `Unsupported event type: push` at startup, blocking any non-PR/non-issue automation use case where `workflow_dispatch` isn't a good fit.

## What changed

- `src/github/context.ts`
  - Import `PushEvent` from `@octokit/webhooks-types`.
  - Add `"push"` to `AUTOMATION_EVENT_NAMES` (same bucket as `workflow_dispatch`, `schedule`, `workflow_run`, `repository_dispatch`).
  - Add `PushEvent` to the `AutomationContext.payload` union.
  - Handle `case "push":` in the `parseGitHubContext()` switch.
- `test/github-context.test.ts`
  - New `push produces an automation context` test in the automation-events block.
  - Extend the `isEntityContext` / `isAutomationContext` type-guard assertions to cover push.

`isAutomationContext()` is derived from `AUTOMATION_EVENT_NAMES`, so adding `"push"` to that tuple makes the type guard recognize it automatically — no other code paths needed changes.

## Why this approach

- **No new input flag.** Push fits cleanly into the existing automation-event bucket. Agent mode is already triggered by the presence of a `prompt:` input, which is how `workflow_dispatch` / `schedule` users drive the action today.
- **No changes to `src/create-prompt/index.ts`.** The second `Unsupported event type` throw lives in tag mode's prompt builder, and tag mode requires an entity context (gated via `isEntityContext` in `detectMode()` and `run.ts`). Push events never reach that switch, so the throw stays as-is to preserve the tag-mode invariant.
- **Entity-only code paths are already gated.** `checkWritePermissions`, `restoreConfigFromBase`, and `updateCommentLink` in `run.ts` are all wrapped in `isEntityContext(context)` checks, so they correctly skip on push events.

## Behavior

With this change, a workflow like:

```yaml
on:
  push:
    branches: [main]
jobs:
  claude:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: anthropics/claude-code-action@v1
        with:
          prompt: "Regenerate ingestion docs from the latest commit"
          claude_args: --max-turns 1
```

…now runs Claude in agent mode (no tracking comment, no PR/issue anchor required), matching how `workflow_dispatch` already works.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test test/github-context.test.ts` passes (new push cases + existing automation events)
- [x] `bun test` full suite green
- [x] `bun run format:check` clean
- [x] Smoke test in a downstream repo: a workflow triggered by `on: push: branches: [main]` reaches Claude and runs the supplied prompt (instead of failing at startup)

Fixes #1456
