### PR TITLE
fix(format): keep all text blocks in step summary tool results

### DIFF
--- a/src/entrypoints/format-turns.ts
+++ b/src/entrypoints/format-turns.ts
@@ -163,8 +163,11 @@ export function formatResultContent(content: any): string {
       typeof parsedContent[0] === "object" &&
       parsedContent[0]?.type === "text"
     ) {
-      // Extract the text field from the first item
-      contentStr = parsedContent[0]?.text || "";
+      // Join every text block; a tool result may carry more than one.
+      contentStr = parsedContent
+        .filter((block: any) => block?.type === "text")
+        .map((block: any) => block?.text || "")
+        .join("\n");
     } else {
       contentStr = String(content).trim();
     }

--- a/test/format-turns.test.ts
+++ b/test/format-turns.test.ts
@@ -111,6 +111,39 @@ describe("formatResultContent", () => {
     const result = formatResultContent(JSON.stringify(structuredContent));
     expect(result).toBe("**→** Hello world\n\n");
   });
+
+  test("keeps every text block, not just the first", () => {
+    const structuredContent = [
+      { type: "text", text: "first line" },
+      { type: "text", text: "second line" },
+      { type: "text", text: "third line" },
+    ];
+    const result = formatResultContent(JSON.stringify(structuredContent));
+    expect(result).toContain("first line");
+    expect(result).toContain("second line");
+    expect(result).toContain("third line");
+  });
+
+  test("ignores non-text blocks when joining", () => {
+    const structuredContent = [
+      { type: "text", text: "visible" },
+      { type: "image", source: { data: "base64data" } },
+      { type: "text", text: "also visible" },
+    ];
+    const result = formatResultContent(JSON.stringify(structuredContent));
+    expect(result).toContain("visible");
+    expect(result).toContain("also visible");
+    expect(result).not.toContain("base64data");
+  });
+
+  test("accepts structured content passed as an array", () => {
+    const result = formatResultContent([
+      { type: "text", text: "alpha" },
+      { type: "text", text: "beta" },
+    ]);
+    expect(result).toContain("alpha");
+    expect(result).toContain("beta");
+  });
 });
 
 describe("formatToolWithResult", () => {


### PR DESCRIPTION
Fixes #1572.

`formatResultContent` only read `parsedContent[0].text`, so a `tool_result` whose `content` holds multiple text blocks rendered only the first one in the step summary — the rest were silently dropped from the Claude Code Report even though they're present in the transcript.

**Before**

```
[{"type":"text","text":"first line"},{"type":"text","text":"second line"}]
→ "**→** first line"
```

**After**

```
→ "**→** first line\nsecond line"
```

Non-text blocks (e.g. images) are skipped rather than stringified, and the single-block case is unchanged.

### Tests

Three cases added to `test/format-turns.test.ts`: multiple text blocks, mixed text/image blocks, and structured content passed as an array rather than a JSON string. All three fail on `main` and pass with this change.

```
bun test              807 pass, 0 fail
bun run typecheck     clean
bun run format:check  clean
```