### PR TITLE
fix: include all text blocks in step summary tool results

### DIFF
--- a/src/entrypoints/format-turns.ts
+++ b/src/entrypoints/format-turns.ts
@@ -159,12 +159,15 @@ export function formatResultContent(content: any): string {
 
     if (
       Array.isArray(parsedContent) &&
-      parsedContent.length > 0 &&
-      typeof parsedContent[0] === "object" &&
-      parsedContent[0]?.type === "text"
+      parsedContent.some(
+        (item) => typeof item === "object" && item?.type === "text",
+      )
     ) {
-      // Extract the text field from the first item
-      contentStr = parsedContent[0]?.text || "";
+      // Concatenate all text blocks from structured tool results
+      contentStr = parsedContent
+        .filter((item) => typeof item === "object" && item?.type === "text")
+        .map((item) => item?.text || "")
+        .join("\n\n");
     } else {
       contentStr = String(content).trim();
     }

--- a/test/format-turns.test.ts
+++ b/test/format-turns.test.ts
@@ -111,6 +111,17 @@ describe("formatResultContent", () => {
     const result = formatResultContent(JSON.stringify(structuredContent));
     expect(result).toBe("**→** Hello world\n\n");
   });
+
+  test("concatenates multiple type:text blocks", () => {
+    const structuredContent = [
+      { type: "text", text: "First finding" },
+      { type: "text", text: "Second finding" },
+    ];
+    const result = formatResultContent(JSON.stringify(structuredContent));
+    expect(result).toContain("```text");
+    expect(result).toContain("First finding");
+    expect(result).toContain("Second finding");
+  });
 });
 
 describe("formatToolWithResult", () => {


### PR DESCRIPTION
## Summary

When formatting tool results for the GitHub Actions step summary, the formatter only kept the first `{ type: "text", text: "..." }` block from structured `tool_result.content` arrays. Secondary findings, file paths, and follow-up details were silently dropped from the visible Claude Code Report.

## Motivation

Fixes #1572 — multi-block structured tool results are common when tools return several text sections. Users only saw the first block in the step summary even though the full content was present in the execution file.

## Changes

- `formatResultContent`: filter and join **all** `type: "text"` blocks with `\n\n` instead of reading only `parsedContent[0]`
- Added regression test for multiple text blocks in structured content

## Tests

- `bun test test/format-turns.test.ts` — 40 pass
- `bun run typecheck` — pass
- `bun run format:check` — pass

## Notes

Joined multi-block content uses the code-block formatter (contains newline), which is consistent with existing formatting rules for multi-line results.