### PR TITLE
Pin bun config for MCP server processes

### DIFF
--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -17,6 +17,20 @@ type PrepareConfigParams = {
   context: GitHubContext;
 };
 
+// Build the bun invocation for one of the action's own MCP servers. The
+// flags mirror the entrypoint invocation in action.yml so the server process
+// reads its runtime config from the action directory rather than from the
+// process working directory.
+function bunServerArgs(scriptPath: string): string[] {
+  const actionPath = process.env.GITHUB_ACTION_PATH;
+  return [
+    "--no-env-file",
+    `--config=${actionPath}/bunfig.toml`,
+    "run",
+    `${actionPath}/${scriptPath}`,
+  ];
+}
+
 async function checkActionsReadPermission(
   token: string,
   owner: string,
@@ -97,10 +111,7 @@ export async function prepareMcpConfig(
     if (shouldIncludeCommentServer) {
       baseMcpConfig.mcpServers.github_comment = {
         command: "bun",
-        args: [
-          "run",
-          `${process.env.GITHUB_ACTION_PATH}/src/mcp/github-comment-server.ts`,
-        ],
+        args: bunServerArgs("src/mcp/github-comment-server.ts"),
         env: {
           GITHUB_TOKEN: githubToken,
           REPO_OWNER: owner,
@@ -116,10 +127,7 @@ export async function prepareMcpConfig(
     if (context.inputs.useCommitSigning) {
       baseMcpConfig.mcpServers.github_file_ops = {
         command: "bun",
-        args: [
-          "run",
-          `${process.env.GITHUB_ACTION_PATH}/src/mcp/github-file-ops-server.ts`,
-        ],
+        args: bunServerArgs("src/mcp/github-file-ops-server.ts"),
         env: {
           GITHUB_TOKEN: githubToken,
           REPO_OWNER: owner,
@@ -142,10 +150,7 @@ export async function prepareMcpConfig(
     ) {
       baseMcpConfig.mcpServers.github_inline_comment = {
         command: "bun",
-        args: [
-          "run",
-          `${process.env.GITHUB_ACTION_PATH}/src/mcp/github-inline-comment-server.ts`,
-        ],
+        args: bunServerArgs("src/mcp/github-inline-comment-server.ts"),
         env: {
           GITHUB_TOKEN: githubToken,
           REPO_OWNER: owner,
@@ -187,10 +192,7 @@ export async function prepareMcpConfig(
       } else {
         baseMcpConfig.mcpServers.github_ci = {
           command: "bun",
-          args: [
-            "run",
-            `${process.env.GITHUB_ACTION_PATH}/src/mcp/github-actions-server.ts`,
-          ],
+          args: bunServerArgs("src/mcp/github-actions-server.ts"),
           env: {
             // Use workflow github token, not app token
             GITHUB_TOKEN: process.env.DEFAULT_WORKFLOW_TOKEN,

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -214,6 +214,46 @@ describe("prepareMcpConfig", () => {
     );
   });
 
+  test("should pin bun config flags before run for every bun server", async () => {
+    process.env.GITHUB_ACTION_PATH = "/test/action/path";
+    process.env.DEFAULT_WORKFLOW_TOKEN = "workflow-token";
+
+    const result = await prepareMcpConfig({
+      githubToken: "test-token",
+      owner: "test-owner",
+      repo: "test-repo",
+      branch: "test-branch",
+      baseBranch: "main",
+      allowedTools: ["mcp__github_inline_comment__create_inline_comment"],
+      mode: "tag",
+      context: {
+        ...mockPRContext,
+        inputs: { ...mockPRContext.inputs, useCommitSigning: true },
+      },
+    });
+
+    const parsed = JSON.parse(result);
+    const servers: Record<string, string> = {
+      github_comment: "src/mcp/github-comment-server.ts",
+      github_file_ops: "src/mcp/github-file-ops-server.ts",
+      github_inline_comment: "src/mcp/github-inline-comment-server.ts",
+      github_ci: "src/mcp/github-actions-server.ts",
+    };
+
+    for (const [name, script] of Object.entries(servers)) {
+      expect(parsed.mcpServers[name]).toBeDefined();
+      expect(parsed.mcpServers[name].command).toBe("bun");
+      expect(parsed.mcpServers[name].args).toEqual([
+        "--no-env-file",
+        "--config=/test/action/path/bunfig.toml",
+        "run",
+        `/test/action/path/${script}`,
+      ]);
+    }
+
+    delete process.env.DEFAULT_WORKFLOW_TOKEN;
+  });
+
   test("should use current working directory when GITHUB_WORKSPACE is not set", async () => {
     delete process.env.GITHUB_WORKSPACE;
 


### PR DESCRIPTION
## Summary

- The action's entrypoints in `action.yml` already run bun with `--no-env-file --config="${GITHUB_ACTION_PATH}/bunfig.toml"` so runtime config resolves from the action directory rather than the current working directory. The bun-based MCP server processes (`github_comment`, `github_file_ops`, `github_inline_comment`, `github_ci`) were spawned with plain `bun run <script>`, so they picked up `bunfig.toml` and `.env` from whatever directory they happened to start in.
- Adds a small `bunServerArgs()` helper that builds the same invocation for all four servers, so they resolve config consistently with the entrypoints.
- The docker-based GitHub MCP server is unchanged.

## Test plan

- [x] `bun test` (805 pass) — new test asserts each bun server's args include the pinned flags before `run`
- [x] `bun run typecheck`
- [x] `bun run format:check`
- [x] Manually confirmed with bun 1.3.x that `--config` alone still loads a cwd `.env`, and `--no-env-file` alone still reads a cwd `bunfig.toml`; both flags together read neither.