### PR TITLE
fix: support labeled action for pull_request events in track_progress

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -134,7 +134,7 @@ inputs:
     required: false
     default: "claude[bot]"
   track_progress:
-    description: "Force tag mode with tracking comments for pull_request and issue events. Only applicable to pull_request (opened, synchronize, ready_for_review, reopened) and issue (opened, edited, labeled, assigned) events."
+    description: "Force tag mode with tracking comments for pull_request and issue events. Only applicable to pull_request (opened, synchronize, ready_for_review, reopened, labeled) and issue (opened, edited, labeled, assigned) events."
     required: false
     default: "false"
   include_fix_links:

--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -103,6 +103,7 @@ function validateTrackProgressEvent(context: GitHubContext): void {
       "synchronize",
       "ready_for_review",
       "reopened",
+      "labeled",
     ];
     if (!validActions.includes(context.eventAction)) {
       throw new Error(

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -76,6 +76,20 @@ describe("detectMode with enhanced routing", () => {
       expect(detectMode(context)).toBe("agent");
     });
 
+    it("should use tag mode when track_progress is true for pull_request.labeled", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "labeled",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: { ...baseContext.inputs, trackProgress: true },
+      };
+
+      expect(detectMode(context)).toBe("tag");
+    });
+
     it("should throw error when track_progress is used with unsupported PR action", () => {
       const context: GitHubContext = {
         ...baseContext,


### PR DESCRIPTION
## Summary

Adds `"labeled"` to the valid `pull_request` actions accepted by `track_progress`, mirroring the existing support for `issue` events (which already allow `labeled`).

Fixes #1585

## Problem

`track_progress` is only valid for `pull_request` actions `opened`, `synchronize`, `ready_for_review`, `reopened`. Using `track_progress: true` with `on: pull_request: types: [labeled]` fails validation:

```
Error: track_progress for pull_request events is only supported for actions: opened, synchronize, ready_for_review, reopened. Current action: labeled
```

This blocks the common "add a label to trigger a Claude PR review" pattern, even though the identical pattern already works for issues.

## Changes

- `src/modes/detector.ts`: add `"labeled"` to `validActions` in `validateTrackProgressEvent()`.
- `action.yml`: update the `track_progress` input description to list `labeled` as a supported `pull_request` action.
- `test/modes/detector.test.ts`: add a test asserting tag mode is used for `pull_request.labeled` with `track_progress: true`.

## Test plan

- [x] `bun test test/modes/detector.test.ts` — 16 pass, 0 fail
- [x] `bun run typecheck` — passes
