### PR TITLE
fix: allow installed plugin skills to execute in headless runs

### DIFF
--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -5,7 +5,7 @@ import { preparePrompt } from "./prepare-prompt";
 import { runClaude } from "./run-claude";
 import { setupClaudeCodeSettings } from "./setup-claude-code-settings";
 import { validateEnvironmentVariables } from "./validate-env";
-import { installPlugins } from "./install-plugins";
+import { installPlugins, getPluginSkillAllowRules } from "./install-plugins";
 import { setExecutionFileOutputIfPresent } from "./execution-file";
 import { setupWorkloadIdentity } from "./workload-identity";
 import type { WorkloadIdentityHandle } from "./workload-identity";
@@ -44,9 +44,20 @@ async function run() {
       promptFile: process.env.INPUT_PROMPT_FILE || "",
     });
 
+    // Skills from explicitly installed plugins must be allowed up front:
+    // permission prompts cannot be answered in CI, so without these rules
+    // the model's Skill invocations are auto-denied.
+    const pluginSkillAllowRules = getPluginSkillAllowRules(
+      process.env.INPUT_PLUGINS,
+    );
+    const allowedTools =
+      [process.env.INPUT_ALLOWED_TOOLS, ...pluginSkillAllowRules]
+        .filter(Boolean)
+        .join(",") || undefined;
+
     const result = await runClaude(promptConfig.path, {
       claudeArgs: process.env.INPUT_CLAUDE_ARGS,
-      allowedTools: process.env.INPUT_ALLOWED_TOOLS,
+      allowedTools,
       disallowedTools: process.env.INPUT_DISALLOWED_TOOLS,
       maxTurns: process.env.INPUT_MAX_TURNS,
       mcpConfig: process.env.INPUT_MCP_CONFIG,

--- a/base-action/src/install-plugins.ts
+++ b/base-action/src/install-plugins.ts
@@ -128,6 +128,31 @@ function parsePlugins(plugins?: string): string[] {
 }
 
 /**
+ * Derives Skill permission allow rules for explicitly installed plugins.
+ *
+ * Headless runs cannot answer interactive permission prompts, so a plugin
+ * skill whose frontmatter requests extra capabilities (e.g. allowed-tools)
+ * is denied when the model invokes it via the Skill tool. Installing a
+ * plugin through the `plugins` input is an explicit opt-in from the workflow
+ * author, so the plugin's skills are allowed to execute.
+ * @param pluginsInput - Newline-separated list of plugin names (same format as installPlugins)
+ * @returns Array of permission rules like `Skill(plugin-name:*)` (empty array if none provided)
+ * @throws {Error} If any plugin name fails validation
+ */
+export function getPluginSkillAllowRules(pluginsInput?: string): string[] {
+  const plugins = parsePlugins(pluginsInput);
+
+  const names = plugins.map((plugin) => {
+    // Strip the marketplace suffix: "code-review@claude-code-plugins" -> "code-review".
+    // Search from index 1 so a leading "@" in a scoped name is preserved.
+    const atIndex = plugin.indexOf("@", 1);
+    return atIndex === -1 ? plugin : plugin.substring(0, atIndex);
+  });
+
+  return [...new Set(names)].map((name) => `Skill(${name}:*)`);
+}
+
+/**
  * Executes a Claude Code CLI command with proper error handling
  * @param claudeExecutable - Path to the Claude executable
  * @param args - Command arguments to pass to the executable

--- a/base-action/test/install-plugins.test.ts
+++ b/base-action/test/install-plugins.test.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env bun
 
 import { describe, test, expect, mock, spyOn, afterEach } from "bun:test";
-import { installPlugins } from "../src/install-plugins";
+import {
+  installPlugins,
+  getPluginSkillAllowRules,
+} from "../src/install-plugins";
 import * as childProcess from "child_process";
 
 describe("installPlugins", () => {
@@ -701,6 +704,63 @@ describe("installPlugins", () => {
       "claude",
       ["plugin", "marketplace", "add", "./my.plugin.marketplace"],
       { stdio: "inherit" },
+    );
+  });
+});
+
+describe("getPluginSkillAllowRules", () => {
+  test("returns empty array when plugins input is undefined", () => {
+    expect(getPluginSkillAllowRules(undefined)).toEqual([]);
+  });
+
+  test("returns empty array when plugins input is empty or whitespace", () => {
+    expect(getPluginSkillAllowRules("")).toEqual([]);
+    expect(getPluginSkillAllowRules("   \n  ")).toEqual([]);
+  });
+
+  test("derives a Skill rule from a plugin with marketplace suffix", () => {
+    // Regression test for #1458: plugin skills invoked via prompt were
+    // permission-denied in headless runs because no Skill allow rule existed.
+    expect(getPluginSkillAllowRules("code-review@claude-code-plugins")).toEqual(
+      ["Skill(code-review:*)"],
+    );
+  });
+
+  test("derives a Skill rule from a bare plugin name", () => {
+    expect(getPluginSkillAllowRules("my-plugin")).toEqual([
+      "Skill(my-plugin:*)",
+    ]);
+  });
+
+  test("derives rules for multiple newline-separated plugins", () => {
+    expect(
+      getPluginSkillAllowRules(
+        "code-review@claude-code-plugins\nfeature-dev@claude-code-plugins",
+      ),
+    ).toEqual(["Skill(code-review:*)", "Skill(feature-dev:*)"]);
+  });
+
+  test("deduplicates plugins that share a name across marketplaces", () => {
+    expect(
+      getPluginSkillAllowRules("tools@marketplace-a\ntools@marketplace-b"),
+    ).toEqual(["Skill(tools:*)"]);
+  });
+
+  test("trims whitespace and skips empty entries", () => {
+    expect(
+      getPluginSkillAllowRules("  code-review@claude-code-plugins  \n\n"),
+    ).toEqual(["Skill(code-review:*)"]);
+  });
+
+  test("preserves a leading @ in scoped plugin names", () => {
+    expect(getPluginSkillAllowRules("@scope/plugin@marketplace")).toEqual([
+      "Skill(@scope/plugin:*)",
+    ]);
+  });
+
+  test("throws on invalid plugin names", () => {
+    expect(() => getPluginSkillAllowRules("bad;name@marketplace")).toThrow(
+      "Invalid plugin name format",
     );
   });
 });

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -38,7 +38,10 @@ import { setupWorkloadIdentity } from "../../base-action/src/workload-identity";
 import type { WorkloadIdentityHandle } from "../../base-action/src/workload-identity";
 import { validateEnvironmentVariables } from "../../base-action/src/validate-env";
 import { setupClaudeCodeSettings } from "../../base-action/src/setup-claude-code-settings";
-import { installPlugins } from "../../base-action/src/install-plugins";
+import {
+  installPlugins,
+  getPluginSkillAllowRules,
+} from "../../base-action/src/install-plugins";
 import { preparePrompt } from "../../base-action/src/prepare-prompt";
 import { runClaude } from "../../base-action/src/run-claude";
 import type { ClaudeRunResult } from "../../base-action/src/run-claude-sdk";
@@ -284,8 +287,16 @@ async function run() {
       promptFile,
     });
 
+    // Skills from explicitly installed plugins must be allowed up front:
+    // permission prompts cannot be answered in CI, so without these rules
+    // the model's Skill invocations are auto-denied.
+    const pluginSkillAllowRules = getPluginSkillAllowRules(
+      process.env.INPUT_PLUGINS,
+    );
+
     const claudeResult: ClaudeRunResult = await runClaude(promptConfig.path, {
       claudeArgs: prepareResult.claudeArgs,
+      allowedTools: pluginSkillAllowRules.join(",") || undefined,
       appendSystemPrompt: process.env.APPEND_SYSTEM_PROMPT,
       model: process.env.ANTHROPIC_MODEL,
       pathToClaudeCodeExecutable: claudeExecutable,


### PR DESCRIPTION
Fixes #1458.

When a workflow installs plugins via the plugins input and the prompt asks Claude to run one of their skills, the run fails with Error: Execute skill: <name>. The cause is permissions rather than installation: headless runs cannot answer permission prompts, and a plugin skill that declares extra capabilities in its frontmatter (for example allowed-tools) is auto-denied when the model invokes the Skill tool, because the action never granted Skill rules for the plugins it just installed. I reproduced this deterministically with a local test plugin and a mock API server against the pinned CLI: the Skill call returns a permission denial with exactly the reported error.

One note on the version bound in the report: fad22eb only bumps the pinned CLI version and the same repro also fails on 2.1.195, so the boundary likely reflects the newer CLI's default model invoking skills through the Skill tool more often, rather than an action code change.

The fix derives Skill(<plugin>:*) allow rules from the plugins input and merges them into allowedTools in both entrypoints. Installing a plugin is already an explicit opt-in by the workflow author, the same trust the action extends by enabling project MCP servers. User-provided allowed_tools and claude_args values are unaffected since parse-sdk-options merges rather than overwrites.

Tests: nine new unit tests for the rule derivation (failing without the fix), full suite passes, typecheck and prettier clean. Also verified end to end through runClaude() against the pinned CLI: before the fix the skill invocation returns is_error with the reported message, after it the skill launches with no permission denials.