### PR TITLE
docs: fix Foundry base URL to include /anthropic path (#816)

### DIFF
--- a/base-action/test/validate-env.test.ts
+++ b/base-action/test/validate-env.test.ts
@@ -236,7 +236,7 @@ describe("validateEnvironmentVariables", () => {
     test("should pass when ANTHROPIC_FOUNDRY_BASE_URL is provided", () => {
       process.env.CLAUDE_CODE_USE_FOUNDRY = "1";
       process.env.ANTHROPIC_FOUNDRY_BASE_URL =
-        "https://test-resource.services.ai.azure.com";
+        "https://test-resource.services.ai.azure.com/anthropic";
 
       expect(() => validateEnvironmentVariables()).not.toThrow();
     });
@@ -245,7 +245,7 @@ describe("validateEnvironmentVariables", () => {
       process.env.CLAUDE_CODE_USE_FOUNDRY = "1";
       process.env.ANTHROPIC_FOUNDRY_RESOURCE = "test-resource";
       process.env.ANTHROPIC_FOUNDRY_BASE_URL =
-        "https://custom.services.ai.azure.com";
+        "https://custom.services.ai.azure.com/anthropic";
 
       expect(() => validateEnvironmentVariables()).not.toThrow();
     });

--- a/docs/cloud-providers.md
+++ b/docs/cloud-providers.md
@@ -130,7 +130,7 @@ AWS Bedrock, GCP Vertex AI, and Microsoft Foundry all support OIDC authenticatio
       --model claude-sonnet-4-5
     # ... other inputs
   env:
-    ANTHROPIC_FOUNDRY_BASE_URL: https://my-resource.services.ai.azure.com
+    ANTHROPIC_FOUNDRY_BASE_URL: https://my-resource.services.ai.azure.com/anthropic
 
 permissions:
   id-token: write # Required for OIDC


### PR DESCRIPTION
## Summary

Fixes #816. The documented `ANTHROPIC_FOUNDRY_BASE_URL` was missing the required `/anthropic` path suffix, so users copying it verbatim get a non-working endpoint.

Per the [official Claude Code Foundry docs](https://code.claude.com/docs/en/microsoft-foundry), the base URL must be:

```
https://{resource}.services.ai.azure.com/anthropic
```

(the Messages API resolves to `.../anthropic/v1/messages`).

## Changes

- `docs/cloud-providers.md` — append `/anthropic` to the `ANTHROPIC_FOUNDRY_BASE_URL` example.
- `base-action/test/validate-env.test.ts` — update the two example base URLs to the corrected form for consistency.

## Notes

This is docs-only in effect. The action forwards `ANTHROPIC_FOUNDRY_BASE_URL` straight through to the CLI (`base-action/action.yml`), which builds the request URL — there is no URL construction in this repo to change (unlike Bedrock's `format(...)` fallback).

## Verification

- `bun test base-action/test/validate-env.test.ts` → 30 pass / 0 fail
- `bun run typecheck` → clean
- `bun run format:check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)