### PR TITLE
Surface actionable auth-failure message in step and tracking comment

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -237,7 +237,19 @@ export async function runClaudeWithSdk(
   }
 
   if (!isSuccess) {
-    if (resultMessage.subtype === "success" && resultMessage.is_error) {
+    // 401/403 means the API rejected the run's credentials, typically an
+    // expired or revoked OAuth token / API key.
+    const apiErrorStatus =
+      "api_error_status" in resultMessage
+        ? resultMessage.api_error_status
+        : null;
+    const authFailureReason =
+      apiErrorStatus === 401 || apiErrorStatus === 403
+        ? `authentication failed (API returned ${apiErrorStatus}). If you use \`claude_code_oauth_token\`, regenerate it with \`claude setup-token\`; if you use \`anthropic_api_key\`, verify the key is valid`
+        : null;
+    if (authFailureReason) {
+      core.error(`Execution failed: ${authFailureReason}`);
+    } else if (resultMessage.subtype === "success" && resultMessage.is_error) {
       core.error(
         "Claude result reported subtype success with is_error:true (run did not complete successfully)",
       );
@@ -247,11 +259,12 @@ export async function runClaudeWithSdk(
     }
     throw new Error(
       `Claude execution failed: ${
-        resultMessage.subtype === "success" && resultMessage.is_error
+        authFailureReason ??
+        (resultMessage.subtype === "success" && resultMessage.is_error
           ? "result is_error:true"
           : "errors" in resultMessage && resultMessage.errors
             ? resultMessage.errors.join(", ")
-            : "unknown error"
+            : "unknown error")
       }`,
     );
   }

--- a/base-action/test/run-claude-sdk.test.ts
+++ b/base-action/test/run-claude-sdk.test.ts
@@ -128,4 +128,66 @@ describe("runClaudeWithSdk", () => {
       coreErrorSpy.mockRestore();
     }
   });
+
+  test("fails with actionable auth guidance when api_error_status is 401", async () => {
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => {},
+    );
+    const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+    const coreErrorSpy = spyOn(
+      await import("@actions/core"),
+      "error",
+    ).mockImplementation(() => {});
+
+    tempDir = await mkdtemp(join(tmpdir(), "claude-sdk-"));
+    process.env.RUNNER_TEMP = tempDir;
+
+    const promptPath = join(tempDir, "prompt.txt");
+    await writeFile(promptPath, "test prompt");
+
+    const initMessage = {
+      type: "system",
+      subtype: "init",
+      session_id: "session-123",
+      model: "claude-sonnet-5",
+    };
+
+    const authErrorResultMessage = {
+      type: "result",
+      subtype: "success",
+      is_error: true,
+      api_error_status: 401,
+      duration_ms: 2013,
+      num_turns: 1,
+      total_cost_usd: 0,
+      permission_denials: [],
+    };
+
+    mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+      query: async function* () {
+        yield initMessage;
+        yield authErrorResultMessage;
+      },
+    }));
+
+    try {
+      const { runClaudeWithSdk } = await import("../src/run-claude-sdk");
+
+      await expect(
+        runClaudeWithSdk(promptPath, {
+          sdkOptions: {},
+          showFullOutput: false,
+          hasJsonSchema: false,
+        }),
+      ).rejects.toThrow("authentication failed (API returned 401)");
+
+      expect(coreErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("regenerate it with `claude setup-token`"),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      consoleLogSpy.mockRestore();
+      coreErrorSpy.mockRestore();
+    }
+  });
 });

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -154,6 +154,7 @@ async function run() {
   let claudeSuccess = false;
   let prepareSuccess = true;
   let prepareError: string | undefined;
+  let executionError: string | undefined;
   let context: GitHubContext | undefined;
   let octokit: Octokits | undefined;
   let workloadIdentity: WorkloadIdentityHandle | undefined;
@@ -313,6 +314,8 @@ async function run() {
     if (!prepareCompleted) {
       prepareSuccess = false;
       prepareError = errorMessage;
+    } else {
+      executionError = errorMessage;
     }
     core.setFailed(`Action failed with error: ${errorMessage}`);
   } finally {
@@ -342,6 +345,7 @@ async function run() {
           outputFile: executionFile,
           prepareSuccess,
           prepareError,
+          executionError,
           useCommitSigning: context.inputs.useCommitSigning,
         });
       } catch (error) {

--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -29,6 +29,7 @@ export type UpdateCommentLinkParams = {
   outputFile?: string;
   prepareSuccess: boolean;
   prepareError?: string;
+  executionError?: string;
   useCommitSigning: boolean;
 };
 
@@ -201,6 +202,9 @@ export async function updateCommentLink(
     } catch (error) {
       console.error("Error reading output file:", error);
       actionFailed = !params.claudeSuccess;
+    }
+    if (actionFailed && params.executionError) {
+      errorDetails = params.executionError;
     }
   }
 


### PR DESCRIPTION
Fixes #1501

When the API rejects the run's credentials (expired/revoked `claude_code_oauth_token` or invalid `anthropic_api_key`), the failure was generic and the tracking comment gave no cause, so an expired token surfaced as an unexplained ~2s failure. #1496 already makes such runs fail the step; this PR adds the cause and the fix instructions.

## Changes

- `base-action/src/run-claude-sdk.ts`: on a failed result, check `api_error_status`; for 401/403 the error is now "authentication failed (API returned 401). If you use `claude_code_oauth_token`, regenerate it with `claude setup-token`; …" instead of the generic message
- `src/entrypoints/run.ts`, `src/entrypoints/update-comment-link.ts`: surface the execution-phase error message in the tracking comment, the same way prepare-phase errors already are
- regression test for the 401 case

## Verification

New test fails on the previous code and passes with the fix. `bun test` 771/771, `bun run typecheck` and `bun run format:check` clean.
