### PR TITLE
fix(sanitizer): redact GitHub user-to-server (ghu_) tokens

### DIFF
--- a/src/github/utils/sanitizer.ts
+++ b/src/github/utils/sanitizer.ts
@@ -83,6 +83,12 @@ export function redactGitHubTokens(content: string): string {
     "[REDACTED_GITHUB_TOKEN]",
   );
 
+  // GitHub user-to-server tokens: ghu_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX (40 chars)
+  content = content.replace(
+    /\bghu_[A-Za-z0-9]{36}\b/g,
+    "[REDACTED_GITHUB_TOKEN]",
+  );
+
   // GitHub installation tokens: ghs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX (40 chars)
   content = content.replace(
     /\bghs_[A-Za-z0-9]{36}\b/g,

--- a/test/sanitizer.test.ts
+++ b/test/sanitizer.test.ts
@@ -276,6 +276,16 @@ describe("redactGitHubTokens", () => {
     );
   });
 
+  it("should redact user-to-server tokens (ghu_)", () => {
+    const token = "ghu_16C7e42F292c6912E7710c838347Ae178B4a";
+    expect(redactGitHubTokens(`User token: ${token}`)).toBe(
+      "User token: [REDACTED_GITHUB_TOKEN]",
+    );
+    expect(
+      redactGitHubTokens(`In a URL: x-access-token:${token}@github.com`),
+    ).toBe("In a URL: x-access-token:[REDACTED_GITHUB_TOKEN]@github.com");
+  });
+
   it("should redact installation tokens (ghs_)", () => {
     const token = "ghs_xz7yzju2SZjGPa0dUNMAx0SH4xDOCS31LXQW";
     expect(redactGitHubTokens(`Install token: ${token}`)).toBe(


### PR DESCRIPTION
## Summary

`redactGitHubTokens` in `src/github/utils/sanitizer.ts` redacts `ghp_`, `gho_`,
`ghs_`, `ghr_`, and `github_pat_` tokens from GitHub content before it reaches
the prompt, but misses `ghu_` — GitHub App user-to-server tokens, one of the
[documented GitHub token prefixes](https://github.blog/security/behind-githubs-new-authentication-token-formats/).
A `ghu_` token appearing in an issue or PR comment currently passes through
sanitization unredacted.

A broader version of this fix was previously attempted in #1098 but was
abandoned before addressing review feedback. This PR takes the minimal,
uncontroversial slice: just the missing documented GitHub prefix, mirroring
the four existing 40-character patterns exactly, with test coverage (which
#1098 lacked).

## Changes

- Add the `ghu_` pattern to `redactGitHubTokens`, alongside the existing
  `gho_`/`ghs_` patterns.
- Add unit tests: plain occurrence and the `x-access-token:ghu_…@github.com`
  git-credential URL form.

## Testing

- `bun test` — 771 pass, 0 fail
- `bun run typecheck` — clean
- `bun run format:check` — clean
