### PR TITLE
feat: expose subscription rate-limit snapshots via rate_limits output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -182,6 +182,9 @@ outputs:
   session_id:
     description: "The Claude Code session ID that can be used with --resume to continue this conversation"
     value: ${{ steps.run.outputs.session_id }}
+  rate_limits:
+    description: "JSON string with the latest subscription rate-limit snapshot per window (keyed by window type, e.g. five_hour/seven_day), as reported by Claude Code during the run. Only set for claude.ai subscription (OAuth) authentication; unset for API key, Bedrock, and Vertex runs."
+    value: ${{ steps.run.outputs.rate_limits }}
 
 runs:
   using: "composite"

--- a/base-action/README.md
+++ b/base-action/README.md
@@ -147,12 +147,13 @@ Do not set `anthropic_api_key` or `claude_code_oauth_token` alongside the federa
 
 ## Outputs
 
-| Output              | Description                                                                                       |
-| ------------------- | ------------------------------------------------------------------------------------------------- |
-| `conclusion`        | Execution status of Claude Code ('success' or 'failure')                                          |
-| `execution_file`    | Path to the JSON file containing Claude Code execution log                                        |
-| `structured_output` | JSON string containing structured output fields when `--json-schema` is provided in `claude_args` |
-| `session_id`        | The Claude Code session ID that can be used with `--resume` to continue this conversation         |
+| Output              | Description                                                                                                                                                                                                          |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `conclusion`        | Execution status of Claude Code ('success' or 'failure')                                                                                                                                                             |
+| `execution_file`    | Path to the JSON file containing Claude Code execution log                                                                                                                                                           |
+| `structured_output` | JSON string containing structured output fields when `--json-schema` is provided in `claude_args`                                                                                                                    |
+| `session_id`        | The Claude Code session ID that can be used with `--resume` to continue this conversation                                                                                                                            |
+| `rate_limits`       | JSON string with the latest subscription rate-limit snapshot per window (e.g. `five_hour`, `seven_day`), including `status`, `utilization` (0-100), and `resetsAt`. Only set for claude.ai subscription (OAuth) runs |
 
 ## Environment Variables
 

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -105,6 +105,9 @@ outputs:
   session_id:
     description: "The Claude Code session ID that can be used with --resume to continue this conversation"
     value: ${{ steps.run_claude.outputs.session_id }}
+  rate_limits:
+    description: "JSON string with the latest subscription rate-limit snapshot per window (keyed by window type, e.g. five_hour/seven_day), as reported by Claude Code during the run. Only set for claude.ai subscription (OAuth) authentication; unset for API key, Bedrock, and Vertex runs."
+    value: ${{ steps.run_claude.outputs.rate_limits }}
 
 runs:
   using: "composite"

--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "path";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import type {
   SDKMessage,
+  SDKRateLimitInfo,
   SDKResultMessage,
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
@@ -130,6 +131,24 @@ function sanitizeSdkOutput(
 }
 
 /**
+ * Publishes the latest subscription rate-limit snapshot per window as the
+ * `rate_limits` output. `rate_limit_event` messages are only emitted for
+ * claude.ai subscription authentication (OAuth); API key, Bedrock, and Vertex
+ * runs produce none, in which case the output is left unset. Set even when
+ * the run fails, since hitting a rate limit is itself a common failure cause.
+ */
+function setRateLimitsOutput(
+  rateLimitsByWindow: Record<string, SDKRateLimitInfo>,
+): void {
+  const windows = Object.keys(rateLimitsByWindow);
+  if (windows.length === 0) {
+    return;
+  }
+  core.setOutput("rate_limits", JSON.stringify(rateLimitsByWindow));
+  core.info(`Set rate_limits with window(s): ${windows.join(", ")}`);
+}
+
+/**
  * Run Claude using the Agent SDK
  */
 export async function runClaudeWithSdk(
@@ -155,10 +174,17 @@ export async function runClaudeWithSdk(
 
   const messages: SDKMessage[] = [];
   let resultMessage: SDKResultMessage | undefined;
+  const rateLimitsByWindow: Record<string, SDKRateLimitInfo> = {};
 
   try {
     for await (const message of query({ prompt, options: sdkOptions })) {
       messages.push(message);
+
+      if (message.type === "rate_limit_event") {
+        // Keep the latest snapshot per window type (five_hour, seven_day, ...)
+        rateLimitsByWindow[message.rate_limit_info.rateLimitType ?? "unknown"] =
+          message.rate_limit_info;
+      }
 
       const sanitized = sanitizeSdkOutput(message, showFullOutput);
       if (sanitized) {
@@ -181,9 +207,12 @@ export async function runClaudeWithSdk(
     }
   } catch (error) {
     console.error("SDK execution error:", error);
+    setRateLimitsOutput(rateLimitsByWindow);
     await writeExecutionFile(messages);
     throw new Error(`SDK execution error: ${error}`);
   }
+
+  setRateLimitsOutput(rateLimitsByWindow);
 
   const result: ClaudeRunResult = {
     conclusion: "failure",

--- a/base-action/test/run-claude-sdk.test.ts
+++ b/base-action/test/run-claude-sdk.test.ts
@@ -128,4 +128,135 @@ describe("runClaudeWithSdk", () => {
       coreErrorSpy.mockRestore();
     }
   });
+
+  test("sets rate_limits output from rate_limit_event messages, keeping the latest snapshot per window", async () => {
+    const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+    const coreSetOutputSpy = spyOn(
+      await import("@actions/core"),
+      "setOutput",
+    ).mockImplementation(() => {});
+
+    tempDir = await mkdtemp(join(tmpdir(), "claude-sdk-"));
+    process.env.RUNNER_TEMP = tempDir;
+
+    const promptPath = join(tempDir, "prompt.txt");
+    await writeFile(promptPath, "test prompt");
+
+    const staleFiveHourInfo = {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 23,
+      resetsAt: 1752684000,
+    };
+    const latestFiveHourInfo = {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 25,
+      resetsAt: 1752684000,
+    };
+    const sevenDayInfo = {
+      status: "allowed_warning",
+      rateLimitType: "seven_day",
+      utilization: 91,
+      resetsAt: 1753029000,
+    };
+
+    mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+      query: async function* () {
+        yield {
+          type: "system",
+          subtype: "init",
+          session_id: "session-123",
+          model: "claude-sonnet-5",
+        };
+        yield { type: "rate_limit_event", rate_limit_info: staleFiveHourInfo };
+        yield { type: "rate_limit_event", rate_limit_info: sevenDayInfo };
+        yield { type: "rate_limit_event", rate_limit_info: latestFiveHourInfo };
+        yield {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          duration_ms: 434,
+          num_turns: 1,
+          total_cost_usd: 0,
+          permission_denials: [],
+        };
+      },
+    }));
+
+    try {
+      const { runClaudeWithSdk } = await import("../src/run-claude-sdk");
+
+      const result = await runClaudeWithSdk(promptPath, {
+        sdkOptions: {},
+        showFullOutput: false,
+        hasJsonSchema: false,
+      });
+
+      expect(result.conclusion).toBe("success");
+      expect(coreSetOutputSpy).toHaveBeenCalledWith(
+        "rate_limits",
+        JSON.stringify({
+          five_hour: latestFiveHourInfo,
+          seven_day: sevenDayInfo,
+        }),
+      );
+    } finally {
+      consoleLogSpy.mockRestore();
+      coreSetOutputSpy.mockRestore();
+    }
+  });
+
+  test("does not set rate_limits output when no rate_limit_event is received", async () => {
+    const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+    const coreSetOutputSpy = spyOn(
+      await import("@actions/core"),
+      "setOutput",
+    ).mockImplementation(() => {});
+
+    tempDir = await mkdtemp(join(tmpdir(), "claude-sdk-"));
+    process.env.RUNNER_TEMP = tempDir;
+
+    const promptPath = join(tempDir, "prompt.txt");
+    await writeFile(promptPath, "test prompt");
+
+    mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+      query: async function* () {
+        yield {
+          type: "system",
+          subtype: "init",
+          session_id: "session-123",
+          model: "claude-sonnet-5",
+        };
+        yield {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          duration_ms: 434,
+          num_turns: 1,
+          total_cost_usd: 0,
+          permission_denials: [],
+        };
+      },
+    }));
+
+    try {
+      const { runClaudeWithSdk } = await import("../src/run-claude-sdk");
+
+      const result = await runClaudeWithSdk(promptPath, {
+        sdkOptions: {},
+        showFullOutput: false,
+        hasJsonSchema: false,
+      });
+
+      expect(result.conclusion).toBe("success");
+      const rateLimitCalls = coreSetOutputSpy.mock.calls.filter(
+        ([name]) => name === "rate_limits",
+      );
+      expect(rateLimitCalls).toHaveLength(0);
+    } finally {
+      consoleLogSpy.mockRestore();
+      coreSetOutputSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
Closes #1518

## What

When Claude Code runs with claude.ai subscription (OAuth) authentication, the SDK stream emits `rate_limit_event` messages carrying the subscription window state (`status`, `utilization` 0-100, `resetsAt`, window type). This PR captures the latest snapshot per window during the existing message loop and exposes it as a new `rate_limits` action output (JSON, keyed by window type), on both the main action and the standalone base-action.

This lets workflows that bill to a Pro/Max subscription report how full the 5-hour and weekly windows are (the same numbers the `/usage` panel shows) and alert before reviews start failing with 429s — see #1518 for the paths that don't work today (statusline hooks never fire in SDK mode, `GET /api/oauth/usage` is unreliable, response headers are unobservable from inside the action).

## Example

```yaml
- uses: anthropics/claude-code-action@v1
  id: review
  with:
    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
    prompt: "..."

- name: Report subscription usage
  if: always()
  run: echo '${{ steps.review.outputs.rate_limits }}' | jq .
```

Output value:

```json
{
  "five_hour": { "status": "allowed", "rateLimitType": "five_hour", "utilization": 25, "resetsAt": 1752684000 },
  "seven_day": { "status": "allowed_warning", "rateLimitType": "seven_day", "utilization": 91, "resetsAt": 1753029000 }
}
```

## Design notes

- **Only stable SDK surfaces are used** — `rate_limit_event` is part of the `SDKMessage` union that the run loop already iterates. The experimental usage control API (`usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET`) was deliberately avoided.
- **The output is set even when the run fails**, since hitting a rate limit is itself a common failure cause and that's when the data matters most. This mirrors how the execution file is written on the error path.
- **Unset for API key / Bedrock / Vertex runs** — no `rate_limit_event` messages are emitted there, mirroring the SDK's own semantics (`rate_limits_available: false`).
- Setting the output inside `run-claude-sdk.ts` (same pattern as `execution-file.ts`) covers both entrypoints — `src/entrypoints/run.ts` and the standalone base-action — without duplicating logic.
- Snapshot objects are passed through as reported by the SDK (no field renaming), keyed by `rateLimitType` with latest-wins semantics when multiple events arrive for the same window.

## Testing

- Two new unit tests in `base-action/test/run-claude-sdk.test.ts`: latest-snapshot-per-window capture across multiple events, and no `rate_limits` output when no events are received.
- `bun test`: 801 pass (root) + 154 pass (base-action), 0 fail.
- `bun run typecheck` clean in both packages; `bun run format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
