### PR TITLE
fix(sdk): make --permission-mode in claude_args take effect

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -259,6 +259,24 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   delete extraArgs["disallowedTools"];
   delete extraArgs["disallowed-tools"];
 
+  // Extract --permission-mode into the SDK's first-class permissionMode option.
+  // Left in extraArgs, the flag still reaches the CLI argv, but the CLI
+  // silently downgrades bypassPermissions to "default" unless the session is
+  // launched with the --allow-dangerously-skip-permissions interlock — which
+  // only the SDK's allowDangerouslySkipPermissions option emits. Passing the
+  // mode as a first-class option (with the companion option for
+  // bypassPermissions, mirroring how the CLI itself delegates sessions) makes
+  // the documented flag actually take effect in headless runs. Note this grants
+  // no new capability: --allow-dangerously-skip-permissions was already
+  // reachable via claude_args pass-through; the bug was that the natural
+  // spelling silently no-opped.
+  const permissionModeValue = extraArgs["permission-mode"];
+  const permissionMode =
+    typeof permissionModeValue === "string" && permissionModeValue.length > 0
+      ? (permissionModeValue as SdkOptions["permissionMode"])
+      : undefined;
+  delete extraArgs["permission-mode"];
+
   // Merge multiple --mcp-config values by combining their mcpServers objects
   // The action prepends its config (github_comment, github_ci, etc.) as inline JSON,
   // and users may provide their own config as inline JSON or file path
@@ -311,6 +329,10 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
     disallowedTools:
       mergedDisallowedTools.length > 0 ? mergedDisallowedTools : undefined,
     systemPrompt,
+    permissionMode,
+    ...(permissionMode === "bypassPermissions" && {
+      allowDangerouslySkipPermissions: true,
+    }),
     fallbackModel: options.fallbackModel,
     pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
     additionalDirectories:

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -565,4 +565,72 @@ describe("parseSdkOptions", () => {
       }
     });
   });
+
+  describe("permission mode extraction", () => {
+    // Regression tests for #1512: --permission-mode passed via claude_args was
+    // forwarded through extraArgs onto the CLI argv, but the CLI silently
+    // downgrades bypassPermissions to "default" unless the session is launched
+    // with the --allow-dangerously-skip-permissions interlock, which only the
+    // SDK's first-class options emit.
+    test("should extract --permission-mode bypassPermissions into first-class SDK options with the safety companion", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--permission-mode bypassPermissions",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.permissionMode).toBe("bypassPermissions");
+      expect(result.sdkOptions.allowDangerouslySkipPermissions).toBe(true);
+      expect(result.sdkOptions.extraArgs?.["permission-mode"]).toBeUndefined();
+    });
+
+    test("should extract non-bypass modes without the safety companion", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--permission-mode acceptEdits",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.permissionMode).toBe("acceptEdits");
+      expect(result.sdkOptions.allowDangerouslySkipPermissions).toBeUndefined();
+      expect(result.sdkOptions.extraArgs?.["permission-mode"]).toBeUndefined();
+    });
+
+    test("should let a later user-provided mode override tag mode's built-in acceptEdits", () => {
+      // Tag mode prepends its own --permission-mode acceptEdits before the
+      // user's claude_args; the last occurrence must win.
+      const options: ClaudeOptions = {
+        claudeArgs:
+          "--permission-mode acceptEdits --allowedTools Edit --permission-mode bypassPermissions",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.permissionMode).toBe("bypassPermissions");
+      expect(result.sdkOptions.allowDangerouslySkipPermissions).toBe(true);
+    });
+
+    test("should leave permissionMode undefined when no --permission-mode is passed", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--max-turns 5",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.permissionMode).toBeUndefined();
+      expect(result.sdkOptions.allowDangerouslySkipPermissions).toBeUndefined();
+    });
+
+    test("should ignore a bare --permission-mode flag with no value", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--permission-mode",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.permissionMode).toBeUndefined();
+      expect(result.sdkOptions.allowDangerouslySkipPermissions).toBeUndefined();
+      expect(result.sdkOptions.extraArgs?.["permission-mode"]).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1512. `--permission-mode bypassPermissions` passed via `claude_args` is
silently ignored: the session initializes with `permissionMode: "default"`, every
tool call outside allow-rules is auto-denied, and the run still reports
`subtype: success` — so headless automation workflows fail invisibly.

## Root cause

`parseSdkOptions` forwards unrecognized flags through `extraArgs`, so
`--permission-mode` **does** reach the spawned CLI's argv. But the CLI
downgrades `bypassPermissions` to `default` unless the session is launched with
the `--allow-dangerously-skip-permissions` interlock — and only the SDK's
first-class `allowDangerouslySkipPermissions` option emits that flag. The CLI's
downgrade warning ("Permission mode downgraded to default — bypass requires
accepting the disclaimer…") is invisible in headless runs unless
`show_full_output: true`.

## Fix

Extract `--permission-mode` from `extraArgs` into the SDK's first-class
`permissionMode` option, and set `allowDangerouslySkipPermissions: true` when
the mode is `bypassPermissions` — the same pairing the CLI itself uses when it
delegates sessions internally. Non-bypass modes (`acceptEdits`, `plan`,
`dontAsk`) are extracted without the companion. Last occurrence still wins, so
a user's `claude_args` value overrides tag mode's built-in `acceptEdits`
exactly as before.

## Security considerations

This grants no new capability: `--allow-dangerously-skip-permissions` was
already reachable verbatim through `claude_args` pass-through. The bug is that
the documented spelling silently no-ops. A workflow author writing
`--permission-mode bypassPermissions` into their workflow file has already
stated the intent the interlock exists to confirm — but if you'd rather the
action fail loudly and require users to pass the interlock flag explicitly,
happy to rework in that direction; the extraction plumbing is the same either
way.

## Changes

- `base-action/src/parse-sdk-options.ts` — extract `permission-mode` from
  `extraArgs` into `sdkOptions.permissionMode` (+ companion for bypass)
- `base-action/test/parse-sdk-options.test.ts` — 5 regression tests: bypass
  extraction with companion, non-bypass without, last-occurrence override of
  tag mode's default, absent flag, bare flag with no value

## Testing

- `bun test` — 775 pass, 0 fail
- `bun run typecheck` — clean
- `bun run format:check` — clean