### PR TITLE
fix: expose conclusion as a root action output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -167,6 +167,9 @@ inputs:
     default: ""
 
 outputs:
+  conclusion:
+    description: "Execution status of Claude Code ('success' or 'failure')"
+    value: ${{ steps.run.outputs.conclusion }}
   execution_file:
     description: "Path to the Claude Code execution output file"
     value: ${{ steps.run.outputs.execution_file }}

--- a/test/action-metadata.test.ts
+++ b/test/action-metadata.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+
+describe("action metadata", () => {
+  test("should expose the conclusion output from the run step", () => {
+    const metadata = readFileSync(
+      new URL("../action.yml", import.meta.url),
+      "utf8",
+    );
+
+    expect(metadata).toMatch(
+      /^  conclusion:\n    description: .+\n    value: \$\{\{ steps\.run\.outputs\.conclusion \}\}$/m,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The unified entrypoint sets `core.setOutput("conclusion", claudeResult.conclusion)`, but the root `action.yml` does not declare or forward that output. Callers therefore cannot reliably consume `steps.<id>.outputs.conclusion`, even though the internal `run` step produces it.

This adds the missing public output mapping:

```yaml
conclusion:
  description: "Execution status of Claude Code ('success' or 'failure')"
  value: ${{ steps.run.outputs.conclusion }}
```

`base-action/action.yml` already exposes the same output, so this also makes the root and standalone action interfaces consistent.

## Regression coverage

Adds a focused metadata test that checks the root output forwards `steps.run.outputs.conclusion`. This catches future drift between outputs set by the entrypoint and outputs exposed by the composite action.

## Verification

- `bun test`: 805 pass, 0 fail
- `bun run typecheck`: clean
- `bunx prettier --check action.yml test/action-metadata.test.ts`: clean
- `git diff --check`: clean