### PR TITLE
fix(sanitizer): strip alt text from reference-style markdown images

### DIFF
--- a/src/github/utils/sanitizer.ts
+++ b/src/github/utils/sanitizer.ts
@@ -10,7 +10,13 @@ export function stripInvisibleCharacters(content: string): string {
 }
 
 export function stripMarkdownImageAltText(content: string): string {
-  return content.replace(/!\[[^\]]*\]\(/g, "![](");
+  // Inline images: ![alt](url) -> ![](url)
+  content = content.replace(/!\[[^\]]*\]\(/g, "![](");
+  // Reference-style images: ![alt][ref] -> ![][ref] (keep the label, drop the
+  // alt text, which is otherwise a hidden-instruction channel just like the
+  // inline form above).
+  content = content.replace(/!\[[^\]]*\](\[[^\]]*\])/g, "![]$1");
+  return content;
 }
 
 export function stripMarkdownLinkTitles(content: string): string {

--- a/test/sanitizer.test.ts
+++ b/test/sanitizer.test.ts
@@ -59,6 +59,22 @@ describe("stripMarkdownImageAltText", () => {
   it("should handle empty alt text", () => {
     expect(stripMarkdownImageAltText("![](image.png)")).toBe("![](image.png)");
   });
+
+  it("should remove alt text from reference-style images", () => {
+    expect(stripMarkdownImageAltText("![example alt text][img1]")).toBe(
+      "![][img1]",
+    );
+    expect(
+      stripMarkdownImageAltText("Text ![description][ref] more text"),
+    ).toBe("Text ![][ref] more text");
+  });
+
+  it("should preserve the reference label of a reference-style image", () => {
+    // the [ref] label must survive so the image definition still resolves;
+    // only the alt text (the injection channel) is removed
+    expect(stripMarkdownImageAltText("![alt][my-ref]")).toBe("![][my-ref]");
+    expect(stripMarkdownImageAltText("![][keep]")).toBe("![][keep]");
+  });
 });
 
 describe("stripMarkdownLinkTitles", () => {


### PR DESCRIPTION
## What

`stripMarkdownImageAltText` (`src/github/utils/sanitizer.ts`) strips alt text from **inline** markdown images `![alt](url)` but misses **reference-style** images `![alt][ref]`, so their alt text survives sanitization and reaches Claude's prompt.

## Why it matters

Image alt text is a hidden-instruction channel: text the poster controls that reaches the model. The sanitizer already removes it for inline images (`![alt](url)` → `![](url)`) as one of several best-effort prompt-injection defenses that run over user-authored issue/PR/comment bodies (`sanitizeContent`). Reference-style images use `][` instead of `](`, so the existing regex `/!\[[^\]]*\]\(/` never matches them and the alt text passes through unchanged.

Reproduced:

```
stripMarkdownImageAltText("![IGNORE ALL PREVIOUS INSTRUCTIONS](x.png)") → "![](x.png)"    (stripped)
stripMarkdownImageAltText("![IGNORE ALL PREVIOUS INSTRUCTIONS][img1]") → unchanged         (leaks)
```

## Fix

Add a second replace for the reference-style form, mirroring the inline handling: `![alt][ref]` → `![][ref]`. The `[ref]` label is preserved (so a valid image definition still resolves); only the alt text is removed. The two patterns don't overlap (`](` vs `][`), so applying them in sequence is safe.

## Tests

Added cases to the `stripMarkdownImageAltText` suite in `test/sanitizer.test.ts`: reference-style alt text is removed while the `[ref]` label is preserved (including the empty-alt `![][ref]` no-op). Each fails before the fix and passes after.

## Verification

- `bun test` → **771 pass, 0 fail** (2 new).
- `bun run typecheck` → clean.
- `bun run format:check` → clean.

This closes a specific gap in an existing best-effort sanitization layer (making reference-style images consistent with the inline handling); it isn't a claim of complete injection prevention.
