### PR TITLE
fix(sdk): fail step when result has is_error:true despite success subtype

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -208,7 +208,10 @@ export async function runClaudeWithSdk(
     throw new Error("No result message received from Claude");
   }
 
-  const isSuccess = resultMessage.subtype === "success";
+  // subtype "success" with is_error:true means the run errored without producing
+  // a real result — treat it as failure so CI does not show a misleading green check.
+  const isSuccess =
+    resultMessage.subtype === "success" && !resultMessage.is_error;
   result.conclusion = isSuccess ? "success" : "failure";
 
   // Handle structured output
@@ -234,14 +237,21 @@ export async function runClaudeWithSdk(
   }
 
   if (!isSuccess) {
+    if (resultMessage.subtype === "success" && resultMessage.is_error) {
+      core.error(
+        "Claude result reported subtype success with is_error:true (run did not complete successfully)",
+      );
+    }
     if ("errors" in resultMessage && resultMessage.errors) {
       core.error(`Execution failed: ${resultMessage.errors.join(", ")}`);
     }
     throw new Error(
       `Claude execution failed: ${
-        "errors" in resultMessage && resultMessage.errors
-          ? resultMessage.errors.join(", ")
-          : "unknown error"
+        resultMessage.subtype === "success" && resultMessage.is_error
+          ? "result is_error:true"
+          : "errors" in resultMessage && resultMessage.errors
+            ? resultMessage.errors.join(", ")
+            : "unknown error"
       }`,
     );
   }

--- a/base-action/test/run-claude-sdk.test.ts
+++ b/base-action/test/run-claude-sdk.test.ts
@@ -63,4 +63,69 @@ describe("runClaudeWithSdk", () => {
       consoleLogSpy.mockRestore();
     }
   });
+
+  test("fails when result subtype is success but is_error is true", async () => {
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => {},
+    );
+    const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+    const coreErrorSpy = spyOn(
+      await import("@actions/core"),
+      "error",
+    ).mockImplementation(() => {});
+
+    tempDir = await mkdtemp(join(tmpdir(), "claude-sdk-"));
+    process.env.RUNNER_TEMP = tempDir;
+
+    const promptPath = join(tempDir, "prompt.txt");
+    await writeFile(promptPath, "test prompt");
+
+    const initMessage = {
+      type: "system",
+      subtype: "init",
+      session_id: "session-123",
+      model: "claude-sonnet-5",
+    };
+
+    const errorResultMessage = {
+      type: "result",
+      subtype: "success",
+      is_error: true,
+      duration_ms: 434,
+      num_turns: 1,
+      total_cost_usd: 0,
+      permission_denials: [],
+    };
+
+    mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+      query: async function* () {
+        yield initMessage;
+        yield errorResultMessage;
+      },
+    }));
+
+    try {
+      const { runClaudeWithSdk } = await import("../src/run-claude-sdk");
+
+      await expect(
+        runClaudeWithSdk(promptPath, {
+          sdkOptions: {},
+          showFullOutput: false,
+          hasJsonSchema: false,
+        }),
+      ).rejects.toThrow("result is_error:true");
+
+      const executionFile = join(tempDir, "claude-execution-output.json");
+      await expect(readFile(executionFile, "utf-8")).resolves.toBe(
+        JSON.stringify([initMessage, errorResultMessage], null, 2),
+      );
+      expect(coreErrorSpy).toHaveBeenCalledWith(
+        "Claude result reported subtype success with is_error:true (run did not complete successfully)",
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      consoleLogSpy.mockRestore();
+      coreErrorSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

When the Claude Agent SDK returns a result with `subtype: "success"` but `is_error: true`, the action now treats the run as a failure instead of reporting a green check.

## Motivation

Fixes #1495. Some workflow runs (notably `pull_request` code-review flows) can emit:

```json
{ "type": "result", "subtype": "success", "is_error": true, ... }
```

Previously, success was inferred only from `subtype`, so the step concluded successfully even though no review actually ran. That produced a misleading green CI gate.

## Changes

- `base-action/src/run-claude-sdk.ts`: require `!is_error` in addition to `subtype === "success"` when computing `isSuccess`
- Add targeted logging and error text for the anomalous `success` + `is_error: true` case without changing messages for standard `error_*` subtypes
- `base-action/test/run-claude-sdk.test.ts`: regression test for the reported failure mode

## Tests

- `bun test ./base-action/test/run-claude-sdk.test.ts` — pass (2/2)
- `bun test` — pass (770/770)
- `bun run typecheck` — pass

## Notes

- This is an intentional behavior change: workflows that previously got a green check on `success` + `is_error: true` will now fail, which matches the expected CI semantics described in the issue.
- The existing `conclusion` output is set to `"failure"` via the catch path when the step fails.

Fixes #1495