### PR TITLE
fix: neutralize the checkout credential under actions/checkout v6+ include layout (#1510)

### DIFF
--- a/src/github/operations/git-config.ts
+++ b/src/github/operations/git-config.ts
@@ -56,6 +56,16 @@ export async function configureGitAuth(
  * action's own token instead (a credential helper when non-write users are
  * allowed, otherwise the origin URL). This applies to every mode, including API
  * commit signing where no other git configuration is needed.
+ *
+ * actions/checkout < v6 stored the header directly in the repo-local config,
+ * where `git config --unset-all` removes it. Since v6.0.0 (backported to
+ * v5.0.1 and v4.3.1) the header is written to a separate file under
+ * RUNNER_TEMP that the repo config pulls in via `include.path`; `--unset-all`
+ * on the local config cannot touch an include-provided value, so the removal
+ * was a silent no-op and the checkout credential (typically the workflow
+ * GITHUB_TOKEN) stayed usable by git for the rest of the job. Clear the
+ * header from the local config AND from every included file so it can no
+ * longer authenticate while Claude runs.
  */
 export async function replaceCheckoutCredentials(
   githubToken: string,
@@ -65,12 +75,35 @@ export async function replaceCheckoutCredentials(
 
   // Remove the authorization header that actions/checkout sets
   console.log("Removing existing git authentication headers...");
+  const extraheaderKey = `http.${GITHUB_SERVER_URL}/.extraheader`;
+  let removedHeader = false;
   try {
-    await $`git config --unset-all http.${GITHUB_SERVER_URL}/.extraheader`;
-    console.log("✓ Removed existing authentication headers");
-  } catch (e) {
-    console.log("No existing authentication headers to remove");
+    await $`git config --unset-all ${extraheaderKey}`;
+    removedHeader = true;
+  } catch {
+    // No extraheader in the local config (expected on the v6+ include layout).
   }
+  try {
+    const includePaths =
+      await $`git config --local --get-all include.path`.text();
+    for (const includePath of includePaths.split("\n")) {
+      const path = includePath.trim();
+      if (!path) continue;
+      try {
+        await $`git config --file ${path} --unset-all ${extraheaderKey}`;
+        removedHeader = true;
+      } catch {
+        // This include does not define the header; leave it untouched.
+      }
+    }
+  } catch {
+    // No include.path entries in the local config.
+  }
+  console.log(
+    removedHeader
+      ? "✓ Removed existing authentication headers"
+      : "No existing authentication headers to remove",
+  );
 
   if (process.env.ALLOWED_NON_WRITE_USERS) {
     // When processing content from non-write users, use a credential helper


### PR DESCRIPTION
Fixes #1510.

## Problem

`configureGitAuth()` removes the credential that `actions/checkout` persists with:

```ts
git config --unset-all http.<server>/.extraheader
```

That edits only the repo-local config. Since **actions/checkout v6.0.0** ([#2286](https://github.com/actions/checkout/pull/2286), backported to v5.0.1 / v4.3.1) the auth header is no longer stored in `.git/config` — it's written to a separate file under `RUNNER_TEMP` and pulled in via `include.path`. `git config --unset-all` cannot remove an include-provided value, so the call is a **no-op**: the action logs `No existing authentication headers to remove` while the checkout credential (typically the workflow `GITHUB_TOKEN`) stays usable by git for the rest of the job — exactly while Claude executes.

## Fix

Clear the header from the local config **and** from every file referenced by `include.path`, so it's neutralized under both layouts:

- pre-v6 (header in local config) → `--unset-all` on the local config (unchanged);
- v6+ (header in an included file) → `git config --file <inc> --unset-all …` on each include.

Includes that don't define the header are left untouched (a no-op `--unset-all` there), so legitimate includes survive.

## Verification

Reproduced the include-based layout with plain git and confirmed the behavior, since git operations aren't unit-tested in this repo (integration lives in `install-test`):

| Case | Before | After fix |
|---|---|---|
| v6+ credential behind `include.path` | `--unset-all` exits 5, header still resolves | header **gone** |
| pre-v6 credential in local config | removed | removed (unchanged) |
| legit include (no header) present | — | **preserved** (include kept, its settings intact) |
| mixed cred-include + legit-include | — | cred **gone**, legit **preserved** |
| no auth configured at all | — | no error (idempotent) |

`bun run typecheck` clean; touched file is prettier-clean. (The repo-wide `format:check` only flags files due to a Windows CRLF checkout, not this change.)
