### PR TITLE
feat(comment): show cost alongside duration in Claude's tracking comment

### DIFF
--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -109,6 +109,12 @@ export function updateCommentBody(input: CommentUpdateInput): string {
     durationStr = minutes > 0 ? `${minutes}m ${seconds}s` : `${seconds}s`;
   }
 
+  // Calculate cost string if available
+  let costStr = "";
+  if (executionDetails?.total_cost_usd !== undefined) {
+    costStr = `$${executionDetails.total_cost_usd.toFixed(4)}`;
+  }
+
   // Build the header
   let header = "";
 
@@ -116,6 +122,9 @@ export function updateCommentBody(input: CommentUpdateInput): string {
     header = "**Claude encountered an error";
     if (durationStr) {
       header += ` after ${durationStr}`;
+    }
+    if (costStr) {
+      header += ` (${costStr})`;
     }
     header += "**";
   } else {
@@ -127,6 +136,9 @@ export function updateCommentBody(input: CommentUpdateInput): string {
     header = `**Claude finished @${username}'s task`;
     if (durationStr) {
       header += ` in ${durationStr}`;
+    }
+    if (costStr) {
+      header += ` (${costStr})`;
     }
     header += "**";
   }

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -254,7 +254,7 @@ describe("updateCommentBody", () => {
   });
 
   describe("execution details", () => {
-    it("includes duration in header for success", () => {
+    it("includes duration and cost in header for success", () => {
       const input = {
         ...baseInput,
         executionDetails: {
@@ -266,7 +266,9 @@ describe("updateCommentBody", () => {
       };
 
       const result = updateCommentBody(input);
-      expect(result).toContain("**Claude finished @testuser's task in 31s**");
+      expect(result).toContain(
+        "**Claude finished @testuser's task in 31s ($0.1338)**",
+      );
     });
 
     it("formats duration in minutes and seconds in header", () => {
@@ -284,20 +286,23 @@ describe("updateCommentBody", () => {
       );
     });
 
-    it("includes duration in error header", () => {
+    it("includes duration and cost in error header", () => {
       const input = {
         ...baseInput,
         actionFailed: true,
         executionDetails: {
+          total_cost_usd: 0.005,
           duration_ms: 45000, // 45 seconds
         },
       };
 
       const result = updateCommentBody(input);
-      expect(result).toContain("**Claude encountered an error after 45s**");
+      expect(result).toContain(
+        "**Claude encountered an error after 45s ($0.0050)**",
+      );
     });
 
-    it("handles missing duration gracefully", () => {
+    it("handles missing duration gracefully by showing cost only", () => {
       const input = {
         ...baseInput,
         executionDetails: {
@@ -307,8 +312,24 @@ describe("updateCommentBody", () => {
       };
 
       const result = updateCommentBody(input);
-      expect(result).toContain("**Claude finished @testuser's task**");
+      expect(result).toContain(
+        "**Claude finished @testuser's task ($0.2500)**",
+      );
       expect(result).not.toContain(" in ");
+    });
+
+    it("handles missing cost gracefully by showing duration only", () => {
+      const input = {
+        ...baseInput,
+        executionDetails: {
+          duration_ms: 31000,
+        },
+        triggerUsername: "testuser",
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).toContain("**Claude finished @testuser's task in 31s**");
+      expect(result).not.toContain("$");
     });
   });
 
@@ -332,7 +353,7 @@ describe("updateCommentBody", () => {
 
       // Check the header structure
       expect(result).toContain(
-        "**Claude finished @trigger-user's task in 1m 5s**",
+        "**Claude finished @trigger-user's task in 1m 5s ($0.0100)**",
       );
       expect(result).toContain("—— [View job]");
       expect(result).toContain(


### PR DESCRIPTION
## Summary
Adds the run's cost next to its duration in Claude's tracking comment on issues/PRs, e.g.:

> **Claude finished @user's task in 31s ($0.1234)**

## Why
`total_cost_usd` is already computed for every run and read into `executionDetails` in `update-comment-link.ts` — it just isn't rendered where people actually look. The tracking comment shows duration but not cost; cost only appears in the Actions Step Summary, which most people reading a PR/issue never open. Surfacing it in the comment makes cost visible to everyone in the loop, and brings the comment to parity with the Step Summary (`format-turns.ts`), which already displays it. This directly answers #59 ("Is there a way to make claude report the cost after a run?"), and speaks to the same cost-visibility need behind #1482.

## Changes
- `src/github/operations/comment-logic.ts`: compute `costStr` from `executionDetails.total_cost_usd` (same `$X.XXXX` formatting already used in the Step Summary) and append it in parentheses after the duration, in both the success and error headers.
- `test/comment-logic.test.ts`: cover duration-only, cost-only, and combined duration+cost cases for both success and error headers.

## Notes
Cost is shown unconditionally (no opt-in flag), matching how duration is already handled and keeping the diff minimal. The number is already visible in the Step Summary on public repos, so this doesn't expose anything new — happy to gate it behind an input if you'd prefer that.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test test/comment-logic.test.ts` — 26 pass
- [x] `bun run format:check`
- [x] Full `bun test` suite — no new failures (2 pre-existing failures in `install-pipefail.test.ts` are network-dependent and unrelated to this change)

Closes #59
Related: #1482