### PR TITLE
fix(branch): validate generated branch name in use_commit_signing path

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -297,6 +297,7 @@ export async function setupBranch(
       // Ensure we're on the source branch
       console.log(`Fetching and checking out source branch: ${sourceBranch}`);
       validateBranchName(sourceBranch);
+      validateBranchName(newBranch);
       execGit(["fetch", "origin", sourceBranch, "--depth=1"]);
       execGit(["checkout", sourceBranch, "--"]);
 

--- a/test/branch-template.test.ts
+++ b/test/branch-template.test.ts
@@ -192,6 +192,14 @@ describe("branch template utilities", () => {
       expect(() => validateBranchName(result)).not.toThrow();
     });
 
+    it("should reject raw colon in template output so use_commit_signing fails early (#1573)", () => {
+      const template = "{{prefix}}release:{{entityNumber}}";
+      const result = generateBranchName(template, "claude/", "issue", 123);
+
+      expect(result).toBe("claude/release:123");
+      expect(() => validateBranchName(result)).toThrow();
+    });
+
     it("should use description in template when provided", () => {
       const template = "{{prefix}}{{description}}/{{entityNumber}}";
       const result = generateBranchName(


### PR DESCRIPTION
## Summary

When `use_commit_signing` is enabled, `setupBranch` validated `sourceBranch` but not the generated `newBranch` before deferring branch creation to the file-ops server. Invalid `branch_name_template` output therefore failed late at the GitHub API instead of early with `validateBranchName`.

## Motivation

Fixes #1573 — both commit modes should reject invalid generated branch names consistently before any git or GitHub API operations.

## Changes

- Add `validateBranchName(newBranch)` in the `useCommitSigning` early-return path, matching the non-signing path
- Add regression test for raw colon in custom template output (`claude/release:123`)

## Tests

- `bun test test/branch-template.test.ts test/validate-branch-name.test.ts` — 60 pass
- `bun run typecheck` — pass
- `bun run format:check` — pass

## Notes

Validation runs after the remote-exists fallback, so the branch name that is actually returned is always checked.