### PR TITLE
fix(branch): sanitize {{label}} in branch_name_template for git-safe names

### DIFF
--- a/src/utils/branch-template.ts
+++ b/src/utils/branch-template.ts
@@ -7,7 +7,27 @@
 const NUM_DESCRIPTION_WORDS = 5;
 
 /**
+ * Normalizes a string into a git-safe lowercase hyphenated segment.
+ */
+function sanitizeBranchSegment(value: string): string {
+  if (!value || value.trim() === "") {
+    return "";
+  }
+
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[:/\s]+/g, "-") // Scoped tokens (area:permissions) or path-like segments
+    .replace(/[^a-z0-9-]/g, "") // Remove non-alphanumeric except hyphens
+    .replace(/-+/g, "-") // Replace multiple hyphens with single
+    .replace(/^-|-$/g, ""); // Remove leading/trailing hyphens
+}
+
+/**
  * Extracts the first 5 words from a title and converts them to kebab-case
+ */
+/**
+ * Extracts the first 5 words from a title and converts them to kebab-case.
  */
 function extractDescription(
   title: string,
@@ -17,15 +37,20 @@ function extractDescription(
     return "";
   }
 
-  return title
-    .trim()
-    .split(/\s+/)
-    .slice(0, numWords) // Only first `numWords` words
-    .join("-")
-    .toLowerCase()
-    .replace(/[^a-z0-9-]/g, "") // Remove non-alphanumeric except hyphens
-    .replace(/-+/g, "-") // Replace multiple hyphens with single
-    .replace(/^-|-$/g, ""); // Remove leading/trailing hyphens
+  return sanitizeBranchSegment(
+    title
+      .trim()
+      .split(/\s+/)
+      .slice(0, numWords) // Only first `numWords` words
+      .join("-"),
+  );
+}
+
+/**
+ * Converts a GitHub label into a git-safe branch name segment.
+ */
+function sanitizeLabel(label: string): string {
+  return sanitizeBranchSegment(label);
 }
 
 export interface BranchTemplateVariables {
@@ -78,7 +103,9 @@ export function generateBranchName(
     entityNumber,
     timestamp: `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, "0")}${String(now.getDate()).padStart(2, "0")}-${String(now.getHours()).padStart(2, "0")}${String(now.getMinutes()).padStart(2, "0")}`,
     sha: sha?.substring(0, 8), // First 8 characters of SHA
-    label: label || entityType, // Fall back to entityType if no label
+    label: label
+      ? sanitizeLabel(label) || entityType
+      : entityType, // Fall back to entityType if no label
     description: title ? extractDescription(title) : undefined,
   };
 

--- a/test/branch-template.test.ts
+++ b/test/branch-template.test.ts
@@ -5,6 +5,7 @@ import {
   applyBranchTemplate,
   generateBranchName,
 } from "../src/utils/branch-template";
+import { validateBranchName } from "../src/github/operations/branch";
 
 describe("branch template utilities", () => {
   describe("applyBranchTemplate", () => {
@@ -121,6 +122,51 @@ describe("branch template utilities", () => {
       );
 
       expect(result).toBe("feature/bug/123");
+    });
+
+    it("should sanitize scoped labels for git-safe branch names", () => {
+      const template = "{{prefix}}{{label}}/{{entityNumber}}";
+      const result = generateBranchName(
+        template,
+        "claude/",
+        "issue",
+        123,
+        undefined,
+        "area:permissions",
+      );
+
+      expect(result).toBe("claude/area-permissions/123");
+      expect(() => validateBranchName(result)).not.toThrow();
+    });
+
+    it("should sanitize labels with colons for git-safe branch names", () => {
+      const template = "{{prefix}}{{label}}-{{entityNumber}}";
+      const result = generateBranchName(
+        template,
+        "claude/",
+        "issue",
+        456,
+        undefined,
+        "provider:bedrock",
+      );
+
+      expect(result).toBe("claude/provider-bedrock-456");
+      expect(() => validateBranchName(result)).not.toThrow();
+    });
+
+    it("should fallback to entityType when label sanitizes to empty", () => {
+      const template = "{{prefix}}{{label}}-{{entityNumber}}";
+      const result = generateBranchName(
+        template,
+        "fix/",
+        "issue",
+        123,
+        undefined,
+        ":::",
+      );
+
+      expect(result).toBe("fix/issue-123");
+      expect(() => validateBranchName(result)).not.toThrow();
     });
 
     it("should fallback to entityType when label template is used but no label provided", () => {


### PR DESCRIPTION
## Summary

Sanitize GitHub label values before substituting them into `branch_name_template`, so scoped labels like `area:permissions` no longer produce branch names containing `:` that fail `validateBranchName` and abort the action run.

## Motivation

Fixes #1491. Labels are free-form and often scoped with `:` or `/` (e.g. `area:permissions`, `provider:bedrock`). The `{{description}}` variable was already normalized to kebab-case, but `{{label}}` was substituted verbatim. A template like `{{prefix}}{{label}}/{{entityNumber}}` could crash the entire run with `process.exit(1)`.

## Changes

- `src/utils/branch-template.ts`: add shared `sanitizeBranchSegment()` helper; route `extractDescription()` and new `sanitizeLabel()` through it
- `generateBranchName()`: substitute sanitized label, falling back to `entityType` when sanitization yields empty
- `test/branch-template.test.ts`: regression tests for scoped labels, colon-containing labels, and empty-sanitize fallback; assert `validateBranchName` passes

## Tests

- `bun test test/branch-template.test.ts` — pass (23/23)
- `bun test` — pass (772/772)
- `bun run typecheck` — pass
- composer-2.5 review: COMMENT (addressed JSDoc + fallback test)

## Notes

- Intentionally scoped to `{{label}}` only; custom templates with literal punctuation in `{{prefix}}` are unchanged (pre-existing behavior).
- Labels that sanitize to empty (e.g. `:::`) fall back to `entityType`, matching the documented fallback when no label is provided.

Fixes #1491