### PR TITLE
fix: handle null author (deleted/ghost accounts) in GitHub data formatter

### DIFF
--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -204,11 +204,9 @@ export function isBodySafeToUse(
  * @param excludeActors - Comma-separated actors to exclude
  * @returns Filtered array of comments
  */
-export function filterCommentsByActor<T extends { author: { login: string } }>(
-  comments: T[],
-  includeActors: string = "",
-  excludeActors: string = "",
-): T[] {
+export function filterCommentsByActor<
+  T extends { author: { login: string } | null },
+>(comments: T[], includeActors: string = "", excludeActors: string = ""): T[] {
   const includeParsed = parseActorFilter(includeActors);
   const excludeParsed = parseActorFilter(excludeActors);
 
@@ -219,7 +217,9 @@ export function filterCommentsByActor<T extends { author: { login: string } }>(
 
   return comments.filter((comment) =>
     shouldIncludeCommentByActor(
-      comment.author.login,
+      // author is null for deleted/ghost accounts; use "" so it matches no
+      // include/exclude username pattern rather than throwing.
+      comment.author?.login ?? "",
       includeParsed,
       excludeParsed,
     ),

--- a/src/github/data/formatter.ts
+++ b/src/github/data/formatter.ts
@@ -21,7 +21,7 @@ export function formatContext(
     const prData = contextData as GitHubPullRequest;
     const sanitizedTitle = sanitizeContent(prData.title);
     return `PR Title: ${sanitizedTitle}
-PR Author: ${prData.author.login}
+PR Author: ${prData.author?.login ?? "ghost"}
 PR Branch: ${prData.headRefName} -> ${prData.baseRefName}
 PR State: ${prData.state}
 PR Labels: ${formatLabels(prData.labels.nodes)}
@@ -33,7 +33,7 @@ Changed Files: ${prData.files.nodes.length} files`;
     const issueData = contextData as GitHubIssue;
     const sanitizedTitle = sanitizeContent(issueData.title);
     return `Issue Title: ${sanitizedTitle}
-Issue Author: ${issueData.author.login}
+Issue Author: ${issueData.author?.login ?? "ghost"}
 Issue State: ${issueData.state}
 Issue Labels: ${formatLabels(issueData.labels.nodes)}`;
   }
@@ -71,7 +71,7 @@ export function formatComments(
 
       body = sanitizeContent(body);
 
-      return `[${comment.author.login} at ${comment.createdAt}]: ${body}`;
+      return `[${comment.author?.login ?? "ghost"} at ${comment.createdAt}]: ${body}`;
     })
     .join("\n\n");
 }
@@ -85,7 +85,7 @@ export function formatReviewComments(
   }
 
   const formattedReviews = reviewData.nodes.map((review) => {
-    let reviewOutput = `[Review by ${review.author.login} at ${review.submittedAt}]: ${review.state}`;
+    let reviewOutput = `[Review by ${review.author?.login ?? "ghost"} at ${review.submittedAt}]: ${review.state}`;
 
     if (review.body && review.body.trim()) {
       let body = review.body;

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -1,4 +1,9 @@
 // Types for GitHub GraphQL query responses
+
+// GitHub's GraphQL API types `author` as the nullable `Actor` interface and
+// returns `null` when the account that wrote the content has been deleted
+// (the "ghost" user). Fields below that hold an author are therefore
+// `GitHubAuthor | null`, so callers must handle the null case.
 export type GitHubAuthor = {
   login: string;
   name?: string;
@@ -8,7 +13,7 @@ export type GitHubComment = {
   id: string;
   databaseId: string;
   body: string;
-  author: GitHubAuthor;
+  author: GitHubAuthor | null;
   createdAt: string;
   updatedAt?: string;
   lastEditedAt?: string;
@@ -39,7 +44,7 @@ export type GitHubFile = {
 export type GitHubReview = {
   id: string;
   databaseId: string;
-  author: GitHubAuthor;
+  author: GitHubAuthor | null;
   body: string;
   state: string;
   submittedAt: string;
@@ -53,7 +58,7 @@ export type GitHubReview = {
 export type GitHubPullRequest = {
   title: string;
   body: string;
-  author: GitHubAuthor;
+  author: GitHubAuthor | null;
   baseRefName: string;
   headRefName: string;
   headRefOid: string;
@@ -95,7 +100,7 @@ export type GitHubPullRequest = {
 export type GitHubIssue = {
   title: string;
   body: string;
-  author: GitHubAuthor;
+  author: GitHubAuthor | null;
   createdAt: string;
   updatedAt?: string;
   lastEditedAt?: string;

--- a/test/data-formatter.test.ts
+++ b/test/data-formatter.test.ts
@@ -872,3 +872,84 @@ describe("formatChangedFilesWithSHA", () => {
     expect(result).toBe("");
   });
 });
+
+describe("null author (deleted/ghost GitHub accounts)", () => {
+  // GitHub's GraphQL API returns `author: null` for issues, PRs, comments, and
+  // reviews written by deleted accounts (the "ghost" user). The formatter must
+  // render a fallback login instead of throwing (which would abort the whole
+  // action's prompt-generation path).
+  const ghostPR: GitHubPullRequest = {
+    title: "Ghost PR",
+    body: "body",
+    author: null,
+    baseRefName: "main",
+    headRefName: "feature/x",
+    headRefOid: "abc123",
+    isCrossRepository: false,
+    headRepository: { owner: { login: "o" }, name: "r" },
+    createdAt: "2024-01-15T10:00:00Z",
+    additions: 1,
+    deletions: 0,
+    state: "OPEN",
+    labels: { nodes: [] },
+    commits: { totalCount: 1, nodes: [] },
+    files: { nodes: [] },
+    comments: { nodes: [] },
+    reviews: { nodes: [] },
+  };
+
+  test("formatContext(PR) renders 'ghost' instead of throwing", () => {
+    expect(() => formatContext(ghostPR, true)).not.toThrow();
+    expect(formatContext(ghostPR, true)).toContain("PR Author: ghost");
+  });
+
+  test("formatContext(issue) renders 'ghost' instead of throwing", () => {
+    const ghostIssue: GitHubIssue = {
+      title: "Ghost issue",
+      body: "body",
+      author: null,
+      createdAt: "2024-01-15T10:00:00Z",
+      state: "OPEN",
+      labels: { nodes: [] },
+      comments: { nodes: [] },
+    };
+    expect(() => formatContext(ghostIssue, false)).not.toThrow();
+    expect(formatContext(ghostIssue, false)).toContain("Issue Author: ghost");
+  });
+
+  test("formatComments renders 'ghost' for a null-author comment", () => {
+    const comments: GitHubComment[] = [
+      {
+        id: "1",
+        databaseId: "1",
+        body: "hi",
+        author: null,
+        createdAt: "2024-01-15T10:00:00Z",
+      },
+    ];
+    expect(() => formatComments(comments)).not.toThrow();
+    expect(formatComments(comments)).toBe(
+      "[ghost at 2024-01-15T10:00:00Z]: hi",
+    );
+  });
+
+  test("formatReviewComments renders 'ghost' for a null-author review", () => {
+    const reviewData = {
+      nodes: [
+        {
+          id: "r1",
+          databaseId: "1",
+          author: null,
+          body: "",
+          state: "COMMENTED",
+          submittedAt: "2024-01-15T10:00:00Z",
+          comments: { nodes: [] },
+        },
+      ],
+    };
+    expect(() => formatReviewComments(reviewData)).not.toThrow();
+    expect(formatReviewComments(reviewData)).toContain(
+      "[Review by ghost at 2024-01-15T10:00:00Z]: COMMENTED",
+    );
+  });
+});


### PR DESCRIPTION
## What

`formatContext`, `formatComments`, and `formatReviewComments` (`src/github/data/formatter.ts`) crash with `TypeError: null is not an object (evaluating 'author.login')` whenever an issue, PR, comment, or review involved in a run was written by a **deleted GitHub account**.

## Why it happens

GitHub's GraphQL API types `author` as the nullable `Actor` interface and returns `null` for content authored by deleted ("ghost") accounts. But `src/github/types.ts` declared `author: GitHubAuthor` (non-null) on `GitHubComment`, `GitHubReview`, `GitHubPullRequest`, and `GitHubIssue`, so the formatter dereferenced `author.login` at four sites (`formatter.ts:24/36/74/88`) with no guard.

A single such comment/review aborts the whole prompt-generation path (`create-prompt` calls `formatComments` / `formatContext` / `formatReviewComments`) and fails the run. `filterCommentsByActor` returns early when no actor filters are configured (the default), so nothing upstream catches the null before it reaches the formatter.

## Fix

- **Make the type honest:** `author: GitHubAuthor | null` on the four GraphQL types, with a comment explaining GitHub's ghost-account behavior. This makes `tsc` enforce null-handling from here on (it surfaced exactly the dereference sites below and no others).
- **Guard every dereference:** `author?.login ?? "ghost"` in `formatter.ts`, and `author?.login ?? ""` in `filterCommentsByActor` (so a ghost author matches no include/exclude username pattern instead of throwing). `"ghost"` mirrors the login GitHub itself shows for deleted accounts.

## Tests

Added a `null author (deleted/ghost GitHub accounts)` suite to `test/data-formatter.test.ts` covering all four call sites (PR context, issue context, comment, review). Each case throws `TypeError` before the fix and renders the `ghost` fallback after.

## Verification

- `bun test` → **773 pass, 0 fail** (4 new).
- `bun run typecheck` → clean (the now-nullable type surfaced no other unguarded dereference).
- `bun run format:check` → clean.

Happy to open a tracking issue as well if the maintainers prefer.
