### PR TITLE
fix: support ANTHROPIC_AUTH_TOKEN as standalone auth method

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -322,6 +322,7 @@ runs:
 
         # Provider configuration
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key || env.ANTHROPIC_API_KEY }}
+        ANTHROPIC_AUTH_TOKEN: ${{ env.ANTHROPIC_AUTH_TOKEN }}
         CLAUDE_CODE_OAUTH_TOKEN: ${{ inputs.claude_code_oauth_token || env.CLAUDE_CODE_OAUTH_TOKEN }}
         ANTHROPIC_FEDERATION_RULE_ID: ${{ inputs.anthropic_federation_rule_id }}
         ANTHROPIC_ORGANIZATION_ID: ${{ inputs.anthropic_organization_id }}

--- a/base-action/src/validate-env.ts
+++ b/base-action/src/validate-env.ts
@@ -7,6 +7,7 @@ export function validateEnvironmentVariables() {
   const useVertex = process.env.CLAUDE_CODE_USE_VERTEX === "1";
   const useFoundry = process.env.CLAUDE_CODE_USE_FOUNDRY === "1";
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY;
+  const anthropicAuthToken = process.env.ANTHROPIC_AUTH_TOKEN;
   const claudeCodeOAuthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
   const federationRuleId = process.env.ANTHROPIC_FEDERATION_RULE_ID;
   const federationOrganizationId = process.env.ANTHROPIC_ORGANIZATION_ID;
@@ -28,14 +29,14 @@ export function validateEnvironmentVariables() {
   }
 
   if (!useBedrock && !useVertex && !useFoundry) {
-    if (!anthropicApiKey && !claudeCodeOAuthToken && !hasWorkloadIdentity) {
+    if (!anthropicApiKey && !anthropicAuthToken && !claudeCodeOAuthToken && !hasWorkloadIdentity) {
       if (hasPartialWorkloadIdentity) {
         errors.push(
           "Workload identity federation requires both ANTHROPIC_FEDERATION_RULE_ID and ANTHROPIC_ORGANIZATION_ID to be set.",
         );
       } else {
         errors.push(
-          "Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or workload identity federation (ANTHROPIC_FEDERATION_RULE_ID and ANTHROPIC_ORGANIZATION_ID) is required when using direct Anthropic API.",
+          "Either ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, CLAUDE_CODE_OAUTH_TOKEN, or workload identity federation (ANTHROPIC_FEDERATION_RULE_ID and ANTHROPIC_ORGANIZATION_ID) is required when using direct Anthropic API.",
         );
       }
     }

--- a/base-action/test/validate-env.test.ts
+++ b/base-action/test/validate-env.test.ts
@@ -11,6 +11,7 @@ describe("validateEnvironmentVariables", () => {
     originalEnv = { ...process.env };
     // Clear relevant environment variables
     delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
     delete process.env.ANTHROPIC_FEDERATION_RULE_ID;
     delete process.env.ANTHROPIC_ORGANIZATION_ID;
     delete process.env.CLAUDE_CODE_USE_BEDROCK;
@@ -42,9 +43,15 @@ describe("validateEnvironmentVariables", () => {
       expect(() => validateEnvironmentVariables()).not.toThrow();
     });
 
+    test("should pass when ANTHROPIC_AUTH_TOKEN is provided", () => {
+      process.env.ANTHROPIC_AUTH_TOKEN = "test-auth-token";
+
+      expect(() => validateEnvironmentVariables()).not.toThrow();
+    });
+
     test("should fail when ANTHROPIC_API_KEY is missing", () => {
       expect(() => validateEnvironmentVariables()).toThrow(
-        "Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or workload identity federation (ANTHROPIC_FEDERATION_RULE_ID and ANTHROPIC_ORGANIZATION_ID) is required when using direct Anthropic API.",
+        "Either ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, CLAUDE_CODE_OAUTH_TOKEN, or workload identity federation (ANTHROPIC_FEDERATION_RULE_ID and ANTHROPIC_ORGANIZATION_ID) is required when using direct Anthropic API.",
       );
     });
 


### PR DESCRIPTION
The GitHub Action previously rejected `AUTH_TOKEN` as a valid authentication method, requiring users to set `API_KEY` or `CODE_OAUTH_TOKEN` even when using custom gateways that authenticate via `Authorization: Bearer` headers. This is inconsistent with the Code CLI, which supports `AUTH_TOKEN` out of the box.

The validation logic in `base-action/src/validate-env.ts` now recognizes `AUTH_TOKEN` as a valid authentication method alongside `API_KEY`, `CODE_OAUTH_TOKEN`, and workload identity federation. The `action.yml` file has been updated to forward `AUTH_TOKEN` from the job environment to the CLI subprocess, matching the behavior of other authentication environment variables.

Users can now authenticate with custom providers using only `AUTH_TOKEN` and `BASE_URL` without workarounds.

Fixes #1294