### PR TITLE
fix(cache): disable setup-bun cache to avoid 5-retry HTML-error burn

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -193,6 +193,14 @@ runs:
       with:
         bun-version: 1.3.14
         token: ${{ inputs.github_token || github.token }}
+        # Disable setup-bun's cache. The upstream save step uses a deterministic
+        # key (Bun version) and isn't ref-aware: on every second-and-subsequent
+        # run against the same PR ref the GitHub cache API rejects the duplicate
+        # key+ref with a 409 (HTML body), and @actions/cache treats the unparsable
+        # response as transient and burns ~20-30s on 5 retries before warning.
+        # The 35 MB Bun binary downloads in 2-3s, so disabling the cache is a net
+        # wallclock win and removes the noisy warning. See issue #1252.
+        no-cache: true
 
     - name: Setup Custom Bun Path
       if: inputs.path_to_bun_executable != ''

--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -121,6 +121,8 @@ runs:
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # https://github.com/oven-sh/setup-bun/releases/tag/v2.2.0
       with:
         bun-version: 1.3.14
+        # Disable setup-bun's cache. See action.yml for details and issue #1252.
+        no-cache: true
 
     - name: Setup Custom Bun Path
       if: inputs.path_to_bun_executable != ''


### PR DESCRIPTION
## Summary

Follow-up to #1259 against current `main`, since the original PR is currently conflicted.

This disables `setup-bun` caching in both composite actions. The cache save can otherwise produce repeated retries and warnings, while downloading the Bun binary directly is faster in the observed runs.

## Credit

Credit to @MukundaKatta for the original diagnosis and implementation in #1259. This PR preserves the original commit authorship and applies the same minimal fix to current `main`.

Additional downstream evidence was reported in https://github.com/anthropics/claude-code-action/pull/1259#issuecomment-5082171611.

Happy to close this PR if the original author prefers to update #1259 instead.

## Validation

- `bun test` — 804 passed, 0 failed
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`
- Root-action setup smoke test at `8221ded6c0915c7b70ebab0b7bab0f42240f9490` (no prompt or API call):
  - [Run 1](https://github.com/necofuryai/necofuryai.dev/actions/runs/30720934126) — passed
  - [Run 2](https://github.com/necofuryai/necofuryai.dev/actions/runs/30720958898) — passed
  - Both runs used the same workflow ref, installed Bun 1.3.14 with `no-cache: true`, emitted no cache retry/save warnings, and left no Actions cache entry for the test branch.

Closes #1252
