### PR TITLE
fix: parse inline --flag=value form in claude_args

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -153,7 +153,26 @@ function parseClaudeArgsToExtraArgs(
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg?.startsWith("--")) {
-      const flag = arg.slice(2);
+      let flag = arg.slice(2);
+
+      // Support the inline `--flag=value` form (accepted by the CLI) in
+      // addition to the space-separated `--flag value` form. Split on the first
+      // `=` only, so values that themselves contain `=` (e.g. inline JSON) are
+      // preserved. Without this, `--allowedTools=Edit,Read` becomes the bogus
+      // key "allowedTools=Edit,Read" and bypasses the tool-merge and
+      // --json-schema detection that parseSdkOptions performs on these keys.
+      const eqIndex = flag.indexOf("=");
+      if (eqIndex !== -1) {
+        const inlineValue = flag.slice(eqIndex + 1);
+        flag = flag.slice(0, eqIndex);
+        if (ACCUMULATING_FLAGS.has(flag) && result[flag]) {
+          result[flag] = `${result[flag]}${ACCUMULATE_DELIMITER}${inlineValue}`;
+        } else {
+          result[flag] = inlineValue;
+        }
+        continue; // inline value consumes no further tokens
+      }
+
       const nextArg = args[i + 1];
 
       // Check if next arg is a value (not another flag)

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -565,4 +565,52 @@ describe("parseSdkOptions", () => {
       }
     });
   });
+
+  describe("--flag=value (inline value) form", () => {
+    test("--allowedTools=value parses the same as the space form", () => {
+      const equals = parseSdkOptions({
+        claudeArgs: "--allowedTools=Edit,Read",
+      });
+      const spaced = parseSdkOptions({
+        claudeArgs: "--allowedTools Edit,Read",
+      });
+
+      // identical result to the space-separated form
+      expect(equals.sdkOptions.allowedTools).toEqual(["Edit", "Read"]);
+      expect(spaced.sdkOptions.allowedTools).toEqual(["Edit", "Read"]);
+      // the raw "allowedTools=Edit,Read" token must not leak into extraArgs
+      expect(equals.sdkOptions.extraArgs?.["allowedTools"]).toBeUndefined();
+      expect(
+        equals.sdkOptions.extraArgs?.["allowedTools=Edit,Read"],
+      ).toBeUndefined();
+    });
+
+    test("--json-schema=... is detected (hasJsonSchema), not left as a bogus key", () => {
+      const result = parseSdkOptions({
+        claudeArgs: '--json-schema={"type":"object"}',
+      });
+      expect(result.hasJsonSchema).toBe(true);
+      expect(result.sdkOptions.extraArgs?.["json-schema"]).toBeDefined();
+    });
+
+    test("splits on the first '=' only, preserving '=' in the value", () => {
+      const result = parseSdkOptions({ claudeArgs: "--model=claude-3-5=beta" });
+      expect(result.sdkOptions.extraArgs?.["model"]).toBe("claude-3-5=beta");
+    });
+
+    test("supports disallowedTools and add-dir in --flag=value form", () => {
+      const result = parseSdkOptions({
+        claudeArgs: "--disallowedTools=Bash --add-dir=/tmp/work",
+      });
+      expect(result.sdkOptions.disallowedTools).toEqual(["Bash"]);
+      expect(result.sdkOptions.additionalDirectories).toEqual(["/tmp/work"]);
+    });
+
+    test("accumulates repeated --allowedTools=... occurrences", () => {
+      const result = parseSdkOptions({
+        claudeArgs: "--allowedTools=Edit --allowedTools=Read,Write",
+      });
+      expect(result.sdkOptions.allowedTools).toEqual(["Edit", "Read", "Write"]);
+    });
+  });
 });


### PR DESCRIPTION
## What

`claude_args` written in the inline `--flag=value` form — which the Claude Code CLI itself accepts — is silently mis-parsed: the flag name and value are never split, so the whole token becomes a bogus `extraArgs` key and the value is dropped.

## Why it matters

`parseClaudeArgsToExtraArgs` (`base-action/src/parse-sdk-options.ts`) does `const flag = arg.slice(2)` and never splits on `=`. So `--allowedTools=Edit,Read` becomes the key `"allowedTools=Edit,Read"` (value `null`) instead of `allowedTools → "Edit,Read"`. Downstream, `parseSdkOptions` keys its interception/merge/detection off exact flag names, so with the `=` form:

- `--allowedTools=` / `--disallowedTools=` / `--add-dir=` are **not merged into `sdkOptions`** — the tools/dirs are silently dropped, and the raw `allowedTools=…` token leaks through to the CLI as a malformed flag (reintroducing the duplicate-`--allowedTools` clobbering that #746 hardened against).
- `--json-schema={…}` is **not detected** — `hasJsonSchema` stays `false`, so structured output is silently skipped.

Reproduced on current `main`:

```
--allowedTools Edit,Read   → allowedTools: ["Edit","Read"]                              (space form, works)
--allowedTools=Edit,Read   → allowedTools: undefined, extraArgs: {"allowedTools=Edit,Read": null}   (BUG)
--json-schema={...}        → hasJsonSchema: false                                       (BUG)
```

## Fix

In the arg loop, split the flag on the **first** `=` only (so a value that itself contains `=`, e.g. inline JSON, is preserved) and route the inline value through the same accumulating / non-accumulating handling used for the space-separated form. `--flag=value` and `--flag value` now produce identical results, and `--flag=value` consumes no following token (matching CLI semantics).

## Tests

Added a `--flag=value (inline value) form` suite to `base-action/test/parse-sdk-options.test.ts`: the `=`-form `allowedTools` equals the space form; `--json-schema=…` sets `hasJsonSchema`; split-on-first-`=` preserves `=` inside the value; `disallowedTools` / `add-dir` work; and repeated `--allowedTools=…` accumulate. Each fails before the fix and passes after.

## Verification

- `bun test` → **774 pass, 0 fail** (5 new).
- `bun run typecheck` → clean.
- `bun run format:check` → clean.
