### PR TITLE
fix: restore credential-free origin URL after token revocation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -445,6 +445,20 @@ runs:
           --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
           run ${GITHUB_ACTION_PATH}/src/entrypoints/post-buffered-inline-comments.ts
 
+    - name: Restore git authentication
+      # Same guard as the revoke step below: the credentials configured for the
+      # run are about to stop working, so they must not be left behind for later
+      # steps (or a second invocation of this action) to pick up (issue #1509).
+      if: always() && inputs.github_token == '' && steps.run.outputs.github_token != '' && steps.run.outputs.skipped_due_to_workflow_validation_mismatch != 'true'
+      shell: bash
+      run: |
+        BUN_BIN="${GITHUB_ACTION_PATH}/bin/bun"
+        [ -x "$BUN_BIN" ] || BUN_BIN="bun"
+        # No --tsconfig-override: see the "Run Claude Code Action" step above.
+        "$BUN_BIN" --no-env-file \
+          --config="${GITHUB_ACTION_PATH}/bunfig.toml" \
+          run ${GITHUB_ACTION_PATH}/src/entrypoints/cleanup-git-config.ts || true
+
     - name: Revoke app token
       if: always() && inputs.github_token == '' && steps.run.outputs.github_token != '' && steps.run.outputs.skipped_due_to_workflow_validation_mismatch != 'true'
       shell: bash

--- a/src/entrypoints/cleanup-git-config.ts
+++ b/src/entrypoints/cleanup-git-config.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+
+/**
+ * Undo the git authentication configured for the run.
+ *
+ * Runs as a post step next to the token revocation so the workspace is left
+ * without a reference to a token that is about to stop working (issue #1509).
+ */
+
+import { cleanupGitAuth } from "../github/operations/git-config";
+
+async function run() {
+  try {
+    await cleanupGitAuth();
+  } catch (error) {
+    // Don't fail the action if cleanup fails, just log it
+    console.error("Failed to clean up git authentication:", error);
+  }
+}
+
+if (import.meta.main) {
+  run();
+}

--- a/src/github/operations/git-config.ts
+++ b/src/github/operations/git-config.ts
@@ -14,10 +14,60 @@ import { GITHUB_SERVER_URL } from "../api/config";
 
 const SSH_SIGNING_KEY_PATH = join(homedir(), ".ssh", "claude_signing_key");
 
+const CREDENTIAL_HELPER_FILENAME = ".git-credential-gh-token";
+
 type GitUser = {
   login: string;
   id: number;
 };
+
+/**
+ * Path of the credential helper script written when ALLOWED_NON_WRITE_USERS is
+ * set. Resolved lazily so setup and cleanup agree even though cleanup runs in a
+ * separate process.
+ */
+export function getCredentialHelperPath(): string {
+  return join(
+    process.env.GITHUB_ACTION_PATH || homedir(),
+    CREDENTIAL_HELPER_FILENAME,
+  );
+}
+
+/**
+ * Remove any embedded credentials from an http(s) remote URL.
+ *
+ * Returns null when the URL carries no credentials, or when it is not an
+ * http(s) URL (ssh remotes never embed a token, so they are left alone).
+ * Rewriting the URL that is actually configured, rather than rebuilding one
+ * from the event context, keeps a remote that points somewhere other than the
+ * event repository intact.
+ */
+export function stripCredentialsFromRemoteUrl(
+  remoteUrl: string,
+): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(remoteUrl);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return null;
+  }
+
+  if (!parsed.username && !parsed.password) {
+    return null;
+  }
+
+  parsed.username = "";
+  parsed.password = "";
+  return parsed.toString();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 export async function configureGitAuth(
   githubToken: string,
@@ -80,10 +130,7 @@ export async function replaceCheckoutCredentials(
     // GITHUB_ACTION_PATH so it sits alongside the action source.
     console.log("Configuring git credential helper...");
     process.env.GH_TOKEN = githubToken;
-    const helperPath = join(
-      process.env.GITHUB_ACTION_PATH || homedir(),
-      ".git-credential-gh-token",
-    );
+    const helperPath = getCredentialHelperPath();
     await writeFile(
       helperPath,
       '#!/bin/sh\necho username=x-access-token\necho password="$GH_TOKEN"\n',
@@ -99,6 +146,57 @@ export async function replaceCheckoutCredentials(
     const remoteUrl = `https://x-access-token:${githubToken}@${serverUrl.host}/${context.repository.owner}/${context.repository.repo}.git`;
     await $`git remote set-url origin ${remoteUrl}`;
     console.log("✓ Updated remote URL with authentication token");
+  }
+}
+
+/**
+ * Undo the git authentication configured for the run.
+ *
+ * The app installation token is revoked when the action finishes, so anything
+ * left pointing at it breaks later git operations in the same job, including a
+ * second invocation of this action, whose tag-mode branch setup fetches before
+ * configuring its own auth (issue #1509). Restores a credential-free origin
+ * URL, drops only the credential helper this action configured, and deletes the
+ * helper script.
+ *
+ * Never throws: cleanup runs in an always() step and must not fail the job.
+ */
+export async function cleanupGitAuth(): Promise<void> {
+  // Restore a credential-free origin URL.
+  try {
+    const originUrl = (
+      await $`git remote get-url origin`.quiet().text()
+    ).trim();
+    const cleanedUrl = stripCredentialsFromRemoteUrl(originUrl);
+    if (cleanedUrl && cleanedUrl !== originUrl) {
+      await $`git remote set-url origin ${cleanedUrl}`.quiet();
+      console.log("✓ Removed embedded credentials from origin remote URL");
+    }
+  } catch {
+    // No git repository or no origin remote; nothing to restore.
+  }
+
+  const helperPath = getCredentialHelperPath();
+
+  // Drop only the helper this action configured, leaving any other helper (for
+  // example one set by the workflow itself) untouched. Scoped to the local
+  // repository config, which is where replaceCheckoutCredentials writes it.
+  try {
+    const configured = (
+      await $`git config --local --get-all credential.helper`.quiet().text()
+    ).trim();
+    if (configured.split("\n").some((value) => value.trim() === helperPath)) {
+      await $`git config --local --unset-all credential.helper ${`^${escapeRegExp(helperPath)}$`}`.quiet();
+      console.log("✓ Removed git credential helper");
+    }
+  } catch {
+    // No credential helper configured.
+  }
+
+  try {
+    await rm(helperPath, { force: true });
+  } catch {
+    // Helper script was never written.
   }
 }
 

--- a/test/git-config-cleanup.test.ts
+++ b/test/git-config-cleanup.test.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env bun
+
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  afterAll,
+} from "bun:test";
+import { $ } from "bun";
+import { mkdtemp, rm, readFile, stat } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  cleanupGitAuth,
+  configureGitAuth,
+  getCredentialHelperPath,
+  stripCredentialsFromRemoteUrl,
+} from "../src/github/operations/git-config";
+import type { GitHubContext } from "../src/github/context";
+
+const TOKEN = "ghs_exampletokenvalue1234567890";
+
+const context = {
+  repository: { owner: "anthropics", repo: "claude-code-action" },
+} as unknown as GitHubContext;
+
+const user = { login: "claude[bot]", id: 1234 };
+
+const cleanUrl = "https://github.com/anthropics/claude-code-action.git";
+const tokenUrl = `https://x-access-token:${TOKEN}@github.com/anthropics/claude-code-action.git`;
+
+async function readGitConfig(repoDir: string): Promise<string> {
+  return readFile(join(repoDir, ".git", "config"), "utf-8");
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("git auth cleanup (issue #1509)", () => {
+  const originalCwd = process.cwd();
+  const originalActionPath = process.env.GITHUB_ACTION_PATH;
+  const originalAllowedNonWriteUsers = process.env.ALLOWED_NON_WRITE_USERS;
+  let repoDir: string;
+  let actionDir: string;
+
+  beforeEach(async () => {
+    repoDir = await mkdtemp(join(tmpdir(), "claude-git-config-repo-"));
+    actionDir = await mkdtemp(join(tmpdir(), "claude-git-config-action-"));
+    process.env.GITHUB_ACTION_PATH = actionDir;
+    delete process.env.ALLOWED_NON_WRITE_USERS;
+
+    process.chdir(repoDir);
+    await $`git init -q`.quiet();
+    await $`git remote add origin ${cleanUrl}`.quiet();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(repoDir, { recursive: true, force: true });
+    await rm(actionDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    process.chdir(originalCwd);
+    if (originalActionPath === undefined) {
+      delete process.env.GITHUB_ACTION_PATH;
+    } else {
+      process.env.GITHUB_ACTION_PATH = originalActionPath;
+    }
+    if (originalAllowedNonWriteUsers === undefined) {
+      delete process.env.ALLOWED_NON_WRITE_USERS;
+    } else {
+      process.env.ALLOWED_NON_WRITE_USERS = originalAllowedNonWriteUsers;
+    }
+  });
+
+  test("removes the token the setup embedded in the origin URL", async () => {
+    await configureGitAuth(TOKEN, context, user);
+
+    // Precondition: the token really is in .git/config.
+    expect(await readGitConfig(repoDir)).toContain("x-access-token");
+
+    await cleanupGitAuth();
+
+    const config = await readGitConfig(repoDir);
+    expect(config).not.toContain("x-access-token");
+    expect(config).not.toContain(TOKEN);
+
+    const origin = (await $`git remote get-url origin`.quiet().text()).trim();
+    expect(origin).toBe(cleanUrl);
+  });
+
+  test("leaves origin usable for a later fetch-style operation", async () => {
+    await $`git remote set-url origin ${tokenUrl}`.quiet();
+
+    await cleanupGitAuth();
+
+    const origin = (await $`git remote get-url origin`.quiet().text()).trim();
+    expect(origin).toBe(cleanUrl);
+    expect(origin).not.toContain("@");
+  });
+
+  test("removes the credential helper and its script (non-write-user path)", async () => {
+    process.env.ALLOWED_NON_WRITE_USERS = "some-user";
+
+    await configureGitAuth(TOKEN, context, user);
+
+    const helperPath = getCredentialHelperPath();
+    expect(await fileExists(helperPath)).toBe(true);
+    // The non-write-user path deliberately keeps .git/config token-free.
+    expect(await readGitConfig(repoDir)).not.toContain(TOKEN);
+
+    await cleanupGitAuth();
+
+    const config = await readGitConfig(repoDir);
+    expect(config).not.toContain("x-access-token");
+    expect(config).not.toContain(TOKEN);
+    expect(config).not.toContain("helper");
+    expect(await fileExists(helperPath)).toBe(false);
+  });
+
+  test("leaves a credential helper set by the workflow alone", async () => {
+    await $`git config credential.helper store`.quiet();
+    await $`git remote set-url origin ${tokenUrl}`.quiet();
+
+    await cleanupGitAuth();
+
+    // Read local config only: the machine running the tests may have a global
+    // credential.helper of its own.
+    const helpers = (
+      await $`git config --local --get-all credential.helper`.quiet().text()
+    ).trim();
+    expect(helpers).toBe("store");
+    expect(helpers).not.toContain(getCredentialHelperPath());
+    expect(await readGitConfig(repoDir)).not.toContain("x-access-token");
+  });
+
+  test("is idempotent so a second invocation in the same job is safe", async () => {
+    await configureGitAuth(TOKEN, context, user);
+
+    await cleanupGitAuth();
+    await cleanupGitAuth();
+
+    const config = await readGitConfig(repoDir);
+    expect(config).not.toContain("x-access-token");
+    const origin = (await $`git remote get-url origin`.quiet().text()).trim();
+    expect(origin).toBe(cleanUrl);
+  });
+
+  test("does not rewrite an ssh remote", async () => {
+    const sshUrl = "git@github.com:anthropics/claude-code-action.git";
+    await $`git remote set-url origin ${sshUrl}`.quiet();
+
+    await cleanupGitAuth();
+
+    const origin = (await $`git remote get-url origin`.quiet().text()).trim();
+    expect(origin).toBe(sshUrl);
+  });
+
+  test("does not throw when there is no origin remote", async () => {
+    await $`git remote remove origin`.quiet();
+
+    await expect(cleanupGitAuth()).resolves.toBeUndefined();
+  });
+});
+
+describe("stripCredentialsFromRemoteUrl", () => {
+  test("removes an embedded token", () => {
+    expect(stripCredentialsFromRemoteUrl(tokenUrl)).toBe(cleanUrl);
+  });
+
+  test("returns null when there is nothing to strip", () => {
+    expect(stripCredentialsFromRemoteUrl(cleanUrl)).toBeNull();
+    expect(
+      stripCredentialsFromRemoteUrl(
+        "git@github.com:anthropics/claude-code-action.git",
+      ),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #1509.

When no `github_token` input is given, the action mints an app installation token and `configureGitAuth` embeds it in the origin remote URL. The final composite step revokes that token but never restores the URL, so the job ends with `origin` pointing at a dead credential. Any later git operation against `origin` fails with "Invalid username or token", most visibly a second invocation of this action, whose tag-mode `setupBranch` fetches before configuring its own auth. That second-invocation symptom is what #1236 reports, so this should close that one out too.

This adds a cleanup step next to the revoke step, under the same guard, that strips credentials from the origin URL, drops the credential helper this action configured, and deletes the helper script. Both auth branches are handled, and the cleanup is idempotent so running the action twice in one job is safe. The clean URL now comes from a shared helper used by both branches so the two paths cannot drift.

I kept the guard identical to the revoke step rather than making it unconditional. A user-supplied `github_token` stays valid after the run, and stripping it could break workflows that push to `origin` afterwards.

The cleanup rewrites whatever URL is actually configured rather than rebuilding one from event context, so a remote pointing somewhere other than the event repo is left intact. That is the concern #966 raises, so there is some overlap. Happy to rebase on it if you would rather land #966 first. Worth flagging too that #1526 edits the same region of `git-config.ts` for a different defect, so whichever lands second will need a rebase.

Tests cover both auth branches, the idempotency case, and assert the resulting `.git/config` carries no `x-access-token` and no dangling `credential.helper`. I checked they fail without the source change.
