### PR TITLE
fix: bump shell-quote to 1.8.4 to remediate CVE-2026-9277

### DIFF
--- a/base-action/bun.lock
+++ b/base-action/bun.lock
@@ -223,7 +223,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 

--- a/base-action/package-lock.json
+++ b/base-action/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@actions/core": "^1.10.1",
-        "shell-quote": "^1.8.3"
+        "shell-quote": "^1.8.4"
       },
       "devDependencies": {
         "@types/bun": "^1.2.12",
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/base-action/package.json
+++ b/base-action/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@anthropic-ai/claude-agent-sdk": "^0.3.220",
-    "shell-quote": "^1.8.3"
+    "shell-quote": "^1.8.4"
   },
   "devDependencies": {
     "@types/bun": "^1.2.12",

--- a/bun.lock
+++ b/bun.lock
@@ -275,7 +275,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@octokit/rest": "^21.1.1",
     "@octokit/webhooks-types": "^7.6.1",
     "node-fetch": "^3.3.2",
-    "shell-quote": "^1.8.3",
+    "shell-quote": "^1.8.4",
     "zod": "^3.24.4"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

`shell-quote` 1.8.3 is affected by CVE-2026-9277 (CRITICAL severity). This bumps the dependency to 1.8.4, which contains the fix, in both the root package and `base-action/`.

| CVE | Package | Before | After |
|-----|---------|--------|-------|
| CVE-2026-9277 | `shell-quote` | 1.8.3 | 1.8.4 (fixed) |

### Files changed
- `package.json`, `bun.lock` (root)
- `base-action/package.json`, `base-action/bun.lock`, `base-action/package-lock.json`

Related to the earlier #1507, which proposed the same dependency bump but went stale/was closed. This PR is rebased on current `main`.