### PR TITLE
fix(mcp): stop retrying deterministic reference update failures

### DIFF
--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -8,8 +8,8 @@ import { resolve } from "path";
 import { constants } from "fs";
 import fetch from "node-fetch";
 import { GITHUB_API_URL } from "../github/api/config";
-import { retryWithBackoff } from "../utils/retry";
 import { validatePathWithinRepo } from "./path-validation";
+import { updateGitReference } from "./update-git-reference";
 
 type GitHubRef = {
   object: {
@@ -365,57 +365,13 @@ server.tool(
       const newCommitData = (await newCommitResponse.json()) as GitHubNewCommit;
 
       // 6. Update the reference to point to the new commit
-      const updateRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`;
-
-      // We're seeing intermittent 403 "Resource not accessible by integration" errors
-      // on certain repos when updating git references. These appear to be transient
-      // GitHub API issues that succeed on retry.
-      await retryWithBackoff(
-        async () => {
-          const updateRefResponse = await fetch(updateRefUrl, {
-            method: "PATCH",
-            headers: {
-              Accept: "application/vnd.github+json",
-              Authorization: `Bearer ${githubToken}`,
-              "X-GitHub-Api-Version": "2022-11-28",
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              sha: newCommitData.sha,
-              force: false,
-            }),
-          });
-
-          if (!updateRefResponse.ok) {
-            const errorText = await updateRefResponse.text();
-
-            // Provide a more helpful error message for 403 permission errors
-            if (updateRefResponse.status === 403) {
-              const permissionError = new Error(
-                `Permission denied: Unable to push commits to branch '${branch}'. ` +
-                  `Please rebase your branch from the main/master branch to allow Claude to commit.\n\n` +
-                  `Original error: ${errorText}`,
-              );
-              throw permissionError;
-            }
-
-            // For other errors, use the original message
-            const error = new Error(
-              `Failed to update reference: ${updateRefResponse.status} - ${errorText}`,
-            );
-
-            // For non-403 errors, fail immediately without retry
-            console.error("Non-retryable error:", updateRefResponse.status);
-            throw error;
-          }
-        },
-        {
-          maxAttempts: 3,
-          initialDelayMs: 1000, // Start with 1 second delay
-          maxDelayMs: 5000, // Max 5 seconds delay
-          backoffFactor: 2, // Double the delay each time
-        },
-      );
+      await updateGitReference({
+        owner,
+        repo,
+        branch,
+        sha: newCommitData.sha,
+        githubToken,
+      });
 
       const simplifiedResult = {
         commit: {
@@ -580,58 +536,13 @@ server.tool(
       const newCommitData = (await newCommitResponse.json()) as GitHubNewCommit;
 
       // 6. Update the reference to point to the new commit
-      const updateRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`;
-
-      // We're seeing intermittent 403 "Resource not accessible by integration" errors
-      // on certain repos when updating git references. These appear to be transient
-      // GitHub API issues that succeed on retry.
-      await retryWithBackoff(
-        async () => {
-          const updateRefResponse = await fetch(updateRefUrl, {
-            method: "PATCH",
-            headers: {
-              Accept: "application/vnd.github+json",
-              Authorization: `Bearer ${githubToken}`,
-              "X-GitHub-Api-Version": "2022-11-28",
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              sha: newCommitData.sha,
-              force: false,
-            }),
-          });
-
-          if (!updateRefResponse.ok) {
-            const errorText = await updateRefResponse.text();
-
-            // Provide a more helpful error message for 403 permission errors
-            if (updateRefResponse.status === 403) {
-              console.log("Received 403 error, will retry...");
-              const permissionError = new Error(
-                `Permission denied: Unable to push commits to branch '${branch}'. ` +
-                  `Please rebase your branch from the main/master branch to allow Claude to commit.\n\n` +
-                  `Original error: ${errorText}`,
-              );
-              throw permissionError;
-            }
-
-            // For other errors, use the original message
-            const error = new Error(
-              `Failed to update reference: ${updateRefResponse.status} - ${errorText}`,
-            );
-
-            // For non-403 errors, fail immediately without retry
-            console.error("Non-retryable error:", updateRefResponse.status);
-            throw error;
-          }
-        },
-        {
-          maxAttempts: 3,
-          initialDelayMs: 1000, // Start with 1 second delay
-          maxDelayMs: 5000, // Max 5 seconds delay
-          backoffFactor: 2, // Double the delay each time
-        },
-      );
+      await updateGitReference({
+        owner,
+        repo,
+        branch,
+        sha: newCommitData.sha,
+        githubToken,
+      });
 
       const simplifiedResult = {
         commit: {

--- a/src/mcp/update-git-reference.ts
+++ b/src/mcp/update-git-reference.ts
@@ -1,0 +1,90 @@
+import fetch, { type RequestInit, type Response } from "node-fetch";
+import { GITHUB_API_URL } from "../github/api/config";
+import { retryWithBackoff, type RetryOptions } from "../utils/retry";
+
+type GitHubFetch = (
+  url: string,
+  init: RequestInit,
+) => Promise<Pick<Response, "ok" | "status" | "text">>;
+
+type UpdateGitReferenceOptions = {
+  owner: string;
+  repo: string;
+  branch: string;
+  sha: string;
+  githubToken: string;
+  fetchFn?: GitHubFetch;
+  retryOptions?: Omit<RetryOptions, "shouldRetry">;
+};
+
+class GitReferenceUpdateError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GitReferenceUpdateError";
+  }
+}
+
+function shouldRetryGitReferenceUpdate(error: Error): boolean {
+  if (!(error instanceof GitReferenceUpdateError)) {
+    return true;
+  }
+
+  return error.status === 403 || error.status === 429 || error.status >= 500;
+}
+
+export async function updateGitReference({
+  owner,
+  repo,
+  branch,
+  sha,
+  githubToken,
+  fetchFn = fetch,
+  retryOptions,
+}: UpdateGitReferenceOptions): Promise<void> {
+  const updateRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`;
+
+  await retryWithBackoff(
+    async () => {
+      const response = await fetchFn(updateRefUrl, {
+        method: "PATCH",
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${githubToken}`,
+          "X-GitHub-Api-Version": "2022-11-28",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ sha, force: false }),
+      });
+
+      if (response.ok) {
+        return;
+      }
+
+      const errorText = await response.text();
+      if (response.status === 403) {
+        throw new GitReferenceUpdateError(
+          response.status,
+          `Permission denied: Unable to push commits to branch '${branch}'. ` +
+            `Please rebase your branch from the main/master branch to allow Claude to commit.\n\n` +
+            `Original error: ${errorText}`,
+        );
+      }
+
+      throw new GitReferenceUpdateError(
+        response.status,
+        `Failed to update reference: ${response.status} - ${errorText}`,
+      );
+    },
+    {
+      maxAttempts: 3,
+      initialDelayMs: 1000,
+      maxDelayMs: 5000,
+      backoffFactor: 2,
+      ...retryOptions,
+      shouldRetry: shouldRetryGitReferenceUpdate,
+    },
+  );
+}

--- a/test/update-git-reference.test.ts
+++ b/test/update-git-reference.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+import { GITHUB_API_URL } from "../src/github/api/config";
+import { updateGitReference } from "../src/mcp/update-git-reference";
+
+const reference = {
+  owner: "owner",
+  repo: "repo",
+  branch: "feature",
+  sha: "abc123",
+  githubToken: "token",
+};
+
+function response(status: number) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => "response body",
+  };
+}
+
+describe("updateGitReference", () => {
+  it("should patch the branch reference", async () => {
+    await updateGitReference({
+      ...reference,
+      fetchFn: async (url, init) => {
+        expect(url).toBe(
+          `${GITHUB_API_URL}/repos/owner/repo/git/refs/heads/feature`,
+        );
+        expect(init.method).toBe("PATCH");
+        expect(init.headers).toMatchObject({ Authorization: "Bearer token" });
+        expect(JSON.parse(String(init.body))).toEqual({
+          sha: "abc123",
+          force: false,
+        });
+        return response(200);
+      },
+    });
+  });
+
+  it("should not retry deterministic client errors", async () => {
+    for (const status of [400, 404, 409, 422]) {
+      let attempts = 0;
+
+      await expect(
+        updateGitReference({
+          ...reference,
+          fetchFn: async () => {
+            attempts++;
+            return response(status);
+          },
+          retryOptions: { initialDelayMs: 1 },
+        }),
+      ).rejects.toThrow(`Failed to update reference: ${status}`);
+
+      expect(attempts).toBe(1);
+    }
+  });
+
+  it("should retry transient HTTP errors", async () => {
+    for (const status of [403, 429, 500]) {
+      let attempts = 0;
+
+      await updateGitReference({
+        ...reference,
+        fetchFn: async () => response(attempts++ === 0 ? status : 200),
+        retryOptions: { initialDelayMs: 1 },
+      });
+
+      expect(attempts).toBe(2);
+    }
+  });
+
+  it("should retry network errors", async () => {
+    let attempts = 0;
+
+    await updateGitReference({
+      ...reference,
+      fetchFn: async () => {
+        attempts++;
+        if (attempts === 1) {
+          throw new Error("network error");
+        }
+        return response(200);
+      },
+      retryOptions: { initialDelayMs: 1 },
+    });
+
+    expect(attempts).toBe(2);
+  });
+});


### PR DESCRIPTION
## Problem

Both `commit_files` and `delete_files` label non-403 Git reference update failures as non-retryable, then throw a plain `Error` into `retryWithBackoff` without a `shouldRetry` predicate. The retry helper therefore performs all three PATCH attempts anyway.

Deterministic responses such as 400, 404, 409, and 422 incur repeated API calls and 3 seconds of backoff even though the request cannot succeed unchanged. The logs also say the error is non-retryable while immediately scheduling another attempt.

## Fix

Extract the duplicated reference PATCH into a shared `updateGitReference` helper and attach the HTTP status to a dedicated error type. The helper now applies one retry policy to both operations:

- Retry network failures, 403, 429, and 5xx responses.
- Fail immediately for other 4xx responses.
- Preserve the existing detailed 403 permission message.

This keeps the retry behavior for transient failures while avoiding repeated deterministic requests.

## Relationship to #1036

#1036 reports the same symptom, but it predates the `shouldRetry` API merged in #1082 and now conflicts with `main`. It also treats every non-403 response, including 429 and 5xx, as permanent. This PR uses the current retry API, preserves transient HTTP retries, removes the duplicated implementation, and adds regression coverage.

## Tests

The new tests verify:

- PATCH URL, method, authorization header, SHA, and `force: false`.
- 400, 404, 409, and 422 stop after one request.
- 403, 429, and 500 retry and recover.
- Network errors retry and recover.

## Verification

- `bun test`: 808 pass, 0 fail
- `bun run typecheck`: clean
- `bunx prettier --check src/mcp/github-file-ops-server.ts src/mcp/update-git-reference.ts test/update-git-reference.test.ts`: clean
- `git diff --check`: clean