### PR TITLE
fix(sdk): keep stdin open until background tasks finish

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -137,7 +137,7 @@ export async function runClaudeWithSdk(
   { sdkOptions, showFullOutput, hasJsonSchema }: ParsedSdkOptions,
 ): Promise<ClaudeRunResult> {
   // Create prompt configuration - may be a string or multi-block message
-  const prompt = await createPromptConfig(promptPath, showFullOutput);
+  const basePrompt = await createPromptConfig(promptPath, showFullOutput);
 
   if (!showFullOutput) {
     console.log(
@@ -155,9 +155,39 @@ export async function runClaudeWithSdk(
 
   const messages: SDKMessage[] = [];
   let resultMessage: SDKResultMessage | undefined;
+  let liveBackgroundTasks = 0;
+
+  // In print mode a background shell is terminated shortly after the final
+  // result once stdin closes. Stream the prompt and keep stdin open until a
+  // result reports no live background tasks (tracked via
+  // background_tasks_changed), so background work runs to completion instead of
+  // being cut off when a turn ends.
+  let releaseStdin!: () => void;
+  const stdinCanClose = new Promise<void>((resolve) => {
+    releaseStdin = resolve;
+  });
+
+  async function* heldOpenPrompt(): AsyncGenerator<SDKUserMessage> {
+    if (typeof basePrompt === "string") {
+      yield {
+        type: "user",
+        session_id: "",
+        message: { role: "user", content: basePrompt },
+        parent_tool_use_id: null,
+      };
+    } else {
+      for await (const message of basePrompt) {
+        yield message;
+      }
+    }
+    await stdinCanClose;
+  }
 
   try {
-    for await (const message of query({ prompt, options: sdkOptions })) {
+    for await (const message of query({
+      prompt: heldOpenPrompt(),
+      options: sdkOptions,
+    })) {
       messages.push(message);
 
       const sanitized = sanitizeSdkOutput(message, showFullOutput);
@@ -165,24 +195,35 @@ export async function runClaudeWithSdk(
         console.log(sanitized);
       }
 
+      if (
+        message.type === "system" &&
+        message.subtype === "background_tasks_changed"
+      ) {
+        liveBackgroundTasks =
+          "tasks" in message && Array.isArray(message.tasks)
+            ? message.tasks.length
+            : 0;
+      }
+
       if (message.type === "result") {
         resultMessage = message as SDKResultMessage;
-        // The SDK's query() iterator should close itself after the
-        // result message, but in some workflow contexts (notably
-        // pull_request-triggered runs) it stays open indefinitely and
-        // the for-await hangs until the workflow's timeout-minutes
-        // kills the job. This causes the action to "succeed" inside
-        // Claude (verdict posted, $cost recorded) but be reported as
-        // cancelled with no execution-output.json written. Break
-        // explicitly: by SDK contract no further messages follow a
-        // result, so the break is safe.
-        break;
+        // Break only when no background tasks remain live: breaking on the
+        // first result orphans still-running background work (#1499), while an
+        // unconditional break was originally needed to avoid a hung iterator
+        // (#1339). A run whose background work never settles is bounded by the
+        // job's timeout-minutes.
+        if (liveBackgroundTasks === 0) {
+          releaseStdin();
+          break;
+        }
       }
     }
   } catch (error) {
     console.error("SDK execution error:", error);
     await writeExecutionFile(messages);
     throw new Error(`SDK execution error: ${error}`);
+  } finally {
+    releaseStdin();
   }
 
   const result: ClaudeRunResult = {


### PR DESCRIPTION
## Problem

When the model launches a background **Bash** task (`run_in_background: true`, or a timeout auto-background) and ends its turn, the background shell is terminated shortly after the final `result` — the termination fires once stdin has closed, and `runClaudeWithSdk` passes a string prompt, so stdin closes immediately. A long background command (build, test suite, …) never finishes and its output is never consumed, yet the step still reports `subtype: "success"`. See #1462 for the user-facing "green run, nothing happened" symptom.

## Change

`base-action/src/run-claude-sdk.ts`: feed the prompt through an async generator that yields it and then holds the CLI's stdin open, and break the loop only when a `result` reports no live background tasks (tracked via the `background_tasks_changed` system message). A `finally` releases the hold if the stream ends or throws.

Because stdin stays open until nothing is live, a completed or killed background task keeps the process alive long enough to run to completion / be observed, and the model receives its follow-up turn(s) to consume the output. Runs with no background tasks are unaffected — they break on the first `result`, preserving the anti-hang guard from #1339.

## Possible alternatives

This behavior originates in Claude Code / the Agents SDK, not in `claude-code-action`; this PR is a consumer-side mitigation. You may prefer a holistic upstream fix — e.g. not terminating background shells while an SDK consumer is still iterating the stream. Happy to adapt or close this in favor of that, or it may be preferred to make this a config option in case other users still desire long-running tasks to be killed or have a timeout.

## See also
#1500 fixes this just for background subagents, but doesn't work for backgrounded Bash commands.
Fixes #1531, #1499.

## Environment

- `@anthropic-ai/claude-agent-sdk` `^0.3.211`
- Headless / `-p` (GitHub Actions)