### PR TITLE
fix: parse claude args with shell parser

### DIFF
--- a/base-action/bun.lock
+++ b/base-action/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@anthropic-ai/claude-agent-sdk": "^0.3.220",
-        "unbash": "^4.0.3",
+        "unbash": "^4.0.5",
       },
       "devDependencies": {
         "@types/bun": "^1.2.12",
@@ -243,7 +243,7 @@
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
-    "unbash": ["unbash@4.0.3", "", {}, "sha512-3cudTErfToSc4Ggv8XGXVNVli/xHKUtUZvaY5UVwhOcUPbQGz7PeaEnT/SAVgNziZtX67KEN9swMUYkLghxA1w=="],
+    "unbash": ["unbash@4.0.5", "", {}, "sha512-EE9xv9cr93DSppe086Rnbq0jwG7MBCEe22JZ4UQ8Bn9RyUwDSoUpBmzdb5+7PzocdqBEb/K73FGPaQUMmLxTQQ=="],
 
     "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 

--- a/base-action/bun.lock
+++ b/base-action/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@anthropic-ai/claude-agent-sdk": "^0.3.220",
-        "shell-quote": "^1.8.3",
+        "unbash": "^4.0.3",
       },
       "devDependencies": {
         "@types/bun": "^1.2.12",
@@ -223,8 +223,6 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
-
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
@@ -244,6 +242,8 @@
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "unbash": ["unbash@4.0.3", "", {}, "sha512-3cudTErfToSc4Ggv8XGXVNVli/xHKUtUZvaY5UVwhOcUPbQGz7PeaEnT/SAVgNziZtX67KEN9swMUYkLghxA1w=="],
 
     "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 

--- a/base-action/package.json
+++ b/base-action/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@anthropic-ai/claude-agent-sdk": "^0.3.220",
-    "unbash": "^4.0.3"
+    "unbash": "^4.0.5"
   },
   "devDependencies": {
     "@types/bun": "^1.2.12",

--- a/base-action/package.json
+++ b/base-action/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@anthropic-ai/claude-agent-sdk": "^0.3.220",
-    "shell-quote": "^1.8.3"
+    "unbash": "^4.0.3"
   },
   "devDependencies": {
     "@types/bun": "^1.2.12",

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -117,9 +117,26 @@ function mergeMcpConfigs(configValues: string[]): string {
  *
  * src/modes/agent/parse-tools.ts reads the same input to decide which MCP
  * servers to install, so it shares this tokenizer (#1357).
+ *
+ * A malformed value is reported rather than tokenized on a best effort basis:
+ * an unterminated quote silently swallows every following flag, which would
+ * otherwise grant a tool nobody asked for and drop the flags after it.
  */
 export function splitClaudeArgs(claudeArgs: string): string[] {
   const script = parseShell(escapeShellMeta(claudeArgs));
+
+  const error = script.errors?.[0];
+  if (error) {
+    // escapeShellMeta substitutes one character for one character, so the
+    // reported position still points into the original claude_args.
+    const excerpt = claudeArgs.slice(error.pos, error.pos + 40).split("\n")[0];
+    throw new Error(
+      `Could not parse claude_args: ${error.message} at position ${error.pos}` +
+        (excerpt ? ` near \`${excerpt}\`` : "") +
+        ". Values containing spaces or shell characters need quoting.",
+    );
+  }
+
   const words: string[] = [];
 
   for (const statement of script.commands) {

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -1,4 +1,4 @@
-import { parse as parseShellArgs } from "shell-quote";
+import { parse as parseShell } from "unbash";
 import type { ClaudeOptions } from "./run-claude";
 import type { Options as SdkOptions } from "@anthropic-ai/claude-agent-sdk";
 
@@ -25,13 +25,12 @@ const ACCUMULATING_FLAGS = new Set([
 // Delimiter used to join accumulated flag values
 const ACCUMULATE_DELIMITER = "\x00";
 
-// shell-quote treats ()|&;<> as control operators and splits adjacent text
-// around them into separate tokens (returned as `{op}` objects, which we then
-// dropped). For CLI args these must be literal characters — e.g. unquoted
-// `--allowedTools Bash(gh:*)` was being mangled into bare `Bash`, silently
-// widening a scoped permission rule to Bash(*). We escape each metachar to a
-// Unicode private-use codepoint before parsing and restore it afterward,
-// keeping shell-quote's quote/whitespace handling intact.
+// ()|&;<> are control operators in shell grammar, so a parser splits adjacent
+// text around them. For CLI args these must be literal characters — e.g.
+// unquoted `--allowedTools Bash(gh:*)` was being mangled into bare `Bash`,
+// silently widening a scoped permission rule to Bash(*). We escape each
+// metachar to a Unicode private-use codepoint before parsing and restore it
+// afterward, keeping quote and whitespace handling intact.
 const SHELL_META_PAIRS: [string, string][] = [
   ["(", ""],
   [")", ""],
@@ -110,17 +109,30 @@ function mergeMcpConfigs(configValues: string[]): string {
 }
 
 /**
- * Strip comment lines from a shell argument string.
- * Lines whose first non-whitespace character is `#` are removed entirely.
- * Inline `#` within a line (e.g. inside a quoted value) is left untouched
- * because shell-quote handles quoting — we only need to remove full comment lines
- * before shell-quote sees them.
+ * Split a claude_args string into words the way a shell would.
+ *
+ * Quoting, comments and line continuations are all resolved by the grammar, so
+ * a `#` inside a quoted value stays part of that value, and a trailing `\`
+ * joins the following line instead of producing an empty argument.
+ *
+ * src/modes/agent/parse-tools.ts reads the same input to decide which MCP
+ * servers to install, so it shares this tokenizer (#1357).
  */
-function stripShellComments(input: string): string {
-  return input
-    .split("\n")
-    .filter((line) => !line.trim().startsWith("#"))
-    .join("\n");
+export function splitClaudeArgs(claudeArgs: string): string[] {
+  const script = parseShell(escapeShellMeta(claudeArgs));
+  const words: string[] = [];
+
+  for (const statement of script.commands) {
+    const command = statement.command;
+    if (command.type !== "Command") continue;
+
+    // A leading `FOO=bar` parses as an assignment prefix rather than a word.
+    for (const assignment of command.prefix) words.push(assignment.text);
+    if (command.name) words.push(command.name.value);
+    for (const word of command.suffix) words.push(word.value);
+  }
+
+  return words.map(unescapeShellMeta);
 }
 
 /**
@@ -136,19 +148,7 @@ function parseClaudeArgsToExtraArgs(
   if (!claudeArgs?.trim()) return {};
 
   const result: Record<string, string | null> = {};
-  const args = parseShellArgs(escapeShellMeta(stripShellComments(claudeArgs)))
-    .map((arg) => {
-      if (typeof arg === "string") return unescapeShellMeta(arg);
-      // With control metachars escaped above, the only non-string shell-quote
-      // can still emit is a glob op (bareword containing *, ?, or [). Its
-      // `pattern` field is the verbatim token text — use it as-is so values
-      // like `Bash(cmd:*)` and `Read(path/**)` round-trip intact.
-      if (typeof arg === "object" && arg !== null && "pattern" in arg) {
-        return unescapeShellMeta((arg as { pattern: string }).pattern);
-      }
-      return undefined;
-    })
-    .filter((arg): arg is string => typeof arg === "string");
+  const args = splitClaudeArgs(claudeArgs);
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];

--- a/base-action/test/parse-shell-args.test.ts
+++ b/base-action/test/parse-shell-args.test.ts
@@ -69,6 +69,17 @@ describe("splitClaudeArgs", () => {
     ]);
   });
 
+  test("should report an unterminated quote instead of swallowing later flags", () => {
+    // Without this the quote runs to the end of the input, so allowedTools
+    // becomes `Read\n--max-turns 5` and --max-turns is silently dropped.
+    expect(() =>
+      splitClaudeArgs(`--allowedTools "Read\n--max-turns 5`),
+    ).toThrow(/unterminated double quote at position 15/);
+    expect(() => splitClaudeArgs(`--allowedTools 'Read`)).toThrow(
+      /unterminated single quote/,
+    );
+  });
+
   test("should keep a # that is inside a quoted value", () => {
     const input = `--append-system-prompt "rules:\n# 1. never force push\n"`;
     expect(splitClaudeArgs(input)).toEqual([

--- a/base-action/test/parse-shell-args.test.ts
+++ b/base-action/test/parse-shell-args.test.ts
@@ -1,44 +1,44 @@
 import { describe, expect, test } from "bun:test";
-import { parse as parseShellArgs } from "shell-quote";
+import { splitClaudeArgs } from "../src/parse-sdk-options";
 
-describe("shell-quote parseShellArgs", () => {
+describe("splitClaudeArgs", () => {
   test("should handle empty input", () => {
-    expect(parseShellArgs("")).toEqual([]);
-    expect(parseShellArgs("   ")).toEqual([]);
+    expect(splitClaudeArgs("")).toEqual([]);
+    expect(splitClaudeArgs("   ")).toEqual([]);
   });
 
   test("should parse simple arguments", () => {
-    expect(parseShellArgs("--max-turns 3")).toEqual(["--max-turns", "3"]);
-    expect(parseShellArgs("-a -b -c")).toEqual(["-a", "-b", "-c"]);
+    expect(splitClaudeArgs("--max-turns 3")).toEqual(["--max-turns", "3"]);
+    expect(splitClaudeArgs("-a -b -c")).toEqual(["-a", "-b", "-c"]);
   });
 
   test("should handle double quotes", () => {
-    expect(parseShellArgs('--config "/path/to/config.json"')).toEqual([
+    expect(splitClaudeArgs('--config "/path/to/config.json"')).toEqual([
       "--config",
       "/path/to/config.json",
     ]);
-    expect(parseShellArgs('"arg with spaces"')).toEqual(["arg with spaces"]);
+    expect(splitClaudeArgs('"arg with spaces"')).toEqual(["arg with spaces"]);
   });
 
   test("should handle single quotes", () => {
-    expect(parseShellArgs("--config '/path/to/config.json'")).toEqual([
+    expect(splitClaudeArgs("--config '/path/to/config.json'")).toEqual([
       "--config",
       "/path/to/config.json",
     ]);
-    expect(parseShellArgs("'arg with spaces'")).toEqual(["arg with spaces"]);
+    expect(splitClaudeArgs("'arg with spaces'")).toEqual(["arg with spaces"]);
   });
 
   test("should handle escaped characters", () => {
-    expect(parseShellArgs("arg\\ with\\ spaces")).toEqual(["arg with spaces"]);
-    expect(parseShellArgs('arg\\"with\\"quotes')).toEqual(['arg"with"quotes']);
+    expect(splitClaudeArgs("arg\\ with\\ spaces")).toEqual(["arg with spaces"]);
+    expect(splitClaudeArgs('arg\\"with\\"quotes')).toEqual(['arg"with"quotes']);
   });
 
   test("should handle mixed quotes", () => {
-    expect(parseShellArgs(`--msg "It's a test"`)).toEqual([
+    expect(splitClaudeArgs(`--msg "It's a test"`)).toEqual([
       "--msg",
       "It's a test",
     ]);
-    expect(parseShellArgs(`--msg 'He said "hello"'`)).toEqual([
+    expect(splitClaudeArgs(`--msg 'He said "hello"'`)).toEqual([
       "--msg",
       'He said "hello"',
     ]);
@@ -46,7 +46,7 @@ describe("shell-quote parseShellArgs", () => {
 
   test("should handle complex real-world example", () => {
     const input = `--max-turns 3 --mcp-config "/Users/john/config.json" --model claude-3-5-sonnet-latest --system-prompt 'You are helpful'`;
-    expect(parseShellArgs(input)).toEqual([
+    expect(splitClaudeArgs(input)).toEqual([
       "--max-turns",
       "3",
       "--mcp-config",
@@ -58,10 +58,41 @@ describe("shell-quote parseShellArgs", () => {
     ]);
   });
 
-  test("should filter out non-string results", () => {
-    // shell-quote can return objects for operators like | > < etc
-    const result = parseShellArgs("echo hello");
-    const filtered = result.filter((arg) => typeof arg === "string");
-    expect(filtered).toEqual(["echo", "hello"]);
+  test("should keep shell metacharacters literal", () => {
+    expect(splitClaudeArgs("--allowedTools Bash(gh:*)")).toEqual([
+      "--allowedTools",
+      "Bash(gh:*)",
+    ]);
+    expect(splitClaudeArgs("--allowedTools Read(path/**)")).toEqual([
+      "--allowedTools",
+      "Read(path/**)",
+    ]);
+  });
+
+  test("should keep a # that is inside a quoted value", () => {
+    const input = `--append-system-prompt "rules:\n# 1. never force push\n"`;
+    expect(splitClaudeArgs(input)).toEqual([
+      "--append-system-prompt",
+      "rules:\n# 1. never force push\n",
+    ]);
+  });
+
+  test("should drop a comment line and a trailing comment", () => {
+    expect(
+      splitClaudeArgs("--model sonnet\n# a comment\n--max-turns 5"),
+    ).toEqual(["--model", "sonnet", "--max-turns", "5"]);
+    expect(splitClaudeArgs("--model sonnet # pick a model")).toEqual([
+      "--model",
+      "sonnet",
+    ]);
+  });
+
+  test("should join a continued line without emitting an empty argument", () => {
+    const input = `--disallowedTools \\\n  "Bash(rm:*)" "Bash(sudo:*)"`;
+    expect(splitClaudeArgs(input)).toEqual([
+      "--disallowedTools",
+      "Bash(rm:*)",
+      "Bash(sudo:*)",
+    ]);
   });
 });

--- a/base-action/test/parse-shell-args.test.ts
+++ b/base-action/test/parse-shell-args.test.ts
@@ -88,6 +88,13 @@ describe("splitClaudeArgs", () => {
     ]);
   });
 
+  test("should keep a # within an unquoted word", () => {
+    expect(splitClaudeArgs("--branch-name fix/#123-description")).toEqual([
+      "--branch-name",
+      "fix/#123-description",
+    ]);
+  });
+
   test("should drop a comment line and a trailing comment", () => {
     expect(
       splitClaudeArgs("--model sonnet\n# a comment\n--max-turns 5"),

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@octokit/rest": "^21.1.1",
         "@octokit/webhooks-types": "^7.6.1",
         "node-fetch": "^3.3.2",
-        "unbash": "^4.0.3",
+        "unbash": "^4.0.5",
         "zod": "^3.24.4",
       },
       "devDependencies": {
@@ -295,7 +295,7 @@
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
-    "unbash": ["unbash@4.0.3", "", {}, "sha512-3cudTErfToSc4Ggv8XGXVNVli/xHKUtUZvaY5UVwhOcUPbQGz7PeaEnT/SAVgNziZtX67KEN9swMUYkLghxA1w=="],
+    "unbash": ["unbash@4.0.5", "", {}, "sha512-EE9xv9cr93DSppe086Rnbq0jwG7MBCEe22JZ4UQ8Bn9RyUwDSoUpBmzdb5+7PzocdqBEb/K73FGPaQUMmLxTQQ=="],
 
     "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@octokit/rest": "^21.1.1",
         "@octokit/webhooks-types": "^7.6.1",
         "node-fetch": "^3.3.2",
-        "shell-quote": "^1.8.3",
+        "unbash": "^4.0.3",
         "zod": "^3.24.4",
       },
       "devDependencies": {
@@ -275,8 +275,6 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
-
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
@@ -296,6 +294,8 @@
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "unbash": ["unbash@4.0.3", "", {}, "sha512-3cudTErfToSc4Ggv8XGXVNVli/xHKUtUZvaY5UVwhOcUPbQGz7PeaEnT/SAVgNziZtX67KEN9swMUYkLghxA1w=="],
 
     "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@octokit/rest": "^21.1.1",
     "@octokit/webhooks-types": "^7.6.1",
     "node-fetch": "^3.3.2",
-    "unbash": "^4.0.3",
+    "unbash": "^4.0.5",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@octokit/rest": "^21.1.1",
     "@octokit/webhooks-types": "^7.6.1",
     "node-fetch": "^3.3.2",
-    "shell-quote": "^1.8.3",
+    "unbash": "^4.0.3",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/src/modes/agent/parse-tools.ts
+++ b/src/modes/agent/parse-tools.ts
@@ -1,39 +1,8 @@
-import { parse as parseShellArgs } from "shell-quote";
+import { splitClaudeArgs } from "../../../base-action/src/parse-sdk-options";
 
 // Flags whose values make up the allowed-tools list.
 // Include both camelCase and hyphenated variants for CLI compatibility.
 const ALLOWED_TOOLS_FLAGS = new Set(["allowedTools", "allowed-tools"]);
-
-/**
- * Strip comment lines from a shell argument string.
- * Lines whose first non-whitespace character is `#` are removed entirely.
- * Mirrors stripShellComments in base-action/src/parse-sdk-options.ts.
- */
-function stripShellComments(input: string): string {
-  return input
-    .split("\n")
-    .filter((line) => !line.trim().startsWith("#"))
-    .join("\n");
-}
-
-/**
- * Tokenize a claude_args string the same way base-action/src/parse-sdk-options.ts
- * does: strip full comment lines, then run shell-quote. shell-quote returns
- * unquoted glob patterns (e.g. `mcp__github__*`) as `{ op: "glob", pattern }`
- * objects rather than strings, so recover their literal text; drop operator
- * tokens (`|`, `>`, `;`, ...) which carry no value.
- */
-function tokenize(claudeArgs: string): string[] {
-  return parseShellArgs(stripShellComments(claudeArgs))
-    .map((token) => {
-      if (typeof token === "string") return token;
-      if (token && typeof token === "object" && "pattern" in token) {
-        return (token as { pattern: string }).pattern;
-      }
-      return null;
-    })
-    .filter((token): token is string => token !== null);
-}
 
 /**
  * Parse the list of allowed tool names from a user-provided claude_args string.
@@ -44,15 +13,15 @@ function tokenize(claudeArgs: string): string[] {
  * tool can be granted to Claude without its MCP server being installed, or a
  * server can be installed for a tool that was never granted (#1357).
  *
- * To stay in agreement it uses the same shell-quote tokenizer and the same
- * "an accumulating flag consumes all consecutive non-flag values" semantics,
- * so `--allowedTools "Read" "Grep" "mcp__github__get_commit"` captures all
- * three values, and commented-out lines are ignored.
+ * To stay in agreement it uses that file's tokenizer (`splitClaudeArgs`) and
+ * the same "an accumulating flag consumes all consecutive non-flag values"
+ * semantics, so `--allowedTools "Read" "Grep" "mcp__github__get_commit"`
+ * captures all three values, and commented-out lines are ignored.
  */
 export function parseAllowedTools(claudeArgs: string): string[] {
   if (!claudeArgs?.trim()) return [];
 
-  const args = tokenize(claudeArgs);
+  const args = splitClaudeArgs(claudeArgs);
   const tools: string[] = [];
   const seen = new Set<string>();
 

--- a/test/modes/parse-tools.test.ts
+++ b/test/modes/parse-tools.test.ts
@@ -150,4 +150,19 @@ describe("parseAllowedTools", () => {
       "mcp__github_comment__*",
     ]);
   });
+
+  test("keeps an unquoted parenthesised tool intact", () => {
+    // Regression for #1357: this parser did not escape shell metacharacters,
+    // so it read `Bash` and `gh:*` while the SDK was granted `Bash(gh:*)`.
+    expect(parseAllowedTools("--allowedTools Bash(gh:*)")).toEqual([
+      "Bash(gh:*)",
+    ]);
+  });
+
+  test("reads tools across a line continuation", () => {
+    expect(parseAllowedTools('--allowedTools \\\n  "Read" "Grep"')).toEqual([
+      "Read",
+      "Grep",
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

`claude_args` is tokenized by dropping any line whose first non-whitespace character is `#`, then running `shell-quote`. That loses information a shell would have kept, and the two places that read `claude_args` disagree about the result.

## Three bugs

**1. A `#` line inside a multi-line quoted value is deleted.**

```
--append-system-prompt "Follow these rules:
# 1. never force push
# 2. never delete branches
"
```

reaches Claude as `Follow these rules:\n`. Both instructions are gone, with no error. A numbered list written with `#` is an ordinary way to write one, and `stripShellComments` says in its own doc comment that inline `#` inside a quoted value is left untouched, which is the intent this breaks.

**2. A line continuation drops the value entirely.**

```
--disallowedTools \
  "Bash(rm:*)" "Bash(sudo:*)"
```

`shell-quote` emits an empty token for the `\`, and the empty token lands where the accumulating flag expects its first value. The result is that `disallowedTools` comes back `undefined`, so neither deny rule applies.

**3. The two `claude_args` readers disagree.**

`src/modes/agent/parse-tools.ts` states that it MUST agree with `parseClaudeArgsToExtraArgs`, because otherwise a tool is granted without its MCP server being installed, or a server is installed for a tool that was never granted (#1357). It never applied the metacharacter escaping the SDK parser applies, so:

```
--allowedTools Bash(gh:*)

  SDK parser      -> ["Bash(gh:*)"]
  MCP installer   -> ["Bash", "gh:*"]
```

## A fourth case, in its own commit

An unterminated quote runs to the end of the input, so this:

```
--allowedTools "Read
--max-turns 5
```

granted the single tool `Read\n--max-turns 5` and silently dropped `--max-turns`. Nothing surfaced, because the previous tokenizer had no way to say the input was malformed. The parser reports a position, so `splitClaudeArgs` now raises it:

```
Could not parse claude_args: unterminated double quote at position 15 near `"Read`.
Values containing spaces or shell characters need quoting.
```

I checked this against every `claude_args` in the test suite and docs, including MCP config JSON, glob tools, nested quotes, line continuations, `#` inside values and escaped spaces. None of them parse with an error. When one does, the token list is already wrong, so failing is better than granting a tool nobody asked for.

This is deliberately a separate commit (`37f020f`). It changes a silent mis-parse into a hard failure, which is a behaviour change rather than a bug fix, so if you would rather keep this PR to the three bugs above, revert that one commit and the rest stands on its own.

## What this changes

`stripShellComments` becomes `splitClaudeArgs`, backed by a shell parser and exported so `parse-tools.ts` can share it instead of keeping a second copy. Comments, quoting and line continuations are resolved by the grammar rather than by scanning lines, so there is one canonical answer for what `claude_args` contains.

The private-use-codepoint escaping for `()|&;<>` is unchanged. Those are genuine control operators in shell grammar, so a parser splits on them too. Keeping the escaping is what makes `--allowedTools Bash(gh:*)` and `Read(path/**)` round-trip, and applying it in the shared tokenizer is what fixes bug 3.

`shell-quote` is now unused and is dropped from both packages. Its test file is updated in place to cover the same behaviours against the tokenizer that replaced it, plus the regressions above.

## About the dependency

This swaps `shell-quote` for [unbash](https://github.com/webpro-nl/unbash), so the dependency count is unchanged. I wrote unbash. I also wrote [knip](https://github.com/webpro-nl/knip), which depends on it, so it already runs against a large amount of real world shell: knip is at about 11.7M downloads a week and unbash at about 8.5M. It has no dependencies of its own, is synchronous, and needs no WASM or async initialisation.

## Verification

```
bun test            810 pass, 0 fail, 44 files   (804 on main, +6 regressions)
bun run typecheck   clean
bun run format      clean
```

All three bugs were reproduced against `main` first and confirmed fixed after.

## Related issues

#1357 is the divergence bug 3 describes.
