### PR TITLE
fix(format): filter out thinking_tokens system messages from step summary

### DIFF
--- a/src/entrypoints/format-turns.ts
+++ b/src/entrypoints/format-turns.ts
@@ -268,7 +268,8 @@ export function groupTurnsNaturally(data: Turn[]): GroupedContent[] {
           type: "system_init",
           tools_count: tools.length,
         });
-      } else {
+      } else if (subtype !== "thinking_tokens") {
+        // Skip thinking_tokens - internal progress events not meant for summary
         groupedContent.push({
           type: "system_other",
           data: turn,

--- a/test/format-turns.test.ts
+++ b/test/format-turns.test.ts
@@ -484,4 +484,34 @@ describe("system_other handling", () => {
     ]);
     expect(markdown).toContain("## ⚙️ System Message");
   });
+
+  test("filters out thinking_tokens system messages", () => {
+    const data: Turn[] = [
+      { type: "system", subtype: "init", tools: [{ name: "tool1" }] },
+      { type: "system", subtype: "thinking_tokens" },
+      { type: "system", subtype: "thinking_tokens" },
+      { type: "system", subtype: "other_subtype" },
+    ];
+
+    const grouped = groupTurnsNaturally(data);
+
+    // Should have init and other_subtype, but not thinking_tokens
+    expect(grouped).toHaveLength(2);
+    expect(grouped[0]?.type).toBe("system_init");
+    expect(grouped[1]?.type).toBe("system_other");
+    expect(grouped[1]?.data?.subtype).toBe("other_subtype");
+  });
+
+  test("thinking_tokens does not appear in formatted output", () => {
+    const data: Turn[] = [
+      { type: "system", subtype: "init", tools: [] },
+      { type: "system", subtype: "thinking_tokens" },
+      { type: "system", subtype: "thinking_tokens" },
+    ];
+
+    const result = formatTurnsFromData(data);
+
+    expect(result).not.toContain("thinking_tokens");
+    expect(result).toContain("## 🚀 System Initialization");
+  });
 });


### PR DESCRIPTION
## Summary

The step summary (Claude Code Report) was cluttered with many "⚙️ System Message" JSON blocks containing `subtype: "thinking_tokens"`, making it hard to read the actual responses and tool executions. This change filters out these internal progress events from the formatted summary.

## Root Cause

The `SDKThinkingTokensMessage` event type (subtype: `thinking_tokens`) was added in Claude Code 2.1.153 / Agent SDK 0.3.153 as a live progress event for UI spinners. The summary formatter in `src/entrypoints/format-turns.ts` predates this event and lacks filtering logic. It rendered all non-init system messages as raw JSON blocks, causing dozens of internal progress events to appear in the step summary.

## Changes

- Added a filter condition in `groupTurnsNaturally` function to skip `thinking_tokens` system messages
- Added regression tests to verify `thinking_tokens` messages are excluded from grouped content and formatted output

## Tests

Added two new test cases:
- `filters out thinking_tokens system messages` - verifies grouping logic skips these events
- `thinking_tokens does not appear in formatted output` - ensures formatted summary excludes these events

Fixes #1478
