### PR TITLE
fix: match label_trigger case-insensitively

### DIFF
--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -38,7 +38,10 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
   if (isIssuesEvent(context) && context.eventAction === "labeled") {
     const labelName = (context.payload as any).label?.name || "";
 
-    if (labelTrigger && labelName === labelTrigger) {
+    if (
+      labelTrigger &&
+      labelName.toLowerCase() === labelTrigger.toLowerCase()
+    ) {
       console.log(`Issue labeled with trigger label '${labelTrigger}'`);
       return true;
     }

--- a/test/trigger-validation.test.ts
+++ b/test/trigger-validation.test.ts
@@ -134,6 +134,20 @@ describe("checkContainsTrigger", () => {
       expect(checkContainsTrigger(context)).toBe(false);
     });
 
+    it("should return true when the labeled name differs only in case from the trigger", () => {
+      const context = {
+        ...mockIssueLabeledContext,
+        payload: {
+          ...mockIssueLabeledContext.payload,
+          label: {
+            ...(mockIssueLabeledContext.payload as any).label,
+            name: "Claude-Task",
+          },
+        },
+      } as ParsedGitHubContext;
+      expect(checkContainsTrigger(context)).toBe(true);
+    });
+
     it("should return false for non-labeled events", () => {
       const context = {
         ...mockIssueLabeledContext,


### PR DESCRIPTION
## Summary

`label_trigger` matched labels with a case-sensitive exact comparison, so a
workflow configured with `label_trigger: "claude-task"` did not fire when an
issue received a label named `Claude-Task` (the same label name in different
casing).

## Fix

Compare the incoming label name and the configured `label_trigger` with
`toLowerCase()` in `checkContainsTrigger`. GitHub label names are unique
without regard to case, so this comparison is unambiguous. It also matches the
`trigger_phrase` check in the same function, which is already case-insensitive.

## Tests

Added a unit test covering a label whose name differs from the trigger only in
case. All checks pass locally:

- `bun test` (805 pass, 0 fail)
- `bun run typecheck` (clean)
- `bun run format:check` (clean)

Fixes #1571
