### PR TITLE
fix: map claude_args model to SDK options

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -201,6 +201,9 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   // Detect if --json-schema is present (for hasJsonSchema flag)
   const hasJsonSchema = "json-schema" in extraArgs;
 
+  const modelFromClaudeArgs = extraArgs["model"] || undefined;
+  delete extraArgs["model"];
+
   const additionalDirectories = extraArgs["add-dir"]
     ? extraArgs["add-dir"]
         .split(ACCUMULATE_DELIMITER)
@@ -304,7 +307,7 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   // Build SDK options - use merged tools from both direct options and claudeArgs
   const sdkOptions: SdkOptions = {
     // Direct options from ClaudeOptions inputs
-    model: options.model,
+    model: options.model || modelFromClaudeArgs,
     maxTurns: options.maxTurns ? parseInt(options.maxTurns, 10) : undefined,
     allowedTools:
       mergedAllowedTools.length > 0 ? mergedAllowedTools : undefined,

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -106,7 +106,8 @@ describe("parseSdkOptions", () => {
       const result = parseSdkOptions(options);
 
       expect(result.sdkOptions.extraArgs?.["allowedTools"]).toBeUndefined();
-      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-3-5-sonnet");
+      expect(result.sdkOptions.extraArgs?.["model"]).toBeUndefined();
+      expect(result.sdkOptions.model).toBe("claude-3-5-sonnet");
     });
 
     test("should handle hyphenated --allowed-tools flag", () => {
@@ -366,7 +367,8 @@ describe("parseSdkOptions", () => {
       );
       expect(mcpConfig.mcpServers).toHaveProperty("server1");
       expect(mcpConfig.mcpServers).toHaveProperty("server2");
-      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-3-5-sonnet");
+      expect(result.sdkOptions.extraArgs?.["model"]).toBeUndefined();
+      expect(result.sdkOptions.model).toBe("claude-3-5-sonnet");
     });
 
     test("should handle real-world scenario: action config + user config", () => {
@@ -436,7 +438,8 @@ describe("parseSdkOptions", () => {
       const result = parseSdkOptions(options);
 
       expect(result.sdkOptions.additionalDirectories).toEqual(["/path/to/dir"]);
-      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-3-5-sonnet");
+      expect(result.sdkOptions.extraArgs?.["model"]).toBeUndefined();
+      expect(result.sdkOptions.model).toBe("claude-3-5-sonnet");
       expect(result.sdkOptions.extraArgs?.["add-dir"]).toBeUndefined();
     });
   });
@@ -464,7 +467,8 @@ describe("parseSdkOptions", () => {
 
       const result = parseSdkOptions(options);
 
-      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-haiku");
+      expect(result.sdkOptions.extraArgs?.["model"]).toBeUndefined();
+      expect(result.sdkOptions.model).toBe("claude-haiku");
       expect(result.sdkOptions.allowedTools).toEqual(["Edit"]);
     });
 
@@ -475,7 +479,8 @@ describe("parseSdkOptions", () => {
 
       const result = parseSdkOptions(options);
 
-      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-haiku");
+      expect(result.sdkOptions.extraArgs?.["model"]).toBeUndefined();
+      expect(result.sdkOptions.model).toBe("claude-haiku");
     });
 
     test("should not strip inline # that appears inside a quoted value", () => {
@@ -485,8 +490,34 @@ describe("parseSdkOptions", () => {
 
       const result = parseSdkOptions(options);
 
-      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-haiku");
+      expect(result.sdkOptions.extraArgs?.["model"]).toBeUndefined();
+      expect(result.sdkOptions.model).toBe("claude-haiku");
       expect(result.sdkOptions.extraArgs?.["prompt"]).toBe("use color #ff0000");
+    });
+  });
+
+  describe("model handling", () => {
+    test("should map --model from claudeArgs to sdkOptions.model", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--model claude-haiku-4-5-20251001",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.model).toBe("claude-haiku-4-5-20251001");
+      expect(result.sdkOptions.extraArgs?.["model"]).toBeUndefined();
+    });
+
+    test("should prefer direct model option over --model from claudeArgs", () => {
+      const options: ClaudeOptions = {
+        model: "claude-sonnet-4-6",
+        claudeArgs: "--model claude-haiku-4-5-20251001",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.model).toBe("claude-sonnet-4-6");
+      expect(result.sdkOptions.extraArgs?.["model"]).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
﻿Fixes #1223.

`--model` supplied through `claude_args` was parsed as a generic extra arg, so the SDK options still had no `model` value. In tag mode that meant the run initialized with the tag-mode default instead of the user-pinned model.

This maps the parsed `--model` value into `sdkOptions.model` and removes it from `extraArgs`, matching how other first-class SDK options are extracted from `claude_args`. A direct `model` option still wins if both are present.

This is separate from #1432: that PR handles the no-model default path, while this one handles an explicit user-supplied `--model` being ignored.

Validation run locally:
- `npx.cmd --yes bun@latest test base-action/test/parse-sdk-options.test.ts`
- `npx.cmd --yes bun@latest run typecheck` from `base-action/`
- `npx.cmd prettier@3.5.3 --check base-action/src/parse-sdk-options.ts base-action/test/parse-sdk-options.test.ts`
- `git diff --check`
