### PR TITLE
feat(context): include diffHunk in PR review comment context

### DIFF
--- a/src/github/api/queries/github.ts
+++ b/src/github/api/queries/github.ts
@@ -84,6 +84,7 @@ export const PR_QUERY = `
                 body
                 path
                 line
+                diffHunk
                 author {
                   login
                 }

--- a/src/github/data/formatter.ts
+++ b/src/github/data/formatter.ts
@@ -118,7 +118,16 @@ export function formatReviewComments(
 
           body = sanitizeContent(body);
 
-          return `  [Comment on ${comment.path}:${comment.line || "?"}]: ${body}`;
+          let formatted = `  [Comment on ${comment.path}:${comment.line || "?"}]: ${body}`;
+
+          // The diff hunk is the code the comment was left on. Without it the
+          // comment arrives without the context it was written against.
+          if (comment.diffHunk) {
+            const diffHunk = sanitizeContent(comment.diffHunk);
+            formatted += `\n  Diff context:\n\`\`\`diff\n${diffHunk}\n\`\`\``;
+          }
+
+          return formatted;
         })
         .join("\n");
       if (comments) {

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -22,6 +22,7 @@ export type GitHubComment = {
 export type GitHubReviewComment = GitHubComment & {
   path: string;
   line: number | null;
+  diffHunk?: string | null;
 };
 
 export type GitHubCommit = {

--- a/test/data-formatter.test.ts
+++ b/test/data-formatter.test.ts
@@ -540,6 +540,43 @@ describe("formatReviewComments", () => {
     expect(result).not.toContain("Diff context:");
   });
 
+  // GitHub returns line: null and diffHunk: "" for outdated comments whose
+  // line no longer exists in the diff (observed on anthropics/claude-code-action#1025).
+  test("omits the diff context for an outdated comment with an empty diff hunk", () => {
+    const reviewData = {
+      nodes: [
+        {
+          id: "review1",
+          databaseId: "300001",
+          author: { login: "reviewer1" },
+          body: "",
+          state: "COMMENTED",
+          submittedAt: "2023-01-01T00:00:00Z",
+          comments: {
+            nodes: [
+              {
+                id: "comment1",
+                databaseId: "200001",
+                body: "Outdated comment",
+                author: { login: "reviewer1" },
+                createdAt: "2023-01-01T00:00:00Z",
+                path: "src/index.ts",
+                line: null,
+                diffHunk: "",
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = formatReviewComments(reviewData);
+
+    expect(result).toContain("[Comment on src/index.ts:?]: Outdated comment");
+    expect(result).not.toContain("Diff context:");
+    expect(result).not.toContain("```diff");
+  });
+
   test("formats review with only body (no comments) correctly", () => {
     const reviewData = {
       nodes: [

--- a/test/data-formatter.test.ts
+++ b/test/data-formatter.test.ts
@@ -471,6 +471,75 @@ describe("formatReviewComments", () => {
     );
   });
 
+  test("includes the diff hunk as context when present", () => {
+    const reviewData = {
+      nodes: [
+        {
+          id: "review1",
+          databaseId: "300001",
+          author: { login: "reviewer1" },
+          body: "",
+          state: "COMMENTED",
+          submittedAt: "2023-01-01T00:00:00Z",
+          comments: {
+            nodes: [
+              {
+                id: "comment1",
+                databaseId: "200001",
+                body: "This can overflow",
+                author: { login: "reviewer1" },
+                createdAt: "2023-01-01T00:00:00Z",
+                path: "src/index.ts",
+                line: 42,
+                diffHunk: "@@ -40,3 +40,3 @@\n-const a = 1;\n+const a = 2;",
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = formatReviewComments(reviewData);
+
+    expect(result).toContain("[Comment on src/index.ts:42]: This can overflow");
+    expect(result).toContain("Diff context:");
+    expect(result).toContain("@@ -40,3 +40,3 @@");
+    expect(result).toContain("+const a = 2;");
+  });
+
+  test("omits the diff context when the comment has no diff hunk", () => {
+    const reviewData = {
+      nodes: [
+        {
+          id: "review1",
+          databaseId: "300001",
+          author: { login: "reviewer1" },
+          body: "",
+          state: "COMMENTED",
+          submittedAt: "2023-01-01T00:00:00Z",
+          comments: {
+            nodes: [
+              {
+                id: "comment1",
+                databaseId: "200001",
+                body: "No hunk here",
+                author: { login: "reviewer1" },
+                createdAt: "2023-01-01T00:00:00Z",
+                path: "src/index.ts",
+                line: 42,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const result = formatReviewComments(reviewData);
+
+    expect(result).toContain("[Comment on src/index.ts:42]: No hunk here");
+    expect(result).not.toContain("Diff context:");
+  });
+
   test("formats review with only body (no comments) correctly", () => {
     const reviewData = {
       nodes: [


### PR DESCRIPTION
Fixes #855.

Review comments were passed to Claude with only `path` and `line`, so the code the comment was actually written against never reached the prompt. `diffHunk` is available on `PullRequestReviewComment` in the GraphQL API but wasn't being selected.

**Before**
```
  [Comment on src/index.ts:42]: This can overflow
```

**After**
```
  [Comment on src/index.ts:42]: This can overflow
  Diff context:
  ```diff
  @@ -40,3 +40,3 @@
  -const a = 1;
  +const a = 2;
  ```
```

Three changes: select `diffHunk` in the reviews query, add it to `GitHubReviewComment` as optional, and render it under the comment.

Two notes on the implementation:

- The hunk is PR-authored content reaching the prompt, so it goes through `sanitizeContent` the same way the comment body does.
- It's optional and the render is guarded, so comments without a hunk produce byte-identical output to before. All existing `formatReviewComments` tests pass unchanged.

Verified `diffHunk` against the live schema rather than assuming:

```
gh api graphql -f query='query { __type(name: "PullRequestReviewComment") { fields { name } } }'
→ diffHunk, line, path
```

### Tests

Two cases added to `test/data-formatter.test.ts`: a comment with a hunk, and one without. On `main` the first fails (`Expected to contain: "Diff context:"`); the second passes both before and after, which is the control showing existing output is unaffected.

```
bun test              806 pass, 0 fail
bun run typecheck     clean
bun run format:check  clean
```