### PR TITLE
fix: make *[bot] actor filter match GraphQL bot authors

### DIFF
--- a/src/github/api/queries/github.ts
+++ b/src/github/api/queries/github.ts
@@ -1,4 +1,8 @@
 // GraphQL queries for GitHub data
+//
+// Author selections include `__typename` so bot actors can be detected.
+// GraphQL `login` for bots omits the REST/UI `[bot]` suffix (e.g. "github-actions"
+// with __typename "Bot"); actor filters rely on that typename for `*[bot]`.
 
 export const PR_QUERY = `
   query($owner: String!, $repo: String!, $number: Int!) {
@@ -7,6 +11,7 @@ export const PR_QUERY = `
         title
         body
         author {
+          __typename
           login
         }
         baseRefName
@@ -57,6 +62,7 @@ export const PR_QUERY = `
             databaseId
             body
             author {
+              __typename
               login
             }
             createdAt
@@ -70,6 +76,7 @@ export const PR_QUERY = `
             id
             databaseId
             author {
+              __typename
               login
             }
             body
@@ -85,6 +92,7 @@ export const PR_QUERY = `
                 path
                 line
                 author {
+                  __typename
                   login
                 }
                 createdAt
@@ -107,6 +115,7 @@ export const ISSUE_QUERY = `
         title
         body
         author {
+          __typename
           login
         }
         createdAt
@@ -124,6 +133,7 @@ export const ISSUE_QUERY = `
             databaseId
             body
             author {
+              __typename
               login
             }
             createdAt

--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -21,6 +21,7 @@ import type {
 import type { CommentWithImages } from "../utils/image-downloader";
 import { downloadCommentImages } from "../utils/image-downloader";
 import {
+  normalizeActorLogin,
   parseActorFilter,
   shouldIncludeCommentByActor,
 } from "../utils/actor-filter";
@@ -205,7 +206,7 @@ export function isBodySafeToUse(
  * @returns Filtered array of comments
  */
 export function filterCommentsByActor<
-  T extends { author: { login: string } | null },
+  T extends { author: { login: string; __typename?: string } | null },
 >(comments: T[], includeActors: string = "", excludeActors: string = ""): T[] {
   const includeParsed = parseActorFilter(includeActors);
   const excludeParsed = parseActorFilter(excludeActors);
@@ -215,15 +216,16 @@ export function filterCommentsByActor<
     return comments;
   }
 
-  return comments.filter((comment) =>
-    shouldIncludeCommentByActor(
-      // author is null for comments from deleted ("ghost") accounts; treat them
-      // as the "ghost" login so filtering never dereferences null and crashes.
+  return comments.filter((comment) => {
+    // GraphQL bot logins lack the "[bot]" suffix; normalize so "*[bot]" works.
+    // author is null for comments from deleted ("ghost") accounts; treat them
+    // as the "ghost" login so filtering never dereferences null and crashes.
+    const actor = normalizeActorLogin(
       comment.author?.login ?? "ghost",
-      includeParsed,
-      excludeParsed,
-    ),
-  );
+      comment.author?.__typename,
+    );
+    return shouldIncludeCommentByActor(actor, includeParsed, excludeParsed);
+  });
 }
 
 type FetchDataParams = {

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -6,6 +6,11 @@
 export type GitHubAuthor = {
   login: string;
   name?: string;
+  /**
+   * GraphQL `__typename` for the Actor interface (e.g. "User", "Bot").
+   * Used to detect bots: GraphQL logins omit the REST/UI `[bot]` suffix.
+   */
+  __typename?: string;
 };
 
 export type GitHubComment = {

--- a/src/github/utils/actor-filter.ts
+++ b/src/github/utils/actor-filter.ts
@@ -12,17 +12,41 @@ export function parseActorFilter(filterString: string): string[] {
 }
 
 /**
+ * Normalizes an actor login for filter matching.
+ *
+ * GitHub GraphQL returns bot `author.login` values without the `[bot]` suffix
+ * (e.g. `"github-actions"` / `"claude"` with `__typename: "Bot"`), while REST
+ * and the UI use `"github-actions[bot]"`. The documented `*[bot]` wildcard and
+ * specific bot patterns like `dependabot[bot]` expect the REST form, so append
+ * `[bot]` when GraphQL identifies the author as a Bot.
+ *
+ * @param login - Actor username (GraphQL or REST form)
+ * @param typename - Optional GraphQL `__typename` (`"Bot"`, `"User"`, …)
+ * @returns Login suitable for matching against actor filter patterns
+ */
+export function normalizeActorLogin(
+  login: string,
+  typename?: string | null,
+): string {
+  if (typename === "Bot" && login && !login.endsWith("[bot]")) {
+    return `${login}[bot]`;
+  }
+  return login;
+}
+
+/**
  * Checks if an actor matches a pattern
  * Supports wildcards: "*[bot]" matches all bots, "dependabot[bot]" matches specific
- * @param actor - Actor username to check
+ * @param actor - Actor username to check (prefer normalizeActorLogin first for GraphQL bots)
  * @param pattern - Pattern to match against
  * @returns true if actor matches pattern
  */
 export function actorMatchesPattern(actor: string, pattern: string): boolean {
-  // Exact match
+  // Exact match (REST-style login, GraphQL login, or already-normalized bot login)
   if (actor === pattern) return true;
 
   // Wildcard bot pattern: "*[bot]" matches any username ending with [bot]
+  // (including GraphQL bots after normalizeActorLogin appends the suffix)
   if (pattern === "*[bot]" && actor.endsWith("[bot]")) return true;
 
   // No match
@@ -31,7 +55,7 @@ export function actorMatchesPattern(actor: string, pattern: string): boolean {
 
 /**
  * Determines if a comment should be included based on actor filters
- * @param actor - Comment author username
+ * @param actor - Comment author username (prefer normalizeActorLogin for GraphQL bots)
  * @param includeActors - Array of actors to include (empty = include all)
  * @param excludeActors - Array of actors to exclude (empty = exclude none)
  * @returns true if comment should be included

--- a/test/actor-filter.test.ts
+++ b/test/actor-filter.test.ts
@@ -3,6 +3,7 @@ import {
   parseActorFilter,
   actorMatchesPattern,
   shouldIncludeCommentByActor,
+  normalizeActorLogin,
 } from "../src/github/utils/actor-filter";
 
 describe("parseActorFilter", () => {
@@ -36,6 +37,40 @@ describe("parseActorFilter", () => {
 
   test("handles wildcard bot pattern", () => {
     expect(parseActorFilter("*[bot]")).toEqual(["*[bot]"]);
+  });
+});
+
+describe("normalizeActorLogin", () => {
+  test("appends [bot] for GraphQL Bot authors without suffix", () => {
+    expect(normalizeActorLogin("github-actions", "Bot")).toBe(
+      "github-actions[bot]",
+    );
+    expect(normalizeActorLogin("claude", "Bot")).toBe("claude[bot]");
+    expect(normalizeActorLogin("dependabot", "Bot")).toBe("dependabot[bot]");
+  });
+
+  test("does not double-append [bot] suffix", () => {
+    expect(normalizeActorLogin("dependabot[bot]", "Bot")).toBe(
+      "dependabot[bot]",
+    );
+    expect(normalizeActorLogin("github-actions[bot]", "Bot")).toBe(
+      "github-actions[bot]",
+    );
+  });
+
+  test("leaves User typename logins unchanged", () => {
+    expect(normalizeActorLogin("human-user", "User")).toBe("human-user");
+    expect(normalizeActorLogin("user-bot", "User")).toBe("user-bot");
+  });
+
+  test("leaves logins unchanged without typename", () => {
+    expect(normalizeActorLogin("github-actions")).toBe("github-actions");
+    expect(normalizeActorLogin("dependabot[bot]")).toBe("dependabot[bot]");
+  });
+
+  test("handles ghost login", () => {
+    expect(normalizeActorLogin("ghost", "Bot")).toBe("ghost[bot]");
+    expect(normalizeActorLogin("ghost")).toBe("ghost");
   });
 });
 
@@ -168,5 +203,23 @@ describe("shouldIncludeCommentByActor", () => {
     expect(
       shouldIncludeCommentByActor("user1", ["*[bot]"], ["dependabot[bot]"]),
     ).toBe(false);
+  });
+
+  test("excludes GraphQL-shaped bots when *[bot] is in exclude list", () => {
+    const graphqlBots = [
+      normalizeActorLogin("github-actions", "Bot"),
+      normalizeActorLogin("claude", "Bot"),
+      normalizeActorLogin("dependabot", "Bot"),
+    ];
+    for (const actor of graphqlBots) {
+      expect(shouldIncludeCommentByActor(actor, [], ["*[bot]"])).toBe(false);
+    }
+    expect(
+      shouldIncludeCommentByActor(
+        normalizeActorLogin("human-user", "User"),
+        [],
+        ["*[bot]"],
+      ),
+    ).toBe(true);
   });
 });

--- a/test/data-fetcher.test.ts
+++ b/test/data-fetcher.test.ts
@@ -1511,12 +1511,48 @@ describe("filterCommentsByActor", () => {
     ];
 
     const { filterCommentsByActor } = require("../src/github/data/fetcher");
-    const filtered = filterCommentsByActor(comments, "", "*[bot]");
-    // ghost comment is retained (it matches no exclude pattern); the bot is dropped.
-    expect(filtered).toHaveLength(2);
-    expect(filtered.map((c: any) => c.body)).toEqual([
+    expect(filterCommentsByActor(comments, "", "*[bot]")).toHaveLength(2);
+    expect(filterCommentsByActor(comments, "", "*[bot]").map((c: any) => c.body)).toEqual([
       "comment1",
       "from a deleted account",
+    ]);
+  });
+
+  test("excludes GraphQL-shaped bot authors with *[bot] wildcard", () => {
+    // GraphQL returns bot logins WITHOUT the [bot] suffix and with __typename Bot
+    // (REST/UI use "github-actions[bot]"). This is the shape PR/issue comments
+    // actually have after PR_QUERY / ISSUE_QUERY.
+    const comments = [
+      {
+        author: { login: "human-user", __typename: "User" },
+        body: "human comment",
+      },
+      {
+        author: { login: "github-actions", __typename: "Bot" },
+        body: "actions bot",
+      },
+      {
+        author: { login: "claude", __typename: "Bot" },
+        body: "claude app bot",
+      },
+      {
+        author: { login: "dependabot", __typename: "Bot" },
+        body: "dependabot",
+      },
+      // Username containing "bot" but not a Bot typename must stay
+      {
+        author: { login: "user-bot", __typename: "User" },
+        body: "human named user-bot",
+      },
+    ];
+
+    const { filterCommentsByActor } = require("../src/github/data/fetcher");
+    const filtered = filterCommentsByActor(comments, "", "*[bot]");
+    // Only human users remain; all Bot-typenamed authors are excluded.
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((c: any) => c.body)).toEqual([
+      "human comment",
+      "human named user-bot",
     ]);
   });
 
@@ -1536,5 +1572,69 @@ describe("filterCommentsByActor", () => {
     const onlyGhost = filterCommentsByActor(comments, "ghost", "");
     expect(onlyGhost).toHaveLength(1);
     expect(onlyGhost[0].body).toBe("from a deleted account");
+  });
+
+  test("includes only GraphQL-shaped bots with *[bot] include filter", () => {
+    const comments = [
+      {
+        author: { login: "human-user", __typename: "User" },
+        body: "human",
+      },
+      {
+        author: { login: "github-actions", __typename: "Bot" },
+        body: "bot",
+      },
+      {
+        author: { login: "claude", __typename: "Bot" },
+        body: "claude",
+      },
+    ];
+
+    const { filterCommentsByActor } = require("../src/github/data/fetcher");
+    const filtered = filterCommentsByActor(comments, "*[bot]", "");
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((c: any) => c.author.login)).toEqual([
+      "github-actions",
+      "claude",
+    ]);
+  });
+
+  test("matches specific REST-style bot pattern against GraphQL Bot login", () => {
+    const comments = [
+      {
+        author: { login: "dependabot", __typename: "Bot" },
+        body: "dependabot",
+      },
+      {
+        author: { login: "renovate", __typename: "Bot" },
+        body: "renovate",
+      },
+      {
+        author: { login: "human-user", __typename: "User" },
+        body: "human",
+      },
+    ];
+
+    const { filterCommentsByActor } = require("../src/github/data/fetcher");
+    const filtered = filterCommentsByActor(comments, "", "dependabot[bot]");
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((c: any) => c.author.login)).toEqual([
+      "renovate",
+      "human-user",
+    ]);
+  });
+
+  test("still supports REST-style logins without __typename", () => {
+    // Fixtures / older shapes that already use the [bot] suffix
+    const comments = [
+      { author: { login: "user1" }, body: "comment1" },
+      { author: { login: "github-actions[bot]" }, body: "comment2" },
+      { author: { login: "claude[bot]" }, body: "comment3" },
+    ];
+
+    const { filterCommentsByActor } = require("../src/github/data/fetcher");
+    const filtered = filterCommentsByActor(comments, "", "*[bot]");
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].author.login).toBe("user1");
   });
 });


### PR DESCRIPTION
## Summary

Make `exclude_comments_by_actor` / `include_comments_by_actor` `*[bot]` wildcard actually match bot comments fetched via GraphQL.

## Motivation

GraphQL `author.login` for bots has **no** `[bot]` suffix (e.g. `"github-actions"`, `"claude"` with `__typename: "Bot"`). The matcher only checked `actor.endsWith("[bot]")`, which is a REST/UI convention the GraphQL path never produces — so `*[bot]` was a silent no-op and bot comments (including the action's own tracking comments) still entered the prompt context.

Fixes #1514

## Changes

- Request `author { __typename login }` in `PR_QUERY` / `ISSUE_QUERY`
- Add optional `__typename` on `GitHubAuthor`
- Add `normalizeActorLogin()`: when `__typename === "Bot"` and login lacks `[bot]`, append `[bot]` for matching (REST convention)
- Apply normalization in `filterCommentsByActor` before include/exclude checks (does not mutate stored login for display)
- Tests:
  - Unit tests for `normalizeActorLogin` + GraphQL-shaped matching
  - GraphQL-shaped fixtures in `filterCommentsByActor` tests (`github-actions`/`claude`/`dependabot` with `__typename: "Bot"`)
  - Existing REST-style `*[bot]` fixtures still pass

## Tests

```bash
bun install
bun test test/actor-filter.test.ts test/data-fetcher.test.ts
bun run typecheck
```

All 110 tests pass (including new GraphQL-shaped cases). Typecheck passes.

## Notes

- Normalization only affects filter matching; formatted output still shows GraphQL logins (e.g. `github-actions` without suffix).
- Matches the existing pattern in `agent-approval-check/agent_approval_check.py` (`normalize_graphql_login`).