### PR TITLE
docs: fix dead example links in custom-automations.md

### DIFF
--- a/docs/custom-automations.md
+++ b/docs/custom-automations.md
@@ -26,7 +26,7 @@ This action supports the following GitHub events ([learn more GitHub event trigg
 
 ## Automated Documentation Updates
 
-Automatically update documentation when specific files change (see [`examples/claude-pr-path-specific.yml`](../examples/claude-pr-path-specific.yml)):
+Automatically update documentation when specific files change (see [`examples/pr-review-filtered-paths.yml`](../examples/pr-review-filtered-paths.yml)):
 
 ```yaml
 on:
@@ -47,7 +47,7 @@ When API files are modified, the action automatically detects that a `prompt` is
 
 ## Author-Specific Code Reviews
 
-Automatically review PRs from specific authors or external contributors (see [`examples/claude-review-from-author.yml`](../examples/claude-review-from-author.yml)):
+Automatically review PRs from specific authors or external contributors (see [`examples/pr-review-filtered-authors.yml`](../examples/pr-review-filtered-authors.yml)):
 
 ```yaml
 on:


### PR DESCRIPTION
## Summary

`docs/custom-automations.md` links to two example workflows that no longer exist:

- `examples/claude-pr-path-specific.yml` (line 29)
- `examples/claude-review-from-author.yml` (line 50)

Both files were renamed in #505 (`3ed1448`) to `pr-review-filtered-paths.yml` and `pr-review-filtered-authors.yml`, but the doc links were not updated, so both render as 404s on GitHub. This PR points the links (text and target) at the current filenames.

## Verification

- `examples/pr-review-filtered-paths.yml` ("Claude Review - Path Specific") and `examples/pr-review-filtered-authors.yml` ("Claude Review - Specific Authors") exist on `main` and match the sections that reference them.
- Scanned all relative links under `docs/` — these two were the only ones pointing at missing files.
- `bun test` (771 pass), `bun run typecheck`, and `bun run format:check` are green.
