### PR TITLE
fix: handle null files field from GraphQL on very large PRs

### DIFF
--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -424,7 +424,12 @@ export async function fetchGitHubData({
       if (prResult.repository.pullRequest) {
         const pullRequest = prResult.repository.pullRequest;
         contextData = pullRequest;
-        changedFiles = pullRequest.files.nodes || [];
+        if (pullRequest.files === null) {
+          console.warn(
+            `GitHub did not return the file list for PR #${prNumber} (diff likely too large); proceeding without file-level context`,
+          );
+        }
+        changedFiles = pullRequest.files?.nodes ?? [];
         comments = filterCommentsByActor(
           filterCommentsToTriggerTime(
             pullRequest.comments?.nodes || [],

--- a/src/github/data/formatter.ts
+++ b/src/github/data/formatter.ts
@@ -28,7 +28,7 @@ PR Labels: ${formatLabels(prData.labels.nodes)}
 PR Additions: ${prData.additions}
 PR Deletions: ${prData.deletions}
 Total Commits: ${prData.commits.totalCount}
-Changed Files: ${prData.files.nodes.length} files`;
+Changed Files: ${prData.files ? `${prData.files.nodes.length} files` : "unknown (file list unavailable)"}`;
   } else {
     const issueData = contextData as GitHubIssue;
     const sanitizedTitle = sanitizeContent(issueData.title);

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -85,9 +85,13 @@ export type GitHubPullRequest = {
       commit: GitHubCommit;
     }>;
   };
+  // GitHub's GraphQL `files` field resolves to null when the PR's diff is too
+  // large for GitHub to compute (very large PRs). `changedFiles` is also
+  // misreported as 0 in that case, so the null must be guarded and treated as
+  // "file list unavailable" rather than "no files changed".
   files: {
     nodes: GitHubFile[];
-  };
+  } | null;
   comments: {
     nodes: GitHubComment[];
   };

--- a/test/data-fetcher.test.ts
+++ b/test/data-fetcher.test.ts
@@ -1775,6 +1775,49 @@ describe("fetchGitHubData integration with time filtering", () => {
     // Webhook says no body at trigger time — attacker-added GraphQL body must not be used
     expect(result.contextData.body).toBe("");
   });
+
+  it("should not crash when GraphQL returns null files for a very large PR", async () => {
+    // GitHub declines to compute the diff for very large PRs: `files` comes
+    // back as null (with no errors entry) and `changedFiles` is misreported
+    // as 0. The fetch must degrade gracefully instead of throwing.
+    const mockOctokits = {
+      graphql: jest.fn().mockResolvedValue({
+        repository: {
+          pullRequest: {
+            number: 7912,
+            title: "Very large PR",
+            body: "PR body",
+            author: { login: "author" },
+            createdAt: "2024-01-15T10:00:00Z",
+            state: "OPEN",
+            labels: { nodes: [] },
+            comments: { nodes: [] },
+            files: null,
+            reviews: { nodes: [] },
+          },
+        },
+        user: { login: "trigger-user" },
+      }),
+      rest: {
+        pulls: {
+          listFiles: jest.fn().mockResolvedValue({ data: [] }),
+        },
+      },
+    };
+
+    const result = await fetchGitHubData({
+      octokits: mockOctokits as any,
+      repository: "test-owner/test-repo",
+      prNumber: "7912",
+      isPR: true,
+      triggerUsername: "trigger-user",
+      triggerTime: "2024-01-15T12:00:00Z",
+    });
+
+    // No file list is available, so the PR is processed without file-level context.
+    expect(result.changedFiles).toEqual([]);
+    expect(result.changedFilesWithSHA).toEqual([]);
+  });
 });
 
 describe("filterCommentsByActor", () => {

--- a/test/data-formatter.test.ts
+++ b/test/data-formatter.test.ts
@@ -108,6 +108,43 @@ Changed Files: 2 files`,
     );
   });
 
+  test("renders an unknown file count when GraphQL returns null files (very large PR)", () => {
+    // GitHub declines to compute the diff for very large PRs and returns
+    // `files: null`. `changedFiles` is misreported as 0 in that case, so the
+    // count must render as unavailable rather than "0 files".
+    const prData: GitHubPullRequest = {
+      title: "Very large PR",
+      body: "PR body",
+      author: { login: "test-user" },
+      baseRefName: "main",
+      headRefName: "feature/test",
+      headRefOid: "abc123",
+      isCrossRepository: false,
+      headRepository: { owner: { login: "testowner" }, name: "testrepo" },
+      createdAt: "2023-01-01T00:00:00Z",
+      additions: 50,
+      deletions: 30,
+      state: "OPEN",
+      labels: {
+        nodes: [],
+      },
+      commits: {
+        totalCount: 3,
+        nodes: [],
+      },
+      files: null,
+      comments: {
+        nodes: [],
+      },
+      reviews: {
+        nodes: [],
+      },
+    };
+
+    const result = formatContext(prData, true);
+    expect(result).toContain("Changed Files: unknown (file list unavailable)");
+  });
+
   test("formats Issue context correctly", () => {
     const issueData: GitHubIssue = {
       title: "Test Issue",


### PR DESCRIPTION
Fixes #1587

## Problem / root cause

GitHub's GraphQL API declines to compute the diff for very large PRs (thousands of changed files). When that happens, the `files` field on `pullRequest` resolves to `null` — with **no** `errors` entry in the response — and `changedFiles` is misreported as `0`. A public repro: querying `monarch-initiative/dismech` PR 7912 returns `{"changedFiles": 0, "files": null}`.

The action types `files` as non-null and dereferences it directly, so any run triggered on such a PR crashes:

```
TypeError: null is not an object (evaluating 'pullRequest.files.nodes')
```

`fetchGitHubData` swallows this into a generic `Failed to fetch PR data` and the action exits with code 1 (see the failing run linked from the issue). There were two crash sites:

- `src/github/data/fetcher.ts` — `pullRequest.files.nodes` (the primary crash in the traceback)
- `src/github/data/formatter.ts` — `prData.files.nodes.length` (latent second crash from the same null)

This is the same class of bug as #1489 (null `author` from GraphQL for deleted accounts), fixed in #1490; this PR mirrors that fix's approach.

## Changes

- **`src/github/types.ts`**: widen `GitHubPullRequest.files` to `{ nodes: GitHubFile[] } | null`, with a comment documenting when GitHub returns null. Since the type is now nullable, `tsc` (strict) flags every dereference — so this covers all of them, not just the one in the traceback.
- **`src/github/data/fetcher.ts`**: guard with `pullRequest.files?.nodes ?? []` and log a warning ("GitHub did not return the file list for this PR (diff likely too large); proceeding without file-level context"). The run degrades gracefully instead of exiting 1 — downstream consumers already handle empty file arrays.
- **`src/github/data/formatter.ts`**: render the changed-file count as `unknown (file list unavailable)` when `files` is null, rather than trusting the misreported `changedFiles: 0` and printing "0 files".

Deliberately **not** included: a REST-API fallback for the file list (floated in the issue). REST file listings are also partial/unreliable for these oversized PRs, and the minimal null-guard matches the scope of the merged precedent #1490.

## Tests

Regression cases mirroring #1490's test placement:

- `test/data-fetcher.test.ts` — a `fetchGitHubData` case whose mocked GraphQL PR response has `files: null`; asserts the fetch resolves (no throw) with empty `changedFiles` / `changedFilesWithSHA`.
- `test/data-formatter.test.ts` — a `formatContext` case with `files: null`; asserts the output contains `Changed Files: unknown (file list unavailable)`.

## Verification

- `bun test`: 823 pass, 0 fail (bun 1.2.12, the version pinned in CI)
- `bun run typecheck` (`tsc --noEmit`): clean
- `bun run format:check` (`prettier --check .`): clean
- Coverage sanity check: temporarily reverting the fetcher guard makes the new fetcher test fail with exactly the reported `TypeError`; restoring the guard turns it green again.
- Re-ran the reporter's public repro at submission time: `monarch-initiative/dismech` PR 7912 still returns `{"changedFiles": 0, "files": null}` via the GraphQL API.
