### PR TITLE
fix(ci): disallow interactive-only tools in headless tag and agent runs

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -76,12 +76,22 @@ export function buildAllowedToolsString(
   return allAllowedTools;
 }
 
+// Headless CI cannot resume after ending a turn; block interactive-only tools by default.
+const HEADLESS_DISALLOWED_TOOLS = [
+  "WebSearch",
+  "WebFetch",
+  "ScheduleWakeup",
+  "SendMessage",
+  "Monitor",
+  "TaskList",
+];
+
 export function buildDisallowedToolsString(
   customDisallowedTools?: string[],
   allowedTools?: string[],
 ): string {
-  // Tag mode: Disable WebSearch and WebFetch by default for security
-  let disallowedTools = ["WebSearch", "WebFetch"];
+  // Tag/agent mode: disable WebSearch/WebFetch and interactive session tools by default.
+  let disallowedTools = [...HEADLESS_DISALLOWED_TOOLS];
 
   // If user has explicitly allowed some default disallowed tools, remove them
   if (allowedTools && allowedTools.length > 0) {

--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -1,6 +1,7 @@
 import { mkdir, rm, writeFile } from "fs/promises";
 import { prepareMcpConfig } from "../../mcp/install-mcp-server";
 import { parseAllowedTools } from "./parse-tools";
+import { buildDisallowedToolsString } from "../../create-prompt";
 import {
   configureGitAuth,
   setupSshSigning,
@@ -119,6 +120,11 @@ export async function prepareAgentMode({
 
   // Append user's claude_args (which may have more --mcp-config flags)
   claudeArgs = `${claudeArgs} ${userClaudeArgs}`.trim();
+
+  const disallowedTools = buildDisallowedToolsString(undefined, allowedTools);
+  if (disallowedTools) {
+    claudeArgs += ` --disallowedTools "${disallowedTools}"`;
+  }
 
   return {
     commentId: undefined,

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -12,7 +12,7 @@ import {
   extractOriginalTitle,
   extractOriginalBody,
 } from "../../github/data/fetcher";
-import { createPrompt } from "../../create-prompt";
+import { createPrompt, buildDisallowedToolsString } from "../../create-prompt";
 import { isEntityContext } from "../../github/context";
 import type { GitHubContext } from "../../github/context";
 import type { Octokits } from "../../github/api/client";
@@ -173,6 +173,11 @@ export async function prepareTagMode({
   // acceptEdits: file edits auto-allowed inside cwd ($GITHUB_WORKSPACE), denied outside.
   // Headless SDK has no prompt handler, so anything that falls through to "ask" is denied.
   claudeArgs += ` --permission-mode acceptEdits --allowedTools "${tagModeTools.join(",")}"`;
+
+  const disallowedTools = buildDisallowedToolsString(undefined, tagModeTools);
+  if (disallowedTools) {
+    claudeArgs += ` --disallowedTools "${disallowedTools}"`;
+  }
 
   // Append user's claude_args (which may have more --mcp-config flags)
   if (userClaudeArgs) {

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -1203,6 +1203,10 @@ describe("buildDisallowedToolsString", () => {
     // The base disallowed tools should be in the result
     expect(result).toContain("WebSearch");
     expect(result).toContain("WebFetch");
+    expect(result).toContain("ScheduleWakeup");
+    expect(result).toContain("SendMessage");
+    expect(result).toContain("Monitor");
+    expect(result).toContain("TaskList");
   });
 
   test("should append custom disallowed tools when provided", async () => {
@@ -1243,12 +1247,24 @@ describe("buildDisallowedToolsString", () => {
   });
 
   test("should remove all hardcoded disallowed tools if they are all in allowed tools", async () => {
-    const allowedTools = ["WebSearch", "WebFetch", "SomeOtherTool"];
+    const allowedTools = [
+      "WebSearch",
+      "WebFetch",
+      "ScheduleWakeup",
+      "SendMessage",
+      "Monitor",
+      "TaskList",
+      "SomeOtherTool",
+    ];
     const result = buildDisallowedToolsString(undefined, allowedTools);
 
-    // Both hardcoded disallowed tools should be removed
+    // All hardcoded disallowed tools should be removed
     expect(result).not.toContain("WebSearch");
     expect(result).not.toContain("WebFetch");
+    expect(result).not.toContain("ScheduleWakeup");
+    expect(result).not.toContain("SendMessage");
+    expect(result).not.toContain("Monitor");
+    expect(result).not.toContain("TaskList");
 
     // Result should be empty since no custom disallowed tools provided
     expect(result).toBe("");
@@ -1256,7 +1272,14 @@ describe("buildDisallowedToolsString", () => {
 
   test("should handle custom disallowed tools when all hardcoded tools are overridden", async () => {
     const customDisallowedTools = ["BadTool1", "BadTool2"];
-    const allowedTools = ["WebSearch", "WebFetch"];
+    const allowedTools = [
+      "WebSearch",
+      "WebFetch",
+      "ScheduleWakeup",
+      "SendMessage",
+      "Monitor",
+      "TaskList",
+    ];
     const result = buildDisallowedToolsString(
       customDisallowedTools,
       allowedTools,
@@ -1265,6 +1288,10 @@ describe("buildDisallowedToolsString", () => {
     // Hardcoded tools should be removed
     expect(result).not.toContain("WebSearch");
     expect(result).not.toContain("WebFetch");
+    expect(result).not.toContain("ScheduleWakeup");
+    expect(result).not.toContain("SendMessage");
+    expect(result).not.toContain("Monitor");
+    expect(result).not.toContain("TaskList");
 
     // Only custom disallowed tools should remain
     expect(result).toBe("BadTool1,BadTool2");

--- a/test/modes/agent.test.ts
+++ b/test/modes/agent.test.ts
@@ -8,6 +8,7 @@ import {
   mock,
 } from "bun:test";
 import { prepareAgentMode } from "../../src/modes/agent";
+import { buildDisallowedToolsString } from "../../src/create-prompt";
 import { createMockAutomationContext } from "../mockContext";
 import * as core from "@actions/core";
 import * as gitConfig from "../../src/github/operations/git-config";
@@ -84,8 +85,11 @@ describe("Agent Mode", () => {
       githubToken: "test-token",
     });
 
-    // Verify claude_args includes user args (no MCP config in agent mode without allowed tools)
-    expect(result.claudeArgs).toBe("--model claude-sonnet-4 --max-turns 10");
+    const headlessDisallowed = buildDisallowedToolsString();
+    const expectedClaudeArgs = `--model claude-sonnet-4 --max-turns 10 --disallowedTools "${headlessDisallowed}"`;
+
+    // Verify claude_args includes user args and headless disallowed tools
+    expect(result.claudeArgs).toBe(expectedClaudeArgs);
     expect(result.claudeArgs).not.toContain("--mcp-config");
 
     // Verify return structure - should fall back to repository.default_branch when no env vars set
@@ -97,7 +101,7 @@ describe("Agent Mode", () => {
         claudeBranch: undefined,
       },
       mcpConfig: expect.any(String),
-      claudeArgs: "--model claude-sonnet-4 --max-turns 10",
+      claudeArgs: expectedClaudeArgs,
     });
 
     // Clean up


### PR DESCRIPTION
## Summary

Disables interactive-only Claude Code tools in headless tag and agent mode runs so CI workflows cannot end a turn while waiting for background work that will never resume.

## Motivation

Fixes #1462. In headless CI, the model could call `ScheduleWakeup`, `SendMessage`, `Monitor`, or `TaskList`, spawn background work, end its turn with a “waiting…” message, and still report **success** — producing silent no-op runs.

## Changes

- Extend default headless disallowed tools: `ScheduleWakeup`, `SendMessage`, `Monitor`, `TaskList` (alongside existing `WebSearch`/`WebFetch`)
- Wire `buildDisallowedToolsString()` into tag and agent mode `claudeArgs` via `--disallowedTools`
- Respect `--allowedTools` overrides when building the default disallowed list

## Tests

- `bun test` — 769 pass
- `bun run typecheck` — pass

## Notes

- Background `Agent` subagents are not globally disabled (too blunt); this PR blocks the resume/wait tooling that makes the failure silent.
- Users can still add more tools via `claude_args --disallowedTools`; defaults are union-merged in `parse-sdk-options`.

Fixes #1462