### PR TITLE
fix: normalize empty branch template segments

### DIFF
--- a/src/utils/branch-template.ts
+++ b/src/utils/branch-template.ts
@@ -42,6 +42,15 @@ function sanitizeLabel(label: string): string {
     .replace(/^-|-$/g, ""); // Remove leading/trailing hyphens
 }
 
+/**
+ * Drops empty branch path segments that can be produced by optional template
+ * variables (for example an emoji-only title causing {{description}} to be
+ * empty in "{{prefix}}{{description}}/{{entityNumber}}").
+ */
+function normalizeBranchTemplateResult(branchName: string): string {
+  return branchName.replace(/\/+/g, "/").replace(/^\/|\/$/g, "");
+}
+
 export interface BranchTemplateVariables {
   prefix: string;
   entityType: string;
@@ -97,9 +106,11 @@ export function generateBranchName(
   };
 
   if (template?.trim()) {
-    const branchName = applyBranchTemplate(template, variables);
+    const branchName = normalizeBranchTemplateResult(
+      applyBranchTemplate(template, variables),
+    );
 
-    // Some templates could produce empty results- validate
+    // Some templates could produce empty results or only empty path segments.
     if (branchName.trim().length > 0) return branchName;
 
     console.log(

--- a/test/branch-template.test.ts
+++ b/test/branch-template.test.ts
@@ -268,6 +268,39 @@ describe("branch template utilities", () => {
       expect(result).toBe("test/-101");
     });
 
+    it("should drop empty slash segments when description sanitizes to empty", () => {
+      const template = "{{prefix}}{{description}}/{{entityNumber}}";
+      const result = generateBranchName(
+        template,
+        "claude/",
+        "issue",
+        123,
+        undefined,
+        undefined,
+        "🎉🎉🎉",
+      );
+
+      expect(result).toBe("claude/123");
+      expect(() => validateBranchName(result)).not.toThrow();
+    });
+
+    it("should fallback to default format when slash normalization leaves an empty result", () => {
+      const template = "{{description}}/";
+      const result = generateBranchName(
+        template,
+        "claude/",
+        "issue",
+        321,
+        undefined,
+        undefined,
+        "日本語のタイトル",
+      );
+
+      expect(result).toMatch(/^claude\/issue-321-\d{8}-\d{4}$/);
+      expect(result.length).toBeLessThanOrEqual(50);
+      expect(() => validateBranchName(result)).not.toThrow();
+    });
+
     it("should fallback to default format when template produces empty result", () => {
       const template = "{{description}}"; // Will be empty if no title provided
       const result = generateBranchName(template, "claude/", "issue", 123);


### PR DESCRIPTION
## Summary

- Normalize generated branch template results to drop empty slash-delimited segments before validation
- Preserve the default-format fallback when slash normalization leaves no usable branch name
- Add regression coverage for titles whose `{{description}}` sanitizes to an empty string

Fixes #1527

## Test plan

- `bun test test/branch-template.test.ts`
- `bun test`
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`
