### PR TITLE
feat: support the merge_group event (agent mode)

### DIFF
--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -51,6 +51,25 @@ export type ScheduleEvent = {
   };
 };
 
+export type MergeGroupEvent = {
+  action: "checks_requested" | "destroyed";
+  merge_group: {
+    head_sha: string;
+    head_ref: string;
+    base_sha: string;
+    base_ref: string;
+  };
+  repository: {
+    name: string;
+    owner: {
+      login: string;
+    };
+  };
+  sender: {
+    login: string;
+  };
+};
+
 // Event name constants for better maintainability
 const ENTITY_EVENT_NAMES = [
   "issues",
@@ -65,6 +84,7 @@ const AUTOMATION_EVENT_NAMES = [
   "repository_dispatch",
   "schedule",
   "workflow_run",
+  "merge_group",
 ] as const;
 
 // Derive types from constants for better maintainability
@@ -118,14 +138,15 @@ export type ParsedGitHubContext = BaseContext & {
   isPR: boolean;
 };
 
-// Context for automation events (workflow_dispatch, repository_dispatch, schedule, workflow_run)
+// Context for automation events (workflow_dispatch, repository_dispatch, schedule, workflow_run, merge_group)
 export type AutomationContext = BaseContext & {
   eventName: AutomationEventName;
   payload:
     | WorkflowDispatchEvent
     | RepositoryDispatchEvent
     | ScheduleEvent
-    | WorkflowRunEvent;
+    | WorkflowRunEvent
+    | MergeGroupEvent;
 };
 
 // Union type for all contexts
@@ -245,6 +266,13 @@ export function parseGitHubContext(): GitHubContext {
         ...commonFields,
         eventName: "workflow_run",
         payload: context.payload as unknown as WorkflowRunEvent,
+      };
+    }
+    case "merge_group": {
+      return {
+        ...commonFields,
+        eventName: "merge_group",
+        payload: context.payload as unknown as MergeGroupEvent,
       };
     }
     default:

--- a/test/github-context.test.ts
+++ b/test/github-context.test.ts
@@ -297,6 +297,28 @@ describe("parseGitHubContext", () => {
       expect(context.eventName).toBe("workflow_run");
       expect(isAutomationContext(context)).toBe(true);
     });
+
+    test("merge_group produces an automation context", () => {
+      setEvent("merge_group", {
+        action: "checks_requested",
+        merge_group: {
+          head_sha: "abc123",
+          head_ref: "refs/heads/gh-readonly-queue/main/pr-42-abc123",
+          base_sha: "def456",
+          base_ref: "refs/heads/main",
+        },
+        repository: repositoryPayload,
+        sender: { login: "test-actor" },
+      });
+
+      const context = parseGitHubContext();
+
+      expect(context.eventName).toBe("merge_group");
+      expect(context.eventAction).toBe("checks_requested");
+      expect(isAutomationContext(context)).toBe(true);
+      expect("entityNumber" in context).toBe(false);
+      expect("isPR" in context).toBe(false);
+    });
   });
 
   describe("invalid partition", () => {
@@ -498,7 +520,7 @@ describe("type guards", () => {
     expect(isEntityContext(workflowDispatchContext)).toBe(false);
   });
 
-  test("isAutomationContext accepts the four automation events", () => {
+  test("isAutomationContext accepts the five automation events", () => {
     expect(isAutomationContext(workflowDispatchContext)).toBe(true);
     expect(
       isAutomationContext(
@@ -513,6 +535,11 @@ describe("type guards", () => {
     expect(
       isAutomationContext(
         createMockAutomationContext({ eventName: "workflow_run" }),
+      ),
+    ).toBe(true);
+    expect(
+      isAutomationContext(
+        createMockAutomationContext({ eventName: "merge_group" }),
       ),
     ).toBe(true);
     expect(isAutomationContext(issuesContext)).toBe(false);

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -222,6 +222,20 @@ describe("detectMode with enhanced routing", () => {
 
       expect(detectMode(context)).toBe("agent");
     });
+
+    it("should use agent mode for merge_group with a prompt", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "merge_group",
+        payload: {} as any,
+        inputs: {
+          ...baseContext.inputs,
+          prompt: "Investigate the merge group CI failures",
+        },
+      };
+
+      expect(detectMode(context)).toBe("agent");
+    });
   });
 
   describe("Custom prompt injection in tag mode", () => {


### PR DESCRIPTION
## Summary

Handles `merge_group` as an automation event (like `workflow_run`/`schedule`), so it routes to agent mode instead of throwing `Unsupported event type: merge_group`. A merge group has no PR/issue number, so it maps to `AutomationContext`; all entity-guarded paths are already skipped via `isEntityContext()`.

## Why

GitHub merge queues run CI against a temporary merge commit before landing a PR. That failure surface had no trigger. This unblocks:

- **Merge-queue failure triage**: run a read-only prompt to summarize why the combined CI failed — including failures only visible in the merged result (semantic conflicts, incompatible migrations, ordering-dependent tests).
- **Parity**: same prompt-based pattern already used with `workflow_run`/`schedule`.

## Changes

All in `src/github/context.ts`: inline `MergeGroupEvent` type, `"merge_group"` added to `AUTOMATION_EVENT_NAMES` and the `AutomationContext.payload` union, and a `case "merge_group"` in `parseGitHubContext()`. Tests added for parsing, type guard, and mode detection.

Out of scope: `github_ci` stays PR-keyed; merge-queue workflows read CI via the generic `github` MCP server with `actions: read` (no code change).

## Example

```yaml
on:
  merge_group:
permissions:
  contents: read
  actions: read
jobs:
  claude:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: anthropics/claude-code-action@main
        with:
          prompt: "Investigate the CI failures in this merge group and summarize the root causes. Do not modify code."
          anthropic_api_key: \${{ secrets.ANTHROPIC_API_KEY }}
          claude_args: '--allowedTools "mcp__github__*"'
```

## Testing

`bun test`, `bun run typecheck`, `bun run format:check` — all pass.

