### PR TITLE
fix: honor configured bot ID for sticky comments

### DIFF
--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -14,8 +14,6 @@ import {
 } from "../../context";
 import type { Octokit } from "@octokit/rest";
 
-const CLAUDE_APP_BOT_ID = 209825114;
-
 export async function createInitialComment(
   octokit: Octokit,
   context: ParsedGitHubContext,
@@ -39,7 +37,7 @@ export async function createInitialComment(
         issue_number: context.entityNumber,
       });
       const existingComment = comments.data.find((comment) => {
-        const idMatch = comment.user?.id === CLAUDE_APP_BOT_ID;
+        const idMatch = comment.user?.id === Number(context.inputs.botId);
         const botNameMatch =
           comment.user?.type === "Bot" &&
           comment.user?.login.toLowerCase().includes("claude");


### PR DESCRIPTION
## Summary

Makes `use_sticky_comment` honor the documented `bot_id` input when locating an existing PR comment.

This supports custom GitHub Apps, whose comments are authored by their own bot identity rather than `claude[bot]`.
