### PR TITLE
fix(context): treat push as an automation event

### DIFF
--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -6,6 +6,7 @@ import type {
   PullRequestEvent,
   PullRequestReviewEvent,
   PullRequestReviewCommentEvent,
+  PushEvent,
   WorkflowRunEvent,
 } from "@octokit/webhooks-types";
 import { CLAUDE_APP_BOT_ID, CLAUDE_BOT_LOGIN } from "./constants";
@@ -65,6 +66,7 @@ const AUTOMATION_EVENT_NAMES = [
   "repository_dispatch",
   "schedule",
   "workflow_run",
+  "push",
 ] as const;
 
 // Derive types from constants for better maintainability
@@ -118,14 +120,15 @@ export type ParsedGitHubContext = BaseContext & {
   isPR: boolean;
 };
 
-// Context for automation events (workflow_dispatch, repository_dispatch, schedule, workflow_run)
+// Context for automation events (workflow_dispatch, repository_dispatch, schedule, workflow_run, push)
 export type AutomationContext = BaseContext & {
   eventName: AutomationEventName;
   payload:
     | WorkflowDispatchEvent
     | RepositoryDispatchEvent
     | ScheduleEvent
-    | WorkflowRunEvent;
+    | WorkflowRunEvent
+    | PushEvent;
 };
 
 // Union type for all contexts
@@ -245,6 +248,13 @@ export function parseGitHubContext(): GitHubContext {
         ...commonFields,
         eventName: "workflow_run",
         payload: context.payload as unknown as WorkflowRunEvent,
+      };
+    }
+    case "push": {
+      return {
+        ...commonFields,
+        eventName: "push",
+        payload: context.payload as unknown as PushEvent,
       };
     }
     default:

--- a/test/github-context.test.ts
+++ b/test/github-context.test.ts
@@ -5,6 +5,7 @@ import type {
   PullRequestEvent,
   PullRequestReviewEvent,
   PullRequestReviewCommentEvent,
+  PushEvent,
   WorkflowRunEvent,
 } from "@octokit/webhooks-types";
 
@@ -297,6 +298,20 @@ describe("parseGitHubContext", () => {
       expect(context.eventName).toBe("workflow_run");
       expect(isAutomationContext(context)).toBe(true);
     });
+
+    test("push produces an automation context", () => {
+      setEvent("push", {
+        ref: "refs/heads/main",
+        repository: repositoryPayload,
+        pusher: { name: "test-user", email: "test@example.com" },
+        commits: [],
+      } as unknown as PushEvent);
+
+      const context = parseGitHubContext();
+
+      expect(context.eventName).toBe("push");
+      expect(isAutomationContext(context)).toBe(true);
+    });
   });
 
   describe("invalid partition", () => {
@@ -498,7 +513,7 @@ describe("type guards", () => {
     expect(isEntityContext(workflowDispatchContext)).toBe(false);
   });
 
-  test("isAutomationContext accepts the four automation events", () => {
+  test("isAutomationContext accepts the six automation events", () => {
     expect(isAutomationContext(workflowDispatchContext)).toBe(true);
     expect(
       isAutomationContext(
@@ -514,6 +529,9 @@ describe("type guards", () => {
       isAutomationContext(
         createMockAutomationContext({ eventName: "workflow_run" }),
       ),
+    ).toBe(true);
+    expect(
+      isAutomationContext(createMockAutomationContext({ eventName: "push" })),
     ).toBe(true);
     expect(isAutomationContext(issuesContext)).toBe(false);
   });

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -222,6 +222,17 @@ describe("detectMode with enhanced routing", () => {
 
       expect(detectMode(context)).toBe("agent");
     });
+
+    it("should use agent mode for push without track_progress", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "push",
+        payload: {} as any,
+        inputs: { ...baseContext.inputs, prompt: "Regenerate docs" },
+      };
+
+      expect(detectMode(context)).toBe("agent");
+    });
   });
 
   describe("Custom prompt injection in tag mode", () => {


### PR DESCRIPTION
## Summary

Register GitHub `push` as a supported automation event so push-triggered workflows can run configured prompts without PR or issue context.

## Motivation

Fixes #1456. Workflows triggered by `on: push` (including reusable workflows invoked from a push) failed immediately with `Unsupported event type: push` before Claude could run. This blocked post-merge doc regeneration and similar automation that intentionally runs after merge rather than on pull requests.

## Changes

- Add `push` to `AUTOMATION_EVENT_NAMES` and handle it in `parseGitHubContext()`
- Include `PushEvent` in the `AutomationContext` payload union
- Add regression tests for context parsing, `isAutomationContext`, and agent mode detection

## Tests

- `bun test` — 771 pass
- `bun run typecheck` — pass
- `bun run format:check` — pass on changed files (one pre-existing warning in unrelated file)

## Notes

Push now follows the same agent-mode path as `workflow_dispatch`, `schedule`, and `workflow_run`: a `prompt` is required to trigger execution, and existing human-actor / `allowed_bots` checks still apply. Reviewed with composer-2.5 — APPROVE.