### PR TITLE
fix: close XSS/HTML-injection CodeQL findings

### DIFF
--- a/docs/create-app.html
+++ b/docs/create-app.html
@@ -687,7 +687,7 @@
           return;
         }
         const form = document.getElementById("org-form");
-        form.action = `https://github.com/organizations/${orgName}/settings/apps/new`;
+        form.action = `https://github.com/organizations/${encodeURIComponent(orgName)}/settings/apps/new`;
         form.submit();
       }
 

--- a/src/github/utils/sanitizer.ts
+++ b/src/github/utils/sanitizer.ts
@@ -116,5 +116,12 @@ export function redactGitHubTokens(content: string): string {
   return content;
 }
 
-export const stripHtmlComments = (content: string) =>
-  content.replace(/<!--[\s\S]*?-->/g, "");
+export const stripHtmlComments = (content: string) => {
+  let result = content.replace(/<!--[\s\S]*?-->/g, "");
+  // Removing a full "<!--...-->" block can leave leftover characters on
+  // either side that recombine into a new delimiter (e.g. "<!<!---->-->"
+  // reduces to "<!-->" with no matching "-->" left for a second pass to
+  // catch). Strip any surviving delimiter tokens outright.
+  result = result.replace(/<!--/g, "").replace(/-->/g, "");
+  return result;
+};

--- a/test/sanitizer.test.ts
+++ b/test/sanitizer.test.ts
@@ -401,4 +401,12 @@ describe("stripHtmlComments (legacy)", () => {
       "Hello World",
     );
   });
+
+  it("should not leave a residual delimiter when leftover characters would recombine into one", () => {
+    // Removing "<!---->" from "<!<!---->--> alert(1)" leaves the prefix "<!"
+    // and suffix "-->" adjacent to each other, reforming "<!-->".
+    const result = stripHtmlComments("<!<!---->--> alert(1)");
+    expect(result).not.toContain("<!--");
+    expect(result).not.toContain("-->");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the two CodeQL error-severity findings currently reported against this repo:

**`js/incomplete-multi-character-sanitization`** — `stripHtmlComments` (`src/github/utils/sanitizer.ts`) removed full `<!--...-->` blocks in a single pass. For input like `"<!<!---->--> alert(1)"`, the leftover prefix (`"<!"`) and suffix (`"-->"`) around the removed block recombine into a new `"<!-->"` delimiter, which survives. A repeated-pass loop doesn't help here since the residual marker has no matching closer for a second pass to find. Fixed by adding a defensive final pass that strips any surviving `<!--`/`-->` tokens outright, guaranteeing no delimiter substring can remain.

**`js/xss-through-dom`** — `docs/create-app.html`'s `submitOrgForm()` read the org name from an input field and interpolated it directly into `form.action` without encoding. Fixed with `encodeURIComponent`.

## Test plan
- Added a regression test in `test/sanitizer.test.ts` covering the recombination case
- `bun test test/sanitizer.test.ts` — 44 pass, 0 fail
- `bun run typecheck` — clean
- `prettier --check` on changed files — clean