### PR TITLE
fix: redact stateless GitHub App installation tokens

### DIFF
--- a/src/github/utils/sanitizer.ts
+++ b/src/github/utils/sanitizer.ts
@@ -95,9 +95,10 @@ export function redactGitHubTokens(content: string): string {
     "[REDACTED_GITHUB_TOKEN]",
   );
 
-  // GitHub installation tokens: ghs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX (40 chars)
+  // GitHub installation tokens: ghs_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX (40 chars, stateful)
+  // or ghs_<AppID>_<JWT> (~520+ chars, stateless)
   content = content.replace(
-    /\bghs_[A-Za-z0-9]{36}\b/g,
+    /\bghs_[A-Za-z0-9._-]{36,}/g,
     "[REDACTED_GITHUB_TOKEN]",
   );
 

--- a/test/sanitizer.test.ts
+++ b/test/sanitizer.test.ts
@@ -302,8 +302,16 @@ describe("redactGitHubTokens", () => {
     ).toBe("In a URL: x-access-token:[REDACTED_GITHUB_TOKEN]@github.com");
   });
 
-  it("should redact installation tokens (ghs_)", () => {
+  it("should redact stateful installation tokens (ghs_)", () => {
     const token = "ghs_xz7yzju2SZjGPa0dUNMAx0SH4xDOCS31LXQW";
+    expect(redactGitHubTokens(`Install token: ${token}`)).toBe(
+      "Install token: [REDACTED_GITHUB_TOKEN]",
+    );
+  });
+
+  it("should redact stateless installation tokens (ghs_)", () => {
+    const token =
+      "ghs_12345_eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3NDU1NjgwMDAsImV4cCI6MTc0NTU2ODM2MCwiaXNzIjoiMTIzNDUifQ.bm90LWEtcmVhbC1zaWduYXR1cmUtanVzdC1mb3ItdW5pdC10ZXN0cy14eHh4eHh4eHh4eHg";
     expect(redactGitHubTokens(`Install token: ${token}`)).toBe(
       "Install token: [REDACTED_GITHUB_TOKEN]",
     );


### PR DESCRIPTION
## Summary
GitHub [introduced](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app#about-installation-access-tokens) a new token format for GitHub App installation tokens on April 27, 2026.

This new stateless token has the format of `ghs_<AppID>_<JWT>` and isn't matched by the existing (`ghs_`) regex pattern in `redactGitHubTokens`.

## Changes
- Updated the `ghs_` pattern to match both the existing stateful (40-char) tokens and the new stateless format, following GitHub's [recommended regex](https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/#before-the-rollout-reaches-your-app-test-proactively).
- Added test cases for both formats.

## Testing

- `bun test` - 805 pass, 0 fail
- `bun run typecheck` - ok
- `bun run format:check` - ok