### PR TITLE
fix: isolate inline comment buffers per run

### DIFF
--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * Reads buffered inline-comment calls from /tmp/inline-comments-buffer.jsonl,
+ * Reads buffered inline-comment calls from this workflow run's buffer,
  * classifies each as "real review" vs "test/probe" using Haiku, and posts
  * only the real ones. Calls with confirmed=false are never posted.
  *
@@ -9,10 +9,13 @@
  * preserves backward compatibility — before this change, all unconfirmed
  * calls posted immediately.
  */
-import { readFileSync } from "fs";
 import { createOctokit } from "../github/api/client";
+import {
+  consumeInlineCommentBuffer,
+  getInlineCommentBufferPath,
+} from "../mcp/inline-comment-buffer";
 
-const BUFFER_PATH = "/tmp/inline-comments-buffer.jsonl";
+const BUFFER_PATH = getInlineCommentBufferPath();
 
 type BufferedComment = {
   ts: string;
@@ -144,10 +147,8 @@ async function postComment(
 }
 
 async function main() {
-  let raw: string;
-  try {
-    raw = readFileSync(BUFFER_PATH, "utf8");
-  } catch {
+  const raw = consumeInlineCommentBuffer(BUFFER_PATH);
+  if (raw === undefined) {
     console.log("No buffered inline comments");
     return;
   }

--- a/src/mcp/github-inline-comment-server.ts
+++ b/src/mcp/github-inline-comment-server.ts
@@ -5,7 +5,10 @@ import { appendFileSync } from "fs";
 import { z } from "zod";
 import { createOctokit } from "../github/api/client";
 import { sanitizeContent } from "../github/utils/sanitizer";
-import { removeBufferedComment } from "./inline-comment-buffer";
+import {
+  getInlineCommentBufferPath,
+  removeBufferedComment,
+} from "./inline-comment-buffer";
 
 // Get repository and PR information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -16,7 +19,7 @@ const PR_NUMBER = process.env.PR_NUMBER;
 // prevents subagents from posting test/probe comments when they inherit this
 // tool and probe it after hitting unrelated errors. The action's post-step
 // reports the buffer count for diagnostics.
-const BUFFER_PATH = "/tmp/inline-comments-buffer.jsonl";
+const BUFFER_PATH = getInlineCommentBufferPath();
 const CLASSIFY_ENABLED = process.env.CLASSIFY_INLINE_COMMENTS !== "false";
 
 if (!REPO_OWNER || !REPO_NAME || !PR_NUMBER) {

--- a/src/mcp/inline-comment-buffer.ts
+++ b/src/mcp/inline-comment-buffer.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
 
 export type BufferedCommentMatch = {
   path: string;
@@ -6,6 +7,54 @@ export type BufferedCommentMatch = {
   startLine?: number;
   body: string;
 };
+
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_.-]/g, "_");
+}
+
+/**
+ * Return a buffer path scoped to one repository workflow run and attempt.
+ *
+ * Self-hosted runners can be reused by multiple repositories, so a fixed
+ * machine-wide path can replay another run's buffered review comments.
+ */
+export function getInlineCommentBufferPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const runnerTemp = env.RUNNER_TEMP || "/tmp";
+  const repository =
+    env.GITHUB_REPOSITORY ||
+    [env.REPO_OWNER, env.REPO_NAME].filter(Boolean).join("/") ||
+    "local";
+  const runId = env.GITHUB_RUN_ID || "local";
+  const runAttempt = env.GITHUB_RUN_ATTEMPT || "1";
+
+  return join(
+    runnerTemp,
+    `inline-comments-buffer-${sanitizePathSegment(repository)}-${sanitizePathSegment(runId)}-${sanitizePathSegment(runAttempt)}.jsonl`,
+  );
+}
+
+/**
+ * Read and remove a completed run's buffer before processing its contents.
+ *
+ * Removing the file immediately keeps stale comments from surviving parsing,
+ * classification, or posting failures.
+ */
+export function consumeInlineCommentBuffer(
+  bufferPath: string,
+): string | undefined {
+  try {
+    return readFileSync(bufferPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  } finally {
+    rmSync(bufferPath, { force: true });
+  }
+}
 
 /**
  * Remove any buffered inline comment that matches an already-posted comment.

--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -152,6 +152,11 @@ export async function prepareMcpConfig(
           REPO_NAME: repo,
           PR_NUMBER: context.entityNumber?.toString() || "",
           GITHUB_API_URL: GITHUB_API_URL,
+          RUNNER_TEMP: process.env.RUNNER_TEMP || "/tmp",
+          GITHUB_REPOSITORY:
+            process.env.GITHUB_REPOSITORY || `${owner}/${repo}`,
+          GITHUB_RUN_ID: process.env.GITHUB_RUN_ID || "",
+          GITHUB_RUN_ATTEMPT: process.env.GITHUB_RUN_ATTEMPT || "",
           CLASSIFY_INLINE_COMMENTS: context.inputs.classifyInlineComments
             ? "true"
             : "false",

--- a/test/inline-comment-buffer.test.ts
+++ b/test/inline-comment-buffer.test.ts
@@ -8,7 +8,63 @@ import {
 } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { removeBufferedComment } from "../src/mcp/inline-comment-buffer";
+import {
+  consumeInlineCommentBuffer,
+  getInlineCommentBufferPath,
+  removeBufferedComment,
+} from "../src/mcp/inline-comment-buffer";
+
+describe("getInlineCommentBufferPath", () => {
+  it("scopes the path by repository, workflow run, and attempt", () => {
+    expect(
+      getInlineCommentBufferPath({
+        RUNNER_TEMP: "/runner/temp",
+        GITHUB_REPOSITORY: "owner/repo",
+        GITHUB_RUN_ID: "12345",
+        GITHUB_RUN_ATTEMPT: "2",
+      }),
+    ).toBe(
+      join("/runner/temp", "inline-comments-buffer-owner_repo-12345-2.jsonl"),
+    );
+  });
+
+  it("uses the MCP repository environment when GITHUB_REPOSITORY is absent", () => {
+    const path = getInlineCommentBufferPath({
+      RUNNER_TEMP: "/runner/temp",
+      REPO_OWNER: "other-owner",
+      REPO_NAME: "other-repo",
+      GITHUB_RUN_ID: "12345",
+      GITHUB_RUN_ATTEMPT: "1",
+    });
+
+    expect(path).toContain("inline-comments-buffer-other-owner_other-repo-");
+  });
+});
+
+describe("consumeInlineCommentBuffer", () => {
+  let dir: string;
+  let bufferPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "inline-buffer-consume-"));
+    bufferPath = join(dir, "buffer.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns the contents and removes the buffer", () => {
+    writeFileSync(bufferPath, '{"body":"Comment"}\n');
+
+    expect(consumeInlineCommentBuffer(bufferPath)).toBe('{"body":"Comment"}\n');
+    expect(existsSync(bufferPath)).toBe(false);
+  });
+
+  it("returns undefined when the buffer does not exist", () => {
+    expect(consumeInlineCommentBuffer(bufferPath)).toBeUndefined();
+  });
+});
 
 describe("removeBufferedComment", () => {
   let dir: string;

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -155,6 +155,11 @@ describe("prepareMcpConfig", () => {
   });
 
   test("should include inline comment server for PRs when tools are allowed", async () => {
+    process.env.RUNNER_TEMP = "/runner/temp";
+    process.env.GITHUB_REPOSITORY = "test-owner/test-repo";
+    process.env.GITHUB_RUN_ID = "12345";
+    process.env.GITHUB_RUN_ATTEMPT = "2";
+
     const result = await prepareMcpConfig({
       githubToken: "test-token",
       owner: "test-owner",
@@ -173,6 +178,23 @@ describe("prepareMcpConfig", () => {
       "test-token",
     );
     expect(parsed.mcpServers.github_inline_comment.env.PR_NUMBER).toBe("456");
+    expect(parsed.mcpServers.github_inline_comment.env.RUNNER_TEMP).toBe(
+      "/runner/temp",
+    );
+    expect(parsed.mcpServers.github_inline_comment.env.GITHUB_REPOSITORY).toBe(
+      "test-owner/test-repo",
+    );
+    expect(parsed.mcpServers.github_inline_comment.env.GITHUB_RUN_ID).toBe(
+      "12345",
+    );
+    expect(parsed.mcpServers.github_inline_comment.env.GITHUB_RUN_ATTEMPT).toBe(
+      "2",
+    );
+
+    delete process.env.RUNNER_TEMP;
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.GITHUB_RUN_ID;
+    delete process.env.GITHUB_RUN_ATTEMPT;
   });
 
   test("should include comment server when no GitHub tools are allowed and signing disabled", async () => {


### PR DESCRIPTION
Fixes #1542.

Inline review comments were buffered at a fixed machine-wide path. On a reused self-hosted runner, a later workflow could therefore consume comments left by another run or repository.

This change scopes the buffer path by repository, workflow run, and attempt under `RUNNER_TEMP`, and passes that scope to the inline-comment MCP server explicitly. The post step consumes and removes the buffer before classification or posting so failures cannot leave it behind for another run.

Regression coverage verifies the scoped path, MCP environment propagation, and buffer cleanup.

Checks:
- `bun test` (808 tests)
- `bun run typecheck`
- `bun run format:check`
