### PR TITLE
ci: pass base-action tool restrictions through claude_args

### DIFF
--- a/.github/workflows/test-base-action.yml
+++ b/.github/workflows/test-base-action.yml
@@ -31,7 +31,7 @@ jobs:
           anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
           anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
           anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
-          allowed_tools: "LS,Read"
+          claude_args: '--allowedTools "LS,Read"'
 
       - name: Verify inline prompt output
         run: |
@@ -90,7 +90,7 @@ jobs:
           anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
           anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
           anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
-          allowed_tools: "LS,Read"
+          claude_args: '--allowedTools "LS,Read"'
 
       - name: Verify prompt file output
         run: |

--- a/.github/workflows/test-custom-executables.yml
+++ b/.github/workflows/test-custom-executables.yml
@@ -59,7 +59,7 @@ jobs:
           anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
           path_to_claude_code_executable: /home/runner/.local/bin/claude
           path_to_bun_executable: /home/runner/.bun/bin/bun
-          allowed_tools: "LS,Read"
+          claude_args: '--allowedTools "LS,Read"'
 
       - name: Verify custom executables worked
         run: |


### PR DESCRIPTION
## Summary

Three repository integration steps still pass `allowed_tools: "LS,Read"` to `./base-action`, even though that input was removed during the v1 simplification. The current metadata only forwards `claude_args` through `INPUT_CLAUDE_ARGS`.

GitHub Actions can warn about the unexpected input and continue, so these workflows may stay green while running without the tool restriction they claim to test.

## Change

Replace the unsupported input with the equivalent current configuration:

```yaml
claude_args: '--allowedTools "LS,Read"'
```

This updates:

- the inline prompt integration test
- the prompt file integration test
- the custom executable integration test

The patch is limited to those three input lines.

## Verification

- Confirmed `base-action/action.yml` forwards `claude_args` to `INPUT_CLAUDE_ARGS`.
- `bun test base-action/test/parse-shell-args.test.ts test/modes/parse-tools.test.ts`: 26 pass, 0 fail
- `bunx prettier --check .github/workflows/test-base-action.yml .github/workflows/test-custom-executables.yml`: clean
- `git diff --check`: clean