### PR TITLE
fix: keep the triggering review/comment in prompt context (#1522)

### DIFF
--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -181,6 +181,30 @@ async function findIssueEventTime(
 }
 
 /**
+ * Extracts the numeric id of the entity that triggered the run (the comment or
+ * review from the webhook payload). It matches the GraphQL `databaseId` of the
+ * fetched comment/review, letting the trigger-time filters retain the entity
+ * that *is* the trigger — which is created/submitted exactly at the trigger
+ * time and would otherwise be dropped by the `>= triggerTime` comparison.
+ *
+ * @param context - Parsed GitHub context from webhook
+ * @returns The numeric entity id, or undefined if the event has no such entity
+ */
+export function extractTriggerEntityId(
+  context: ParsedGitHubContext,
+): number | undefined {
+  if (isIssueCommentEvent(context)) {
+    return context.payload.comment.id;
+  } else if (isPullRequestReviewEvent(context)) {
+    return context.payload.review.id;
+  } else if (isPullRequestReviewCommentEvent(context)) {
+    return context.payload.comment.id;
+  }
+
+  return undefined;
+}
+
+/**
  * Extracts the original title from the GitHub webhook payload.
  * This is the title as it existed when the trigger event occurred.
  *
@@ -241,13 +265,36 @@ export function extractOriginalBody(
  * @returns Filtered array of comments that were created and last edited before trigger time
  */
 export function filterCommentsToTriggerTime<
-  T extends { createdAt: string; updatedAt?: string; lastEditedAt?: string },
->(comments: T[], triggerTime: string | undefined): T[] {
+  T extends {
+    databaseId?: string | number;
+    createdAt: string;
+    updatedAt?: string;
+    lastEditedAt?: string;
+  },
+>(
+  comments: T[],
+  triggerTime: string | undefined,
+  triggerEntityId?: number,
+): T[] {
   if (!triggerTime) return comments;
 
   const triggerTimestamp = new Date(triggerTime).getTime();
 
   return comments.filter((comment) => {
+    // Always keep the entity that IS the trigger. It is created/submitted at the
+    // trigger time, so the comparisons below would otherwise drop it. This filter
+    // exists to exclude content injected at/after the trigger, and the trigger
+    // itself is not injected (an edit that bumps updatedAt to the submit time
+    // must not evict it either). databaseId is compared as a string because the
+    // GraphQL id is a string while the webhook payload id is a number.
+    if (
+      triggerEntityId !== undefined &&
+      comment.databaseId !== undefined &&
+      String(comment.databaseId) === String(triggerEntityId)
+    ) {
+      return true;
+    }
+
     // Comment must have been created before trigger (not at or after)
     const createdTimestamp = new Date(comment.createdAt).getTime();
     if (createdTimestamp >= triggerTimestamp) {
@@ -273,13 +320,36 @@ export function filterCommentsToTriggerTime<
  * Similar to filterCommentsToTriggerTime but for GitHubReview objects which use submittedAt instead of createdAt.
  */
 export function filterReviewsToTriggerTime<
-  T extends { submittedAt: string; updatedAt?: string; lastEditedAt?: string },
->(reviews: T[], triggerTime: string | undefined): T[] {
+  T extends {
+    databaseId?: string | number;
+    submittedAt: string;
+    updatedAt?: string;
+    lastEditedAt?: string;
+  },
+>(
+  reviews: T[],
+  triggerTime: string | undefined,
+  triggerEntityId?: number,
+): T[] {
   if (!triggerTime) return reviews;
 
   const triggerTimestamp = new Date(triggerTime).getTime();
 
   return reviews.filter((review) => {
+    // Always keep the review that IS the trigger (submitted exactly at the
+    // trigger time). Dropping it here also drops its inline comments downstream,
+    // which is the reported bug: a review with only inline comments and an empty
+    // body left the prompt with no review context at all. databaseId is compared
+    // as a string because the GraphQL id is a string while the webhook payload
+    // id is a number.
+    if (
+      triggerEntityId !== undefined &&
+      review.databaseId !== undefined &&
+      String(review.databaseId) === String(triggerEntityId)
+    ) {
+      return true;
+    }
+
     // Review must have been submitted before trigger (not at or after)
     const submittedTimestamp = new Date(review.submittedAt).getTime();
     if (submittedTimestamp >= triggerTimestamp) {
@@ -367,6 +437,7 @@ type FetchDataParams = {
   isPR: boolean;
   triggerUsername?: string;
   triggerTime?: string;
+  triggerEntityId?: number;
   originalTitle?: string;
   originalBody?: string | null;
   includeCommentsByActor?: string;
@@ -394,6 +465,7 @@ export async function fetchGitHubData({
   isPR,
   triggerUsername,
   triggerTime,
+  triggerEntityId,
   originalTitle,
   originalBody,
   includeCommentsByActor,
@@ -434,6 +506,7 @@ export async function fetchGitHubData({
           filterCommentsToTriggerTime(
             pullRequest.comments?.nodes || [],
             triggerTime,
+            triggerEntityId,
           ),
           includeCommentsByActor,
           excludeCommentsByActor,
@@ -461,6 +534,7 @@ export async function fetchGitHubData({
           filterCommentsToTriggerTime(
             contextData?.comments?.nodes || [],
             triggerTime,
+            triggerEntityId,
           ),
           includeCommentsByActor,
           excludeCommentsByActor,
@@ -527,7 +601,11 @@ export async function fetchGitHubData({
   if (reviewData && reviewData.nodes) {
     // Drop reviews submitted or edited after the trigger, then filter by actor.
     reviewData.nodes = filterCommentsByActor(
-      filterReviewsToTriggerTime(reviewData.nodes, triggerTime),
+      filterReviewsToTriggerTime(
+        reviewData.nodes,
+        triggerTime,
+        triggerEntityId,
+      ),
       includeCommentsByActor,
       excludeCommentsByActor,
     );
@@ -536,7 +614,11 @@ export async function fetchGitHubData({
     reviewData.nodes.forEach((review) => {
       if (review.comments?.nodes) {
         review.comments.nodes = filterCommentsByActor(
-          filterCommentsToTriggerTime(review.comments.nodes, triggerTime),
+          filterCommentsToTriggerTime(
+            review.comments.nodes,
+            triggerTime,
+            triggerEntityId,
+          ),
           includeCommentsByActor,
           excludeCommentsByActor,
         );

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -10,6 +10,7 @@ import { prepareMcpConfig } from "../../mcp/install-mcp-server";
 import {
   fetchGitHubData,
   resolveTriggerTimestamp,
+  extractTriggerEntityId,
   extractOriginalTitle,
   extractOriginalBody,
 } from "../../github/data/fetcher";
@@ -47,6 +48,7 @@ export async function prepareTagMode({
   const commentId = commentData.id;
 
   const triggerTime = await resolveTriggerTimestamp(context, octokit);
+  const triggerEntityId = extractTriggerEntityId(context);
   const originalTitle = extractOriginalTitle(context);
   const originalBody = extractOriginalBody(context);
 
@@ -57,6 +59,7 @@ export async function prepareTagMode({
     isPR: context.isPR,
     triggerUsername: context.actor,
     triggerTime,
+    triggerEntityId,
     originalTitle,
     originalBody,
     includeCommentsByActor: context.inputs.includeCommentsByActor,

--- a/test/data-fetcher.test.ts
+++ b/test/data-fetcher.test.ts
@@ -753,6 +753,85 @@ describe("filterReviewsToTriggerTime", () => {
       expect(filtered).toEqual(reviews);
     });
   });
+
+  describe("trigger entity retention (by id)", () => {
+    it("keeps the review that IS the trigger even though it is submitted exactly at trigger time", () => {
+      const triggeringReview = {
+        ...createMockReview("2024-01-15T12:00:00Z"), // submittedAt === triggerTime
+        databaseId: "987654",
+      };
+
+      // Without the id, this review is dropped (submitted at trigger time)...
+      expect(
+        filterReviewsToTriggerTime([triggeringReview], triggerTime).length,
+      ).toBe(0);
+
+      // ...but passing the triggering entity's numeric webhook id retains it.
+      const filtered = filterReviewsToTriggerTime(
+        [triggeringReview],
+        triggerTime,
+        987654,
+      );
+      expect(filtered.length).toBe(1);
+      expect(filtered[0]).toBe(triggeringReview);
+    });
+
+    it("keeps the triggering review even when updatedAt is bumped to the submit time", () => {
+      const triggeringReview = {
+        ...createMockReview("2024-01-15T12:00:00Z", "2024-01-15T12:00:00Z"),
+        databaseId: "555",
+      };
+
+      const filtered = filterReviewsToTriggerTime(
+        [triggeringReview],
+        triggerTime,
+        555,
+      );
+      expect(filtered.length).toBe(1);
+    });
+
+    it("still drops a non-trigger review submitted at the trigger time when a trigger id is given", () => {
+      const triggeringReview = {
+        ...createMockReview("2024-01-15T12:00:00Z"),
+        databaseId: "111",
+      };
+      const otherReview = {
+        ...createMockReview("2024-01-15T12:00:00Z"),
+        databaseId: "222",
+      };
+
+      const filtered = filterReviewsToTriggerTime(
+        [triggeringReview, otherReview],
+        triggerTime,
+        111,
+      );
+      expect(filtered.length).toBe(1);
+      expect(filtered[0]?.databaseId).toBe("111");
+    });
+
+    it("keeps the triggering comment created exactly at trigger time", () => {
+      const triggeringComment = {
+        id: "c1",
+        databaseId: "42",
+        body: "inline note",
+        author: { login: "reviewer" },
+        createdAt: "2024-01-15T12:00:00Z", // createdAt === triggerTime
+        isMinimized: false,
+      };
+
+      // Dropped without the id; retained when the trigger comment id is passed.
+      expect(
+        filterCommentsToTriggerTime([triggeringComment], triggerTime).length,
+      ).toBe(0);
+      const filtered = filterCommentsToTriggerTime(
+        [triggeringComment],
+        triggerTime,
+        42,
+      );
+      expect(filtered.length).toBe(1);
+      expect(filtered[0]).toBe(triggeringComment);
+    });
+  });
 });
 
 describe("isBodySafeToUse", () => {


### PR DESCRIPTION
Fixes #1522.

## Problem

`filterReviewsToTriggerTime()` / `filterCommentsToTriggerTime()` drop any entity whose submit/creation time is `>= triggerTime`, to keep content injected at/after the trigger out of the prompt (TOCTOU protection). But the entity that *is* the trigger is submitted/created **exactly** at `triggerTime`, so `>=` always filtered it out.

For a `pull_request_review` trigger this dropped the triggering review **and all of its inline comments** (they hang off the review node, which was removed). When a reviewer submits only inline comments with an empty body, `<review_comments>` renders "No review comments" and Claude receives nothing about the review it is supposed to respond to.

The edit-time check compounds it: reviews fetch `updatedAt`, which GitHub stamps at submit time, so even relaxing the submit comparison alone wouldn't be enough.

## Fix

Retain the entity whose `databaseId` matches the triggering webhook payload id, exempting **only that one entity** from both the submit/create and edit-time checks. The `>=` comparison is left untouched for every other entity, so post-trigger injection is still filtered — this is deliberately narrower than relaxing `>=` to `>`, which would admit *any* same-second entity.

- New `extractTriggerEntityId(context)` returns `review.id` / `comment.id` from the payload (mirrors `extractTriggerTimestamp`).
- Threaded through `fetchGitHubData` to both filters (covers `pull_request_review`, `pull_request_review_comment`, and `issue_comment` triggers).
- `databaseId` is string-compared: the GraphQL id is a `string`, the webhook id is a `number`.

## Tests

Added 4 tests to `test/data-fetcher.test.ts`:
- the triggering review is dropped without the id and **kept** when the id is passed;
- it's kept even when `updatedAt` is bumped to the submit time (edit-check bypass);
- a *non-trigger* review submitted at the same time is **still dropped** (the exemption is precise);
- the triggering comment created exactly at trigger time is kept.

`bun test test/data-fetcher.test.ts` → 80 pass / 0 fail. `bun run typecheck` clean. Only the two touched source files + the test are changed.
