### PR TITLE
fix(workflows): require trusted author for @claude trigger

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,19 @@ on:
 
 jobs:
   claude:
+    # The trigger-phrase checks below only confirm *what* was said, not *who*
+    # said it. Without an author check, any commenter (including a bot quoting
+    # a prior "@claude" mention back, e.g. in a notification digest) can invoke
+    # this job. Restricting to OWNER/MEMBER/COLLABORATOR and excluding bots
+    # keeps the job from starting at all for untrusted or automated triggers.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.type != 'Bot' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/examples/claude-wif.yml
+++ b/examples/claude-wif.yml
@@ -18,11 +18,19 @@ on:
 
 jobs:
   claude:
+    # The trigger-phrase checks below only confirm *what* was said, not *who*
+    # said it. Without an author check, any commenter (including a bot quoting
+    # a prior "@claude" mention back, e.g. in a notification digest) can invoke
+    # this job. Restricting to OWNER/MEMBER/COLLABORATOR and excluding bots
+    # keeps the job from starting at all for untrusted or automated triggers.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.type != 'Bot' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/examples/claude.yml
+++ b/examples/claude.yml
@@ -12,11 +12,19 @@ on:
 
 jobs:
   claude:
+    # The trigger-phrase checks below only confirm *what* was said, not *who*
+    # said it. Without an author check, any commenter (including a bot quoting
+    # a prior "@claude" mention back, e.g. in a notification digest) can invoke
+    # this job. Restricting to OWNER/MEMBER/COLLABORATOR and excluding bots
+    # keeps the job from starting at all for untrusted or automated triggers.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.type != 'Bot' &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Related to #1481 and #1445. While looking into those, I found the specific
files with the gap they describe: `examples/claude.yml`, `examples/claude-wif.yml`,
and this repo's own `.github/workflows/claude.yml` all gate the `claude` job
purely on trigger-phrase presence (`contains(github.event.comment.body, '@claude')`),
with no check on who authored the comment/review/issue.

Note: I checked `docs/usage.md` and the `/install-github-app` command mentioned
in #1481 — the former doesn't contain a trigger `if:` example, and the latter
lives in the separate `claude-code` CLI repo, so neither was in scope here. I
also confirmed the action's own runtime checks (`checkHumanActor`,
`checkWritePermissions`) already reject bot/non-writer actors before Claude
executes — so this isn't closing an exploit, it's a fail-fast improvement:
the job no longer spins up a runner at all for an untrusted trigger, and the
example templates people copy now demonstrate the safer pattern by default.

## Changes

Add to the `if:` condition in all three files:
- `github.event.sender.type != 'Bot'`
- `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), <event>.author_association)`
  per event type (comment/review/issue), matching the field each event
  actually populates

## Testing

- YAML syntax validated for all three files
- `bun test` — 770 pass, 0 fail (no test changes needed; these are workflow configs)
- `bun run typecheck` / `bun run format:check` — clean