### PR TITLE
docs: map custom_instructions to --append-system-prompt (#1480)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -337,17 +337,17 @@ For a complete list of available settings and their descriptions, see the [Claud
 
 Many individual input parameters have been consolidated into `claude_args` or `settings`. Here's how to migrate:
 
-| Old Input             | New Approach                                             |
-| --------------------- | -------------------------------------------------------- |
-| `allowed_tools`       | Use `claude_args: "--allowedTools Tool1,Tool2"`          |
-| `disallowed_tools`    | Use `claude_args: "--disallowedTools Tool1,Tool2"`       |
-| `max_turns`           | Use `claude_args: "--max-turns 10"`                      |
-| `model`               | Use `claude_args: "--model claude-4-0-sonnet-20250805"`  |
-| `claude_env`          | Use `settings` with `"env"` object                       |
-| `custom_instructions` | Use `claude_args: "--system-prompt 'Your instructions'"` |
-| `mcp_config`          | Use `claude_args: "--mcp-config '{...}'"`                |
-| `direct_prompt`       | Use `prompt` input instead                               |
-| `override_prompt`     | Use `prompt` with GitHub context variables               |
+| Old Input             | New Approach                                                    |
+| --------------------- | --------------------------------------------------------------- |
+| `allowed_tools`       | Use `claude_args: "--allowedTools Tool1,Tool2"`                 |
+| `disallowed_tools`    | Use `claude_args: "--disallowedTools Tool1,Tool2"`              |
+| `max_turns`           | Use `claude_args: "--max-turns 10"`                             |
+| `model`               | Use `claude_args: "--model claude-4-0-sonnet-20250805"`         |
+| `claude_env`          | Use `settings` with `"env"` object                              |
+| `custom_instructions` | Use `claude_args: "--append-system-prompt 'Your instructions'"` |
+| `mcp_config`          | Use `claude_args: "--mcp-config '{...}'"`                       |
+| `direct_prompt`       | Use `prompt` input instead                                      |
+| `override_prompt`     | Use `prompt` with GitHub context variables                      |
 
 ## Custom Executables for Specialized Environments
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -153,7 +153,7 @@ prompt: "Review this PR for security vulnerabilities"
 **These inputs are deprecated in v1.0:**
 
 - **`direct_prompt`** → Use `prompt` instead
-- **`custom_instructions`** → Use `claude_args` with `--system-prompt`
+- **`custom_instructions`** → Use `claude_args` with `--append-system-prompt` (appends to the default system prompt, matching v0 behavior; `--system-prompt` replaces it entirely)
 
 Migration examples:
 
@@ -165,7 +165,7 @@ custom_instructions: "Focus on security"
 # New (v1.0)
 prompt: "Review this PR"
 claude_args: |
-  --system-prompt "Focus on security"
+  --append-system-prompt "Focus on security"
 ```
 
 ### Why doesn't Claude execute my bash commands?

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -14,19 +14,19 @@ This guide helps you migrate from Claude Code Action v0.x to v1.0. The new versi
 
 The following inputs have been deprecated and replaced:
 
-| Deprecated Input      | Replacement                          | Notes                                         |
-| --------------------- | ------------------------------------ | --------------------------------------------- |
-| `mode`                | Auto-detected                        | Action automatically chooses based on context |
-| `direct_prompt`       | `prompt`                             | Direct drop-in replacement                    |
-| `override_prompt`     | `prompt`                             | Use GitHub context variables instead          |
-| `custom_instructions` | `claude_args: --system-prompt`       | Move to CLI arguments                         |
-| `max_turns`           | `claude_args: --max-turns`           | Use CLI format                                |
-| `model`               | `claude_args: --model`               | Specify via CLI                               |
-| `allowed_tools`       | `claude_args: --allowedTools`        | Use CLI format                                |
-| `disallowed_tools`    | `claude_args: --disallowedTools`     | Use CLI format                                |
-| `claude_env`          | `settings` with env object           | Use settings JSON                             |
-| `mcp_config`          | `claude_args: --mcp-config`          | Pass MCP config via CLI arguments             |
-| `timeout_minutes`     | Use GitHub Actions `timeout-minutes` | Configure at job level instead of input level |
+| Deprecated Input      | Replacement                           | Notes                                                                               |
+| --------------------- | ------------------------------------- | ----------------------------------------------------------------------------------- |
+| `mode`                | Auto-detected                         | Action automatically chooses based on context                                       |
+| `direct_prompt`       | `prompt`                              | Direct drop-in replacement                                                          |
+| `override_prompt`     | `prompt`                              | Use GitHub context variables instead                                                |
+| `custom_instructions` | `claude_args: --append-system-prompt` | Appends to the default prompt (v0 behavior); `--system-prompt` replaces it entirely |
+| `max_turns`           | `claude_args: --max-turns`            | Use CLI format                                                                      |
+| `model`               | `claude_args: --model`                | Specify via CLI                                                                     |
+| `allowed_tools`       | `claude_args: --allowedTools`         | Use CLI format                                                                      |
+| `disallowed_tools`    | `claude_args: --disallowedTools`      | Use CLI format                                                                      |
+| `claude_env`          | `settings` with env object            | Use settings JSON                                                                   |
+| `mcp_config`          | `claude_args: --mcp-config`           | Pass MCP config via CLI arguments                                                   |
+| `timeout_minutes`     | Use GitHub Actions `timeout-minutes`  | Configure at job level instead of input level                                       |
 
 ## Migration Examples
 
@@ -52,7 +52,7 @@ The following inputs have been deprecated and replaced:
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     claude_args: |
       --max-turns 10
-      --system-prompt "Follow our coding standards"
+      --append-system-prompt "Follow our coding standards"
       --allowedTools Edit,Read,Write
 ```
 
@@ -255,14 +255,15 @@ claude_args: |
 
 ### Common claude_args Options
 
-| Option              | Description              | Example                                |
-| ------------------- | ------------------------ | -------------------------------------- |
-| `--max-turns`       | Limit conversation turns | `--max-turns 10`                       |
-| `--model`           | Specify Claude model     | `--model claude-4-0-sonnet-20250805`   |
-| `--allowedTools`    | Enable specific tools    | `--allowedTools Edit,Read,Write`       |
-| `--disallowedTools` | Disable specific tools   | `--disallowedTools WebSearch`          |
-| `--system-prompt`   | Add system instructions  | `--system-prompt "Focus on security"`  |
-| `--mcp-config`      | Add MCP server config    | `--mcp-config '{"mcpServers": {...}}'` |
+| Option                   | Description                                                               | Example                                                |
+| ------------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `--max-turns`            | Limit conversation turns                                                  | `--max-turns 10`                                       |
+| `--model`                | Specify Claude model                                                      | `--model claude-4-0-sonnet-20250805`                   |
+| `--allowedTools`         | Enable specific tools                                                     | `--allowedTools Edit,Read,Write`                       |
+| `--disallowedTools`      | Disable specific tools                                                    | `--disallowedTools WebSearch`                          |
+| `--system-prompt`        | Replace the entire default system prompt                                  | `--system-prompt "Focus on security"`                  |
+| `--append-system-prompt` | Append to the default system prompt (keeps Claude Code's built-in prompt) | `--append-system-prompt "Follow our coding standards"` |
+| `--mcp-config`           | Add MCP server config                                                     | `--mcp-config '{"mcpServers": {...}}'`                 |
 
 ## Provider-Specific Updates
 
@@ -330,7 +331,7 @@ You can also pass MCP configuration from a file:
 - [ ] Remove `mode` input (auto-detected now)
 - [ ] Replace `direct_prompt` with `prompt`
 - [ ] Replace `override_prompt` with `prompt` using GitHub context
-- [ ] Move `custom_instructions` to `claude_args` with `--system-prompt`
+- [ ] Move `custom_instructions` to `claude_args` with `--append-system-prompt`
 - [ ] Convert `max_turns` to `claude_args` with `--max-turns`
 - [ ] Convert `model` to `claude_args` with `--model`
 - [ ] Convert `allowed_tools` to `claude_args` with `--allowedTools`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -99,7 +99,7 @@ These inputs are deprecated and will be removed in a future version:
 | `mode`                | **DEPRECATED**: Mode is now automatically detected based on workflow context                 | Remove this input; the action auto-detects the correct mode    |
 | `direct_prompt`       | **DEPRECATED**: Use `prompt` instead                                                         | Replace with `prompt`                                          |
 | `override_prompt`     | **DEPRECATED**: Use `prompt` with template variables or `claude_args` with `--system-prompt` | Use `prompt` for templates or `claude_args` for system prompts |
-| `custom_instructions` | **DEPRECATED**: Use `claude_args` with `--system-prompt` or include in `prompt`              | Move instructions to `prompt` or use `claude_args`             |
+| `custom_instructions` | **DEPRECATED**: Use `claude_args` with `--append-system-prompt` or include in `prompt`       | Move instructions to `prompt` or use `claude_args`             |
 | `max_turns`           | **DEPRECATED**: Use `claude_args` with `--max-turns` instead                                 | Use `claude_args: "--max-turns 5"`                             |
 | `model`               | **DEPRECATED**: Use `claude_args` with `--model` instead                                     | Use `claude_args: "--model claude-4-0-sonnet-20250805"`        |
 | `fallback_model`      | **DEPRECATED**: Use `claude_args` with fallback configuration                                | Configure fallback in `claude_args` or `settings`              |
@@ -139,7 +139,7 @@ For a comprehensive guide on migrating from v0.x to v1.0, including step-by-step
     anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     claude_args: |
       --max-turns 10
-      --system-prompt "Focus on security"
+      --append-system-prompt "Focus on security"
 ```
 
 #### Automation Workflows


### PR DESCRIPTION
## Summary

Fixes #1480. The v1 migration guide maps the v0 `custom_instructions` input to `claude_args: --system-prompt`, but the semantics differ:

- `custom_instructions` (v0) **appended** to Claude Code's default system prompt.
- `--system-prompt` **replaces** the entire default system prompt.

Anyone following the guide silently lost the whole built-in Claude Code system prompt (tool-usage guidance, sub-agent conventions, etc.), keeping only their custom lines. The append-semantics equivalent is `--append-system-prompt`.

Credit to @szihs for the report and the self-contained reproducer in #1480, which captures the composed `system` field on the wire and shows `--system-prompt` dropping the default prompt while `--append-system-prompt` supplements it.

## Changes (`docs/migration-guide.md`, docs-only)

- Map `custom_instructions` → `--append-system-prompt` in the deprecated-inputs table, the migration example, and the migration checklist.
- Correct the `claude_args` options table: `--system-prompt` **replaces** the entire default system prompt; add an `--append-system-prompt` row for append behavior.

## Scope

Covers suggestions (1) and (2) from #1480. The optional runtime warning when `claude_args` contains `--system-prompt` — suggestion (3) — is a code change and is intentionally left as a separate follow-up.

## Verification

- `bun run format:check` → clean
- No code paths touched; the action already forwards `--append-system-prompt` through `claude_args`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)