### PR TITLE
fix(sdk): don't end the run while background subagents are still running (#1499)

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -155,6 +155,11 @@ export async function runClaudeWithSdk(
 
   const messages: SDKMessage[] = [];
   let resultMessage: SDKResultMessage | undefined;
+  // Number of subagent tasks currently running in the background. Subagents
+  // launched via the Agent tool run in the background by default (Claude Code
+  // >= 2.1.198); each `background_tasks_changed` system message reports the
+  // full live set.
+  let liveBackgroundTasks = 0;
 
   try {
     for await (const message of query({ prompt, options: sdkOptions })) {
@@ -165,18 +170,35 @@ export async function runClaudeWithSdk(
         console.log(sanitized);
       }
 
+      if (
+        message.type === "system" &&
+        message.subtype === "background_tasks_changed"
+      ) {
+        liveBackgroundTasks =
+          "tasks" in message && Array.isArray(message.tasks)
+            ? message.tasks.length
+            : 0;
+      }
+
       if (message.type === "result") {
         resultMessage = message as SDKResultMessage;
-        // The SDK's query() iterator should close itself after the
-        // result message, but in some workflow contexts (notably
-        // pull_request-triggered runs) it stays open indefinitely and
-        // the for-await hangs until the workflow's timeout-minutes
-        // kills the job. This causes the action to "succeed" inside
-        // Claude (verdict posted, $cost recorded) but be reported as
-        // cancelled with no execution-output.json written. Break
-        // explicitly: by SDK contract no further messages follow a
-        // result, so the break is safe.
-        break;
+        // The SDK's query() iterator should close itself after the result
+        // message, but in some workflow contexts (notably pull_request-
+        // triggered runs) it stays open indefinitely and the for-await hangs
+        // until the workflow's timeout-minutes kills the job, so we break
+        // explicitly (#1339).
+        //
+        // However, subagents launched via the Agent tool run as background
+        // tasks by default (Claude Code >= 2.1.198). The parent agent's
+        // dispatch turn emits a `result` while those subagents are still
+        // running; breaking on it ends the run and orphans them, so the parent
+        // never gets the follow-up turn(s) to consume their output (#1499).
+        // Only break once no background tasks remain live; the SDK's
+        // async-agent stall watchdog bounds the wait if a subagent never
+        // completes.
+        if (liveBackgroundTasks === 0) {
+          break;
+        }
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
`runClaudeWithSdk` (`base-action/src/run-claude-sdk.ts`) breaks the `query()` loop on the first `result` message — added in #1339 to avoid a `pull_request` hang. But subagents launched via the `Agent` tool run as **background tasks by default** (Claude Code ≥ 2.1.198), so the parent agent's dispatch turn emits a `result` while the subagents are still running. Breaking on it ends the run and orphans them, and the parent never gets the follow-up turn(s) to consume their output. Full write-up in #1499.
This tracks the live background-task set via the `background_tasks_changed` system message and only breaks once no background tasks remain live. The SDK's async-agent stall watchdog bounds the wait if a subagent never completes, so the #1339 anti-hang guard is preserved. With no background subagents (e.g. tag mode) the behavior is unchanged — break on the first result.

Fixes #1499

## Known limitation
This fixes the primary failure (terminating on the first `result` while subagents run). A narrower race can remain: when multiple subagents finish near-simultaneously, the live set can drain to empty while a per-task follow-up turn (the one that consolidates) is still queued, so the loop may break on an interim follow-up `result` before the final turn. Fully closing that likely needs SDK-level knowledge of whether more follow-up turns are pending (discussed in #1499). Happy to iterate if you'd prefer a different approach.
