### PR TITLE
fix: convert --json-schema from extraArgs to native SDK outputFormat

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -333,6 +333,20 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
       : ["user", "project", "local"],
   };
 
+  // Convert --json-schema to native outputFormat (instead of CLI pass-through
+  // via extraArgs, which crashes on Vertex AI)
+  if (hasJsonSchema && extraArgs["json-schema"]) {
+    try {
+      sdkOptions.outputFormat = {
+        type: "json_schema" as const,
+        schema: JSON.parse(extraArgs["json-schema"]),
+      };
+    } catch (e) {
+      console.warn(`Failed to parse --json-schema value as JSON: ${e}`);
+    }
+    delete extraArgs["json-schema"];
+  }
+
   // Remove setting-sources from extraArgs to avoid passing it twice
   delete extraArgs["setting-sources"];
 

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -206,7 +206,13 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
       `[json-schema debug] raw claudeArgs (last 80): ...${raw.slice(-80)}`,
     );
     console.log(
-      `[json-schema debug] parsed extraArgs["json-schema"] (first 80): ${val.slice(0, 80)}...`,
+      `[json-schema debug] parsed value length: ${val.length}`,
+    );
+    console.log(
+      `[json-schema debug] parsed value (first 80): ${val.slice(0, 80)}...`,
+    );
+    console.log(
+      `[json-schema debug] parsed value (last 80): ...${val.slice(-80)}`,
     );
   }
 

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -198,6 +198,18 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   // Parse claudeArgs into extraArgs for CLI pass-through
   const extraArgs = parseClaudeArgsToExtraArgs(options.claudeArgs);
 
+  // DEBUG: trace json-schema through shell-quote parsing
+  if ("json-schema" in extraArgs) {
+    const raw = options.claudeArgs ?? "";
+    const val = extraArgs["json-schema"] ?? "";
+    console.log(
+      `[json-schema debug] raw claudeArgs (last 80): ...${raw.slice(-80)}`,
+    );
+    console.log(
+      `[json-schema debug] parsed extraArgs["json-schema"] (first 80): ${val.slice(0, 80)}...`,
+    );
+  }
+
   // Detect if --json-schema is present (for hasJsonSchema flag)
   const hasJsonSchema = "json-schema" in extraArgs;
 

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -444,17 +444,50 @@ describe("parseSdkOptions", () => {
     });
   });
 
-  describe("other extraArgs passthrough", () => {
-    test("should pass through json-schema in extraArgs", () => {
+  describe("json-schema to outputFormat conversion", () => {
+    test("should convert json-schema to outputFormat instead of extraArgs", () => {
+      const schema = {
+        type: "object",
+        properties: { name: { type: "string" } },
+        required: ["name"],
+      };
+      const options: ClaudeOptions = {
+        claudeArgs: `--json-schema '${JSON.stringify(schema)}'`,
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.outputFormat).toEqual({
+        type: "json_schema",
+        schema,
+      });
+      expect(result.sdkOptions.extraArgs?.["json-schema"]).toBeUndefined();
+      expect(result.hasJsonSchema).toBe(true);
+    });
+
+    test("should set hasJsonSchema true even after converting to outputFormat", () => {
       const options: ClaudeOptions = {
         claudeArgs: `--json-schema '{"type":"object"}'`,
       };
 
       const result = parseSdkOptions(options);
 
-      expect(result.sdkOptions.extraArgs?.["json-schema"]).toBe(
-        '{"type":"object"}',
-      );
+      expect(result.hasJsonSchema).toBe(true);
+      expect(result.sdkOptions.outputFormat).toEqual({
+        type: "json_schema",
+        schema: { type: "object" },
+      });
+    });
+
+    test("should leave json-schema in extraArgs when JSON parsing fails", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: `--json-schema 'not-valid-json'`,
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.outputFormat).toBeUndefined();
+      expect(result.sdkOptions.extraArgs?.["json-schema"]).toBeUndefined();
       expect(result.hasJsonSchema).toBe(true);
     });
   });


### PR DESCRIPTION
extraArgs passes --json-schema as a CLI flag to the subprocess, which crashes on Vertex AI. The SDK has a native outputFormat option that maps to the API's output_config.format and works correctly. This follows the same extraction pattern used for allowedTools, model, and add-dir.
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>