### PR TITLE
fix(branch): avoid fork PR fetch collision with checked-out branch

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -140,6 +140,56 @@ function execGit(args: string[]): void {
   execFileSync("git", args, { stdio: "inherit", env: process.env });
 }
 
+function readGitOutput(args: string[]): string {
+  return execFileSync("git", args, { encoding: "utf-8", env: process.env }).trim();
+}
+
+function getCurrentBranchName(): string | null {
+  try {
+    const currentBranch = readGitOutput(["branch", "--show-current"]);
+    return currentBranch.length > 0 ? currentBranch : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remote ref used to fetch a fork PR head without colliding with a local
+ * branch that may already be checked out (e.g. `main` on tag-mode runs).
+ */
+export function forkPullRequestHeadRef(entityNumber: number): string {
+  return `refs/remotes/pull/${entityNumber}/head`;
+}
+
+export function forkPullRequestFetchArgs(
+  entityNumber: number,
+  fetchDepth: number,
+): string[] {
+  return [
+    "fetch",
+    "origin",
+    `--depth=${fetchDepth}`,
+    `+pull/${entityNumber}/head:${forkPullRequestHeadRef(entityNumber)}`,
+  ];
+}
+
+export function forkPullRequestCheckoutArgs(
+  entityNumber: number,
+  headRefName: string,
+  currentBranch: string | null,
+): string[] {
+  const pullHeadRef = forkPullRequestHeadRef(entityNumber);
+
+  // When the fork head shares the runner's checked-out branch name (common in
+  // tag-mode workflows on the default branch), avoid repointing that local
+  // branch and instead read the PR head from a detached checkout.
+  if (currentBranch === headRefName) {
+    return ["checkout", "--detach", pullHeadRef, "--"];
+  }
+
+  return ["checkout", "-B", headRefName, pullHeadRef, "--"];
+}
+
 export type BranchInfo = {
   baseBranch: string;
   claudeBranch?: string;
@@ -189,18 +239,20 @@ export async function setupBranch(
         console.log(
           `PR #${entityNumber} is from a fork, fetching via refs/pull/${entityNumber}/head...`,
         );
-        execGit([
-          "fetch",
-          "origin",
-          `--depth=${fetchDepth}`,
-          `pull/${entityNumber}/head:${branchName}`,
-        ]);
+        execGit(forkPullRequestFetchArgs(entityNumber, fetchDepth));
+        execGit(
+          forkPullRequestCheckoutArgs(
+            entityNumber,
+            branchName,
+            getCurrentBranchName(),
+          ),
+        );
       } else {
         // Execute git commands to checkout PR branch (dynamic depth based on PR size)
         // Using execFileSync instead of shell template literals for security
         execGit(["fetch", "origin", `--depth=${fetchDepth}`, branchName]);
+        execGit(["checkout", branchName, "--"]);
       }
-      execGit(["checkout", branchName, "--"]);
 
       console.log(`Successfully checked out PR branch for PR #${entityNumber}`);
 

--- a/test/fork-pr-branch-checkout.test.ts
+++ b/test/fork-pr-branch-checkout.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import {
+  forkPullRequestCheckoutArgs,
+  forkPullRequestFetchArgs,
+  forkPullRequestHeadRef,
+} from "../src/github/operations/branch";
+
+describe("fork PR branch checkout helpers", () => {
+  it("uses a namespaced remote ref that cannot collide with checked-out branches", () => {
+    expect(forkPullRequestHeadRef(38)).toBe("refs/remotes/pull/38/head");
+  });
+
+  it("force-fetches the pull head into the namespaced remote ref", () => {
+    expect(forkPullRequestFetchArgs(38, 20)).toEqual([
+      "fetch",
+      "origin",
+      "--depth=20",
+      "+pull/38/head:refs/remotes/pull/38/head",
+    ]);
+  });
+
+  it("checks out detached when the fork head collides with the current branch", () => {
+    expect(forkPullRequestCheckoutArgs(38, "main", "main")).toEqual([
+      "checkout",
+      "--detach",
+      "refs/remotes/pull/38/head",
+      "--",
+    ]);
+  });
+
+  it("creates a local branch when the fork head name is safe to use", () => {
+    expect(forkPullRequestCheckoutArgs(38, "feature-x", "main")).toEqual([
+      "checkout",
+      "-B",
+      "feature-x",
+      "refs/remotes/pull/38/head",
+      "--",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes fork PR checkout failures in tag-mode workflows when the fork head branch name matches the branch already checked out on the runner (e.g. `main`).

## Motivation

`setupBranch` fetched cross-repo PR heads with `pull/<N>/head:<headRefName>`, which writes into `refs/heads/<headRefName>`. If that branch is currently checked out, git refuses with:

```
fatal: refusing to fetch into branch 'refs/heads/main' checked out at '...'
```

This breaks `issue_comment` / tag-mode runs on fork PRs opened from the fork's default branch.

Fixes #1423

## Changes

- Fetch fork PR heads into a namespaced remote ref: `refs/remotes/pull/<N>/head`
- Use force fetch (`+`) so reruns can update the ref safely
- When the fork head name collides with the current branch, check out the PR head in detached mode
- Otherwise create/update a local branch from the fetched PR head so `git push` keeps working for differently named fork heads
- Add unit tests for the new checkout helpers

## Tests

- `bun test test/fork-pr-branch-checkout.test.ts` — pass
- `bun run typecheck` — pass

## Notes

Detached checkout is only used for the collision case described in #1423. Non-colliding fork PRs still get a local branch at `headRefName`.