### PR TITLE
fix(mcp): merge user's --mcp-config file path instead of discarding it

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "fs";
 import { parse as parseShellArgs } from "shell-quote";
 import type { ClaudeOptions } from "./run-claude";
 import type { Options as SdkOptions } from "@anthropic-ai/claude-agent-sdk";
@@ -62,7 +63,10 @@ type McpConfig = {
  * Merge multiple MCP config values into a single config.
  * Each config can be a JSON string or a file path.
  * For JSON strings, mcpServers objects are merged.
- * For file paths, they are kept as-is (user's file takes precedence and is used last).
+ * For file paths, the file is read and its mcpServers merged in the same way;
+ * if it can't be read or parsed, it is kept as-is and returned verbatim
+ * (only when no inline JSON was present) so the caller can pass it straight
+ * through to the CLI.
  */
 function mergeMcpConfigs(configValues: string[]): string {
   const merged: McpConfig = { mcpServers: {} };
@@ -84,27 +88,42 @@ function mergeMcpConfigs(configValues: string[]): string {
         lastFilePath = trimmed;
       }
     } else {
-      // It's a file path - store it to handle separately
-      lastFilePath = trimmed;
+      // It's a file path. This action always runs in its own Bun process on
+      // the runner, so the file system is available here and the path is
+      // local to that same runner — read and merge it now. Fall back to
+      // recording it as lastFilePath (today's passthrough behavior) on any
+      // failure: file missing/unreadable, invalid JSON, no mcpServers key, or
+      // an mcpServers value that isn't a plain object (a string or array
+      // would corrupt Object.assign below by spreading per-character/index).
+      // The fallback is a live path, not dead code: tag mode always prepends
+      // the action's own config as inline JSON, but agent mode only prepends
+      // it when at least one built-in server is enabled (see
+      // src/modes/agent/index.ts and src/mcp/install-mcp-server.ts) — so in
+      // agent-mode runs with no built-in servers active, this file-path
+      // branch is the only value present and must still work standalone.
+      try {
+        const fileContents = readFileSync(trimmed, "utf-8");
+        const parsed = JSON.parse(fileContents) as McpConfig;
+        if (
+          parsed.mcpServers &&
+          typeof parsed.mcpServers === "object" &&
+          !Array.isArray(parsed.mcpServers)
+        ) {
+          Object.assign(merged.mcpServers!, parsed.mcpServers);
+        } else {
+          lastFilePath = trimmed;
+        }
+      } catch {
+        lastFilePath = trimmed;
+      }
     }
   }
 
-  // If we have file paths, we need to keep the merged JSON and let the file
-  // be handled separately. Since we can only return one value, merge what we can.
-  // If there's a file path, we need a different approach - read the file at runtime.
-  // For now, if there's a file path, we'll stringify the merged config.
-  // The action prepends its config as JSON, so we can safely merge inline JSON configs.
-
-  // If no inline configs were found (all file paths), return the last file path
+  // If no inline configs were found (all file paths, or a file path that
+  // failed to read/parse), return the last file path.
   if (Object.keys(merged.mcpServers!).length === 0 && lastFilePath) {
     return lastFilePath;
   }
-
-  // Note: If user passes a file path, we cannot merge it at parse time since
-  // we don't have access to the file system here. The action's built-in MCP
-  // servers are always passed as inline JSON, so they will be merged.
-  // If user also passes inline JSON, it will be merged.
-  // If user passes a file path, they should ensure it includes all needed servers.
 
   return JSON.stringify(merged);
 }

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env bun
 
 import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { parseSdkOptions } from "../src/parse-sdk-options";
 import type { ClaudeOptions } from "../src/run-claude";
 
@@ -340,7 +343,10 @@ describe("parseSdkOptions", () => {
 
     test("should merge inline JSON configs when file path is also present", () => {
       // When action provides inline JSON and user provides a file path,
-      // the inline JSON configs should be merged (file paths cannot be merged at parse time)
+      // the inline JSON configs should be merged. The file path here is not
+      // merged because /tmp/user-config.json does not exist, so this
+      // exercises the read-failure fallback rather than proving file paths
+      // in general can't be merged (see the "existing file" test below).
       const options: ClaudeOptions = {
         claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config '{"mcpServers":{"github_ci":{"command":"node"}}}' --mcp-config /tmp/user-config.json`,
       };
@@ -353,6 +359,144 @@ describe("parseSdkOptions", () => {
       );
       expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
       expect(mcpConfig.mcpServers).toHaveProperty("github_ci");
+    });
+
+    test("should merge an existing mcp-config file's servers with the action's inline config", () => {
+      // Reproduces the real tag-mode shape (issue #1544): the action prepends
+      // its own MCP config as inline JSON, then the user's --mcp-config points
+      // at a real file on disk. Unlike the two tests above (which reference
+      // nonexistent files and fall back to today's file-path passthrough),
+      // this file exists and should be read and merged.
+      const tempDir = mkdtempSync(join(tmpdir(), "mcp-config-test-"));
+      const userConfigPath = join(tempDir, "user-mcp-config.json");
+      try {
+        writeFileSync(
+          userConfigPath,
+          JSON.stringify({
+            mcpServers: {
+              user_server: { command: "custom", args: ["run"] },
+            },
+          }),
+        );
+
+        const actionConfig = JSON.stringify({
+          mcpServers: {
+            github_comment: { command: "node", args: ["server.js"] },
+          },
+        });
+
+        const options: ClaudeOptions = {
+          claudeArgs: `--mcp-config '${actionConfig}' --mcp-config ${userConfigPath}`,
+        };
+
+        const result = parseSdkOptions(options);
+
+        const mcpConfig = JSON.parse(
+          result.sdkOptions.extraArgs?.["mcp-config"] as string,
+        );
+        expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
+        expect(mcpConfig.mcpServers).toHaveProperty("user_server");
+        expect(mcpConfig.mcpServers.user_server.command).toBe("custom");
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    test("should fall back to passthrough when an existing mcp-config file has no mcpServers key", () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "mcp-config-test-"));
+      const userConfigPath = join(tempDir, "no-mcp-servers.json");
+      try {
+        writeFileSync(userConfigPath, JSON.stringify({ notMcpServers: {} }));
+
+        const actionConfig = JSON.stringify({
+          mcpServers: {
+            github_comment: { command: "node", args: ["server.js"] },
+          },
+        });
+
+        const options: ClaudeOptions = {
+          claudeArgs: `--mcp-config '${actionConfig}' --mcp-config ${userConfigPath}`,
+        };
+
+        const result = parseSdkOptions(options);
+
+        const mcpConfig = JSON.parse(
+          result.sdkOptions.extraArgs?.["mcp-config"] as string,
+        );
+        expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
+        expect(Object.keys(mcpConfig.mcpServers)).toHaveLength(1);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    test("should fall back to passthrough (not corrupt the merge) when an existing mcp-config file's mcpServers is a string", () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "mcp-config-test-"));
+      const userConfigPath = join(tempDir, "string-mcp-servers.json");
+      try {
+        writeFileSync(
+          userConfigPath,
+          JSON.stringify({ mcpServers: "not-an-object" }),
+        );
+
+        const actionConfig = JSON.stringify({
+          mcpServers: {
+            github_comment: { command: "node", args: ["server.js"] },
+          },
+        });
+
+        const options: ClaudeOptions = {
+          claudeArgs: `--mcp-config '${actionConfig}' --mcp-config ${userConfigPath}`,
+        };
+
+        const result = parseSdkOptions(options);
+
+        const mcpConfig = JSON.parse(
+          result.sdkOptions.extraArgs?.["mcp-config"] as string,
+        );
+        expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
+        // The corrupted-merge failure mode spreads the string char-by-char
+        // into numeric keys ("0", "1", ...) - assert none of those exist.
+        expect(mcpConfig.mcpServers).not.toHaveProperty("0");
+        expect(mcpConfig.mcpServers).not.toHaveProperty("1");
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    test("should fall back to passthrough (not corrupt the merge) when an existing mcp-config file's mcpServers is an array", () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "mcp-config-test-"));
+      const userConfigPath = join(tempDir, "array-mcp-servers.json");
+      try {
+        writeFileSync(
+          userConfigPath,
+          JSON.stringify({ mcpServers: ["not", "an", "object"] }),
+        );
+
+        const actionConfig = JSON.stringify({
+          mcpServers: {
+            github_comment: { command: "node", args: ["server.js"] },
+          },
+        });
+
+        const options: ClaudeOptions = {
+          claudeArgs: `--mcp-config '${actionConfig}' --mcp-config ${userConfigPath}`,
+        };
+
+        const result = parseSdkOptions(options);
+
+        const mcpConfig = JSON.parse(
+          result.sdkOptions.extraArgs?.["mcp-config"] as string,
+        );
+        expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
+        // The corrupted-merge failure mode spreads the array by index into
+        // numeric keys ("0", "1", "2") - assert none of those exist.
+        expect(mcpConfig.mcpServers).not.toHaveProperty("0");
+        expect(mcpConfig.mcpServers).not.toHaveProperty("1");
+        expect(mcpConfig.mcpServers).not.toHaveProperty("2");
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
     });
 
     test("should handle mcp-config with other flags", () => {


### PR DESCRIPTION
Fixes #1544.

### The problem

`mergeMcpConfigs()` folds every `--mcp-config` value into a single value, because `extraArgs` is `Record<string, string | null>` and can hold only one value per flag. Inline JSON is merged into `merged.mcpServers`; a **file path** is only recorded in `lastFilePath` and returned when no inline JSON was seen at all:

```ts
if (Object.keys(merged.mcpServers!).length === 0 && lastFilePath) {
  return lastFilePath;
}
return JSON.stringify(merged);
```

Tag mode always prepends the action's own config as inline JSON (`src/modes/tag/index.ts`), and agent mode does whenever at least one built-in server is enabled (`src/modes/agent/index.ts`, gated on `Object.keys(ourConfig.mcpServers).length > 0`). In those cases `merged.mcpServers` is never empty, so a user's `--mcp-config <file>` is dropped with no error, no warning, and no log line. The action's own servers register normally, which makes the failure look like a problem with the user's server rather than with config plumbing.

The existing comments said the file "cannot be merged at parse time since we don't have access to the file system here." That isn't so — `base-action/` functions are imported and run in-process on the runner (per `CLAUDE.md`, "imported directly, not subprocess"), and the path is local to that same runner. This PR corrects those comments too.

### The fix

When a `--mcp-config` value is a file path, read it and merge its `mcpServers` with the same precedence as inline JSON. On **any** failure — missing, unreadable, invalid JSON, no `mcpServers` key, or `mcpServers` present but not a plain object — fall back to exactly the current behavior of recording it as `lastFilePath`.

That fallback is what keeps this backward compatible. Two existing tests reference `/tmp/user-mcp-config.json` and `/tmp/user-config.json`, neither of which exists; both keep passing unmodified through the fallback path. No existing test was edited, other than one stale comment (see below).

### Behavior change worth calling out

A file-based config can now override an action-internal server key such as `github_comment`, because later values win. Previously the whole file was discarded, so a file-based override was structurally impossible.

This is a parity fix, not a new capability: the identical override is already possible today via inline JSON, and both forms are gated on whoever controls `claude_args` — a workflow-author trust boundary that predates this change. Flagging it explicitly so it's a deliberate call rather than something to discover later. If reserving built-in server names is wanted, that seems like a separate decision from #1544.

### Scope note

The shape guard is applied only to the new file-path branch. The inline-JSON branch above it has the same pre-existing gap (a non-object `mcpServers` would spread into numeric keys), but it predates this PR and widening the diff to cover it would make this more than a single-concern fix. Happy to follow up separately if that's wanted.

### Tests

Added to the existing `describe("mcp-config merging", ...)` block, each using a real temp file created and cleaned up in a `try`/`finally`:

- action's inline config + user's **readable** file → both sets of servers present (this is the #1544 repro; it fails on `main`)
- file with valid JSON but **no `mcpServers` key** → falls back, built-ins survive
- file whose `mcpServers` is a **string**, and one where it is an **array** → falls back, and the merged result has no numeric keys

Also updated one stale comment on the pre-existing "file path is also present" test, which claimed file paths cannot be merged at parse time — that test passes because its referenced file does not exist, so it exercises the fallback.

`bun test`, `bun run typecheck`, and `bun run format:check` all pass.
