### PR TITLE
fix: sanitize {{label}} in branch name templates

### DIFF
--- a/src/utils/branch-template.ts
+++ b/src/utils/branch-template.ts
@@ -28,6 +28,20 @@ function extractDescription(
     .replace(/^-|-$/g, ""); // Remove leading/trailing hyphens
 }
 
+/**
+ * Sanitizes a label into a git-safe branch segment. Labels are free-form and
+ * often scoped (e.g. "area:permissions"), so characters that are invalid in a
+ * branch name (":", "/", spaces, ...) are replaced with a hyphen rather than
+ * dropped, keeping the label readable. Returns "" if nothing usable remains.
+ */
+function sanitizeLabel(label: string): string {
+  return label
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-") // Replace runs of invalid chars with a hyphen
+    .replace(/-+/g, "-") // Collapse multiple hyphens
+    .replace(/^-|-$/g, ""); // Remove leading/trailing hyphens
+}
+
 export interface BranchTemplateVariables {
   prefix: string;
   entityType: string;
@@ -78,7 +92,7 @@ export function generateBranchName(
     entityNumber,
     timestamp: `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}-${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}`,
     sha: sha?.substring(0, 8), // First 8 characters of SHA
-    label: label || entityType, // Fall back to entityType if no label
+    label: (label && sanitizeLabel(label)) || entityType, // Sanitize; fall back to entityType if empty/no label
     description: title ? extractDescription(title) : undefined,
   };
 

--- a/test/branch-template.test.ts
+++ b/test/branch-template.test.ts
@@ -5,6 +5,7 @@ import {
   applyBranchTemplate,
   generateBranchName,
 } from "../src/utils/branch-template";
+import { validateBranchName } from "../src/github/operations/branch";
 
 describe("branch template utilities", () => {
   describe("applyBranchTemplate", () => {
@@ -142,6 +143,53 @@ describe("branch template utilities", () => {
       );
 
       expect(result).toBe("dev/enhancement-issue_789");
+    });
+
+    it("should sanitize scoped labels that contain invalid git characters", () => {
+      const template = "{{prefix}}{{label}}/{{entityNumber}}";
+      const result = generateBranchName(
+        template,
+        "claude/",
+        "issue",
+        123,
+        undefined,
+        "area:permissions",
+      );
+
+      expect(result).toBe("claude/area-permissions/123");
+      // Regression: an unsanitized ":" here previously failed validateBranchName
+      // and crashed the run via process.exit(1).
+      expect(() => validateBranchName(result)).not.toThrow();
+    });
+
+    it("should replace spaces in labels with hyphens", () => {
+      const template = "{{prefix}}{{label}}-{{entityNumber}}";
+      const result = generateBranchName(
+        template,
+        "fix/",
+        "issue",
+        456,
+        undefined,
+        "needs review",
+      );
+
+      expect(result).toBe("fix/needs-review-456");
+      expect(() => validateBranchName(result)).not.toThrow();
+    });
+
+    it("should fall back to entityType when a label sanitizes to empty", () => {
+      const template = "{{prefix}}{{label}}-{{entityNumber}}";
+      const result = generateBranchName(
+        template,
+        "fix/",
+        "pr",
+        789,
+        undefined,
+        "🎉",
+      );
+
+      expect(result).toBe("fix/pr-789");
+      expect(() => validateBranchName(result)).not.toThrow();
     });
 
     it("should use description in template when provided", () => {


### PR DESCRIPTION
`{{label}}` was the only free-text branch-template variable substituted without sanitization. `{{description}}` goes through `extractDescription` (kebab-case, stripped to `[a-z0-9-]`), but `generateBranchName` passed the label straight through as `label || entityType`. A scoped label like `area:permissions` therefore lands a `:` in the branch name, which `validateBranchName` rejects — and because the branch setup block catches that error and calls `process.exit(1)`, the whole run dies rather than degrading. This repo's own labels (`area:permissions`, `provider:1p`) trigger it.

This adds a small `sanitizeLabel` helper and applies it before substitution. Unlike `extractDescription`, which drops invalid characters, it replaces runs of them with a hyphen so scoped labels stay readable (`area:permissions` → `area-permissions`, `needs review` → `needs-review`). If a label sanitizes to nothing (e.g. an emoji-only label), it falls back to `entityType`, matching the existing no-label behavior.

I deliberately kept this to the label variable and left the custom-template return path untouched — it intentionally skips the lowercase/truncation that the default path applies, so I didn't want to change those semantics.

Tests: added regression cases in `test/branch-template.test.ts` covering a scoped label, a label with spaces, and a label that sanitizes to empty, each asserting the result also passes `validateBranchName` (so the `process.exit(1)` path can't regress). Full suite green (`bun test`, `bun run typecheck`, `bun run format:check`).

Fixes #1491
