### PR TITLE
fix: respect configured base URL and model in inline comment classifier

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -426,6 +426,9 @@ runs:
         REPO_NAME: ${{ github.event.repository.name }}
         PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        ANTHROPIC_BASE_URL: ${{ env.ANTHROPIC_BASE_URL }}
+        ANTHROPIC_MODEL: ${{ env.ANTHROPIC_MODEL }}
+        CLAUDE_ARGS: ${{ inputs.claude_args }}
       run: |
         BUN_BIN="${GITHUB_ACTION_PATH}/bin/bun"
         [ -x "$BUN_BIN" ] || BUN_BIN="bun"

--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env bun
 /**
  * Reads buffered inline-comment calls from /tmp/inline-comments-buffer.jsonl,
- * classifies each as "real review" vs "test/probe" using Haiku, and posts
- * only the real ones. Calls with confirmed=false are never posted.
+ * classifies each as "real review" vs "test/probe" using the configured model,
+ * and posts only the real ones. Calls with confirmed=false are never posted.
  *
  * If the Anthropic API is unavailable (Bedrock/Vertex users without a direct
  * key), falls back to posting everything with confirmed !== false. This
@@ -10,6 +10,7 @@
  * calls posted immediately.
  */
 import { readFileSync } from "fs";
+import { parse as parseShellArgs } from "shell-quote";
 import { createOctokit } from "../github/api/client";
 
 const BUFFER_PATH = "/tmp/inline-comments-buffer.jsonl";
@@ -42,7 +43,57 @@ For each numbered comment body below, respond with ONLY a JSON array of booleans
 Comments:
 `;
 
-async function classifyComments(bodies: string[]): Promise<boolean[] | null> {
+export function getAnthropicMessagesUrl(
+  baseUrl = process.env.ANTHROPIC_BASE_URL,
+): string {
+  const resolvedBaseUrl = baseUrl?.trim() || "https://api.anthropic.com";
+  return `${resolvedBaseUrl.replace(/\/+$/, "")}/v1/messages`;
+}
+
+function stripShellComments(input: string): string {
+  return input
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("#"))
+    .join("\n");
+}
+
+export function getClassificationModel(): string {
+  const envModel = process.env.ANTHROPIC_MODEL?.trim();
+  if (envModel) {
+    return envModel;
+  }
+
+  const claudeArgs = process.env.CLAUDE_ARGS?.trim();
+  if (claudeArgs) {
+    const args = parseShellArgs(stripShellComments(claudeArgs))
+      .map((arg) => {
+        if (typeof arg === "string") return arg;
+        if (typeof arg === "object" && arg !== null && "pattern" in arg) {
+          return (arg as { pattern: string }).pattern;
+        }
+        return undefined;
+      })
+      .filter((arg): arg is string => typeof arg === "string");
+
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === "--model" && i + 1 < args.length) {
+        const model = args[i + 1];
+        if (model && !model.startsWith("--")) {
+          return model;
+        }
+      }
+      if (args[i]?.startsWith("--model=")) {
+        return args[i]!.slice("--model=".length);
+      }
+    }
+  }
+
+  return "claude-haiku-4-5";
+}
+
+export async function classifyComments(
+  bodies: string[],
+): Promise<boolean[] | null> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     console.log(
@@ -56,7 +107,7 @@ async function classifyComments(bodies: string[]): Promise<boolean[] | null> {
     bodies.map((b, i) => `${i + 1}. ${JSON.stringify(b)}`).join("\n");
 
   try {
-    const res = await fetch("https://api.anthropic.com/v1/messages", {
+    const res = await fetch(getAnthropicMessagesUrl(), {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -64,7 +115,7 @@ async function classifyComments(bodies: string[]): Promise<boolean[] | null> {
         "anthropic-version": "2023-06-01",
       },
       body: JSON.stringify({
-        model: "claude-haiku-4-5",
+        model: getClassificationModel(),
         max_tokens: 1024,
         messages: [{ role: "user", content: prompt }],
       }),

--- a/test/post-buffered-inline-comments.test.ts
+++ b/test/post-buffered-inline-comments.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  classifyComments,
+  getAnthropicMessagesUrl,
+  getClassificationModel,
+} from "../src/entrypoints/post-buffered-inline-comments";
+
+describe("post-buffered-inline-comments", () => {
+  let originalAnthropicApiKey: string | undefined;
+  let originalAnthropicBaseUrl: string | undefined;
+  let originalAnthropicModel: string | undefined;
+  let originalClaudeArgs: string | undefined;
+  let fetchSpy: ReturnType<typeof spyOn> | undefined;
+
+  beforeEach(() => {
+    originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+    originalAnthropicBaseUrl = process.env.ANTHROPIC_BASE_URL;
+    originalAnthropicModel = process.env.ANTHROPIC_MODEL;
+    originalClaudeArgs = process.env.CLAUDE_ARGS;
+
+    process.env.ANTHROPIC_API_KEY = "test-api-key";
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_MODEL;
+    delete process.env.CLAUDE_ARGS;
+
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "[true]" }],
+      }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    if (originalAnthropicApiKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
+    }
+
+    if (originalAnthropicBaseUrl === undefined) {
+      delete process.env.ANTHROPIC_BASE_URL;
+    } else {
+      process.env.ANTHROPIC_BASE_URL = originalAnthropicBaseUrl;
+    }
+
+    if (originalAnthropicModel === undefined) {
+      delete process.env.ANTHROPIC_MODEL;
+    } else {
+      process.env.ANTHROPIC_MODEL = originalAnthropicModel;
+    }
+
+    if (originalClaudeArgs === undefined) {
+      delete process.env.CLAUDE_ARGS;
+    } else {
+      process.env.CLAUDE_ARGS = originalClaudeArgs;
+    }
+
+    fetchSpy?.mockRestore();
+  });
+
+  test("uses the default Anthropic messages endpoint", () => {
+    expect(getAnthropicMessagesUrl()).toBe(
+      "https://api.anthropic.com/v1/messages",
+    );
+  });
+
+  test("trims trailing slashes from ANTHROPIC_BASE_URL", async () => {
+    process.env.ANTHROPIC_BASE_URL = "https://proxy.example.com/anthropic/";
+
+    await classifyComments(["This catches a bug in the changed branch."]);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://proxy.example.com/anthropic/v1/messages",
+      expect.any(Object),
+    );
+  });
+
+  test("prefers ANTHROPIC_MODEL over claude args", () => {
+    process.env.ANTHROPIC_MODEL = "MiniMax-M2.7";
+    process.env.CLAUDE_ARGS = '--model "MiniMax-M3"';
+
+    expect(getClassificationModel()).toBe("MiniMax-M2.7");
+  });
+
+  test("reads the model from claude args when ANTHROPIC_MODEL is unset", async () => {
+    process.env.CLAUDE_ARGS = '# comment\n--model "MiniMax-M3" --max-turns 1';
+
+    await classifyComments(["This catches a bug in the changed branch."]);
+
+    const requestBody = JSON.parse(
+      String((fetchSpy?.mock.calls[0]?.[1] as { body: string }).body),
+    ) as { model: string };
+    expect(requestBody.model).toBe("MiniMax-M3");
+  });
+});


### PR DESCRIPTION
Reason: The inline comment classifier must use the configured Anthropic-compatible base URL and model instead of hardcoded defaults.

Changes:
- Resolved the classification endpoint from `ANTHROPIC_BASE_URL`.
- Resolved the classification model from `ANTHROPIC_MODEL` or `CLAUDE_ARGS`.
- Passed the relevant env vars into the post-buffered inline comments step.
- Added tests for the default URL, custom base URL, and model selection.

Checks:
- `~/.bun/bin/bun test test/post-buffered-inline-comments.test.ts`
- `~/.bun/bin/bun run typecheck`
- `~/.bun/bin/bun run format:check`
- `git diff --check`
