### PR TITLE
fix: merge MCP config files with built-in servers

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -1,4 +1,5 @@
 import { parse as parseShellArgs } from "shell-quote";
+import { readFileSync } from "fs";
 import type { ClaudeOptions } from "./run-claude";
 import type { Options as SdkOptions } from "@anthropic-ai/claude-agent-sdk";
 
@@ -61,50 +62,23 @@ type McpConfig = {
 /**
  * Merge multiple MCP config values into a single config.
  * Each config can be a JSON string or a file path.
- * For JSON strings, mcpServers objects are merged.
- * For file paths, they are kept as-is (user's file takes precedence and is used last).
+ * Configs are applied in order, so later servers override earlier ones.
  */
 function mergeMcpConfigs(configValues: string[]): string {
   const merged: McpConfig = { mcpServers: {} };
-  let lastFilePath: string | null = null;
 
   for (const config of configValues) {
     const trimmed = config.trim();
     if (!trimmed) continue;
 
-    // Check if it's a JSON string (starts with {) or a file path
-    if (trimmed.startsWith("{")) {
-      try {
-        const parsed = JSON.parse(trimmed) as McpConfig;
-        if (parsed.mcpServers) {
-          Object.assign(merged.mcpServers!, parsed.mcpServers);
-        }
-      } catch {
-        // If JSON parsing fails, treat as file path
-        lastFilePath = trimmed;
-      }
-    } else {
-      // It's a file path - store it to handle separately
-      lastFilePath = trimmed;
+    const content = trimmed.startsWith("{")
+      ? trimmed
+      : readFileSync(trimmed, "utf8");
+    const parsed = JSON.parse(content) as McpConfig;
+    if (parsed.mcpServers) {
+      Object.assign(merged.mcpServers!, parsed.mcpServers);
     }
   }
-
-  // If we have file paths, we need to keep the merged JSON and let the file
-  // be handled separately. Since we can only return one value, merge what we can.
-  // If there's a file path, we need a different approach - read the file at runtime.
-  // For now, if there's a file path, we'll stringify the merged config.
-  // The action prepends its config as JSON, so we can safely merge inline JSON configs.
-
-  // If no inline configs were found (all file paths), return the last file path
-  if (Object.keys(merged.mcpServers!).length === 0 && lastFilePath) {
-    return lastFilePath;
-  }
-
-  // Note: If user passes a file path, we cannot merge it at parse time since
-  // we don't have access to the file system here. The action's built-in MCP
-  // servers are always passed as inline JSON, so they will be merged.
-  // If user also passes inline JSON, it will be merged.
-  // If user passes a file path, they should ensure it includes all needed servers.
 
   return JSON.stringify(merged);
 }

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env bun
 
 import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { parseSdkOptions } from "../src/parse-sdk-options";
 import type { ClaudeOptions } from "../src/run-claude";
 
@@ -338,21 +341,34 @@ describe("parseSdkOptions", () => {
       );
     });
 
-    test("should merge inline JSON configs when file path is also present", () => {
-      // When action provides inline JSON and user provides a file path,
-      // the inline JSON configs should be merged (file paths cannot be merged at parse time)
-      const options: ClaudeOptions = {
-        claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config '{"mcpServers":{"github_ci":{"command":"node"}}}' --mcp-config /tmp/user-config.json`,
-      };
+    test("should merge a file-path config with inline configs", () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "mcp-config-test-"));
+      const configPath = join(tempDir, "user-config.json");
 
-      const result = parseSdkOptions(options);
+      try {
+        writeFileSync(
+          configPath,
+          JSON.stringify({
+            mcpServers: {
+              user_server: { command: "custom", args: ["run"] },
+            },
+          }),
+        );
+        const options: ClaudeOptions = {
+          claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config '${configPath}'`,
+        };
 
-      // The inline JSON configs should be merged
-      const mcpConfig = JSON.parse(
-        result.sdkOptions.extraArgs?.["mcp-config"] as string,
-      );
-      expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
-      expect(mcpConfig.mcpServers).toHaveProperty("github_ci");
+        const result = parseSdkOptions(options);
+        const mcpConfig = JSON.parse(
+          result.sdkOptions.extraArgs?.["mcp-config"] as string,
+        );
+
+        expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
+        expect(mcpConfig.mcpServers).toHaveProperty("user_server");
+        expect(mcpConfig.mcpServers.user_server.command).toBe("custom");
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
     });
 
     test("should handle mcp-config with other flags", () => {


### PR DESCRIPTION
Fixes #1544.

When the action prepends its built-in MCP config, a later `--mcp-config <file>` is currently remembered but never included in the merged value. The user's servers therefore disappear without an error while the built-in servers still work.

This reads file-path configs when multiple MCP configs need to be combined and merges their `mcpServers` in argument order, preserving the existing later-value precedence. A regression test exercises the built-in inline config plus user file-path case.

Tests:
- `bun test` (804 passed)
- `bun run typecheck`
- `bun run format:check`