### PR TITLE
fix: respect ANTHROPIC_BASE_URL for inline comment classification

### DIFF
--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -42,7 +42,16 @@ For each numbered comment body below, respond with ONLY a JSON array of booleans
 Comments:
 `;
 
-async function classifyComments(bodies: string[]): Promise<boolean[] | null> {
+export function getAnthropicMessagesUrl(
+  baseUrl = process.env.ANTHROPIC_BASE_URL,
+): string {
+  const resolvedBaseUrl = baseUrl?.trim() || "https://api.anthropic.com";
+  return `${resolvedBaseUrl.replace(/\/+$/, "")}/v1/messages`;
+}
+
+export async function classifyComments(
+  bodies: string[],
+): Promise<boolean[] | null> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     console.log(
@@ -56,7 +65,7 @@ async function classifyComments(bodies: string[]): Promise<boolean[] | null> {
     bodies.map((b, i) => `${i + 1}. ${JSON.stringify(b)}`).join("\n");
 
   try {
-    const res = await fetch("https://api.anthropic.com/v1/messages", {
+    const res = await fetch(getAnthropicMessagesUrl(), {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -227,7 +236,9 @@ async function main() {
   console.log(`Posted ${posted}/${toPost.length}`);
 }
 
-main().catch((e) => {
-  console.error("post-buffered-inline-comments failed:", e);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((e) => {
+    console.error("post-buffered-inline-comments failed:", e);
+    process.exit(1);
+  });
+}

--- a/test/post-buffered-inline-comments.test.ts
+++ b/test/post-buffered-inline-comments.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  classifyComments,
+  getAnthropicMessagesUrl,
+} from "../src/entrypoints/post-buffered-inline-comments";
+
+describe("post-buffered-inline-comments classification", () => {
+  let originalAnthropicApiKey: string | undefined;
+  let originalAnthropicBaseUrl: string | undefined;
+  let fetchSpy: any;
+
+  beforeEach(() => {
+    originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+    originalAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    process.env.ANTHROPIC_API_KEY = "test-api-key";
+    delete process.env.ANTHROPIC_BASE_URL;
+
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "[true]" }],
+      }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    if (originalAnthropicApiKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
+    }
+
+    if (originalAnthropicBaseUrl === undefined) {
+      delete process.env.ANTHROPIC_BASE_URL;
+    } else {
+      process.env.ANTHROPIC_BASE_URL = originalAnthropicBaseUrl;
+    }
+
+    fetchSpy.mockRestore();
+  });
+
+  test("uses the default Anthropic messages endpoint", () => {
+    expect(getAnthropicMessagesUrl()).toBe(
+      "https://api.anthropic.com/v1/messages",
+    );
+  });
+
+  test("appends the messages path to ANTHROPIC_BASE_URL", async () => {
+    process.env.ANTHROPIC_BASE_URL = "https://proxy.example.com/anthropic";
+
+    await classifyComments(["This catches a bug in the changed branch."]);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://proxy.example.com/anthropic/v1/messages",
+      expect.any(Object),
+    );
+  });
+
+  test("handles a trailing slash in ANTHROPIC_BASE_URL", async () => {
+    process.env.ANTHROPIC_BASE_URL = "https://proxy.example.com/anthropic/";
+
+    await classifyComments(["This catches a bug in the changed branch."]);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://proxy.example.com/anthropic/v1/messages",
+      expect.any(Object),
+    );
+  });
+});


### PR DESCRIPTION
﻿Fixes #1418.

This updates the buffered inline comment classifier to build its Anthropic messages endpoint from `ANTHROPIC_BASE_URL` when configured, while keeping the existing `https://api.anthropic.com/v1/messages` default. It also normalizes trailing slashes so proxy/base URLs can be configured without producing a double slash.

Validation run locally:
- `npx.cmd --yes bun@latest test ./test/post-buffered-inline-comments.test.ts`
- `npx.cmd --yes bun@latest run typecheck`
- `npx.cmd prettier@3.5.3 --check src/entrypoints/post-buffered-inline-comments.ts test/post-buffered-inline-comments.test.ts`
- `git diff --check`
