### PR TITLE
fix: allow leading underscore in branch names (valid per git-check-ref-format)

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -27,7 +27,7 @@ function extractFirstLabel(githubData: FetchDataResult): string | undefined {
  * This prevents command injection by ensuring only safe characters are used.
  *
  * Valid branch names:
- * - Start with alphanumeric character or @ (not dash, to prevent option injection)
+ * - Start with alphanumeric character, underscore, or @ (not dash, to prevent option injection)
  * - Contain only alphanumeric, forward slash, hyphen, underscore, period, hash (#), plus (+), comma (,), or at sign (@)
  * - Do not start or end with a period
  * - Do not end with a slash
@@ -68,12 +68,15 @@ export function validateBranchName(branchName: string): void {
   // @ is valid per git-check-ref-format anywhere in a ref name, including the first character
   //   (e.g. ticket conventions like "TICKET-123@add-feature" or prefixes like "@hotfix/...");
   //   the bare name "@" (HEAD shorthand) and the "@{" sequence (reflog syntax) are rejected below.
+  // _ is valid per git-check-ref-format anywhere in a ref name, including the first character;
+  //   leading underscores are a common convention for release/internal branches (e.g.
+  //   "_release/v1.2.3"), which previously failed validation as a PR's base branch.
   // All git calls use execFileSync (not shell interpolation), so none of these characters carry injection risk.
-  const validPattern = /^[a-zA-Z0-9@][a-zA-Z0-9/_.#+,@-]*$/;
+  const validPattern = /^[a-zA-Z0-9@_][a-zA-Z0-9/_.#+,@-]*$/;
 
   if (!validPattern.test(branchName)) {
     throw new Error(
-      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character or '@' and contain only alphanumeric characters, forward slashes, hyphens, underscores, periods, hashes (#), plus signs (+), commas (,), or at signs (@).`,
+      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character, underscore, or '@' and contain only alphanumeric characters, forward slashes, hyphens, underscores, periods, hashes (#), plus signs (+), commas (,), or at signs (@).`,
     );
   }
 

--- a/test/validate-branch-name.test.ts
+++ b/test/validate-branch-name.test.ts
@@ -74,6 +74,16 @@ describe("validateBranchName", () => {
       expect(() => validateBranchName("@hotfix/login-timeout")).not.toThrow();
       expect(() => validateBranchName("agent/task@abc123")).not.toThrow();
     });
+
+    it("should accept branch names starting with underscore (git-valid, common for release branches)", () => {
+      // Leading underscores are valid per git check-ref-format and a common
+      // convention for release/internal branches. Rejecting them broke the
+      // action on any open PR whose base branch was e.g. "_release/v1.2.3",
+      // since setupBranch validates the PR's baseRefName after checkout.
+      expect(() => validateBranchName("_release/v1.2.3")).not.toThrow();
+      expect(() => validateBranchName("_internal")).not.toThrow();
+      expect(() => validateBranchName("_wip/feature-x")).not.toThrow();
+    });
   });
 
   describe("command injection attempts", () => {


### PR DESCRIPTION
## Problem

`validateBranchName()` rejects branch names that start with an underscore, even though they are valid per `git check-ref-format`:

```
Error: Action failed with error: Invalid branch name: "_release/v0.4.15". Branch names must start with an alphanumeric character or '@' and contain only alphanumeric characters, forward slashes, hyphens, underscores, periods, hashes (#), plus signs (+), commas (,), or at signs (@).
```

Underscores are already allowed everywhere in the name *except* the first character. Because `setupBranch()` validates the PR's `baseRefName` after checking out an open PR (`src/github/operations/branch.ts`), the action fails on **every open PR targeting a branch like `_release/v1.2.3`** — a common convention for release/internal branches. There is no input that bypasses this path.

## Fix

Add `_` to the first-character class of the whitelist pattern:

```diff
-  const validPattern = /^[a-zA-Z0-9@][a-zA-Z0-9/_.#+,@-]*$/;
+  const validPattern = /^[a-zA-Z0-9@_][a-zA-Z0-9/_.#+,@-]*$/;
```

A leading underscore carries no option-injection risk — only a leading dash does, and that is still rejected separately. All git calls already go through `execFileSync`, so there is no shell-interpolation risk either. The error message and doc comments are updated to match.

This follows the same pattern as prior fixes relaxing this whitelist for other git-valid characters: `#` (#1137), `@` (#998), `+` (#1248), `,` (#1310).

## Testing

- Added cases to `test/validate-branch-name.test.ts` covering `_release/v1.2.3`, `_internal`, and `_wip/feature-x`
- `bun test`: 770 pass, 0 fail
- `bun run typecheck`: clean
- `prettier --check` on changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
