### PR TITLE
Invoke the formatter directly from the format hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run format"
+            "command": "bunx prettier@3.5.3 --no-config --write ."
           }
         ],
         "matcher": "Edit|Write|MultiEdit"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 # Test fixtures should not be formatted to preserve exact output matching
 test/fixtures/
+# Snapshot of PR-authored config kept for review; do not reformat
+.claude-pr/

--- a/docs/security.md
+++ b/docs/security.md
@@ -49,6 +49,12 @@
 
 This is general guidance for these event types — see [GitHub's documentation](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).
 
+### Which files come from the base branch on pull requests
+
+When the action runs against a pull request, it restores a fixed list of Claude configuration paths from the PR base branch before starting Claude: `.claude/`, `.mcp.json`, `.claude.json`, `.gitmodules`, `.ripgreprc`, `CLAUDE.md`, `CLAUDE.local.md`, and `.husky/`. Paths in that list that do not exist on the base branch are removed, and the PR-authored versions are kept under `.claude-pr/` for reference only.
+
+Everything else in the working tree — including `package.json`, lockfiles, `Makefile`, `node_modules/`, and formatter/linter config files — stays at the PR head. If a hook, `apiKeyHelper`, or `statusLine` command in your base-branch `.claude/settings.json` runs a package-manager script (`bun run …`, `npm run …`, `yarn …`, `pnpm run …`), a `make` target, a repo-relative script, or a tool that loads executable project config, that command resolves through files the pull request supplies. Keep such commands self-contained: invoke the tool directly with a pinned version and pass its configuration on the command line (for example `bunx prettier@3.5.3 --no-config --write .` rather than `bun run format`).
+
 ### `claude-code-action` vs `claude-code-base-action`
 
 `claude-code-base-action` is a lower-level building block that installs and runs Claude Code with the inputs you provide. It does not perform actor permission checks or restore project configuration from the base ref. If you need those behaviors, use this action (`claude-code-action`). See the [base-action README](../base-action/README.md#trust-model) for details.

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,6 +55,8 @@ When the action runs against a pull request, it restores a fixed list of Claude 
 
 Everything else in the working tree — including `package.json`, lockfiles, `Makefile`, `node_modules/`, and formatter/linter config files — stays at the PR head. If a hook, `apiKeyHelper`, or `statusLine` command in your base-branch `.claude/settings.json` runs a package-manager script (`bun run …`, `npm run …`, `yarn …`, `pnpm run …`), a `make` target, a repo-relative script, or a tool that loads executable project config, that command resolves through files the pull request supplies. Keep such commands self-contained: invoke the tool directly with a pinned version and pass its configuration on the command line (for example `bunx prettier@3.5.3 --no-config --write .` rather than `bun run format`).
 
+Note that the runtime executing the tool also reads project config. `bunx <tool>` runs the tool's script under `node` when `node` is on `PATH` (as it is on GitHub-hosted runners); when only Bun is available, Bun executes the script itself and reads `bunfig.toml` from the checkout — including `preload` entries — which comes from the PR head. On such runners, make sure `node` is on `PATH` for the hook, and treat `bunfig.toml` and `.npmrc` in the checkout as PR-controlled runtime config.
+
 ### `claude-code-action` vs `claude-code-base-action`
 
 `claude-code-base-action` is a lower-level building block that installs and runs Claude Code with the inputs you provide. It does not perform actor permission checks or restore project configuration from the base ref. If you need those behaviors, use this action (`claude-code-action`). See the [base-action README](../base-action/README.md#trust-model) for details.

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -86,6 +86,15 @@ function ensureClaudePrExcludedFromGit(): void {
  * commits with `git add -A`, the revert will be included in that commit. This
  * is a narrow UX tradeoff for closing the RCE surface.
  *
+ * Only the paths listed in SENSITIVE_PATHS come from the base branch; the rest
+ * of the working tree stays at the PR head. A base-branch hook or setting that
+ * calls out through files a PR can change — package-manager scripts
+ * (`bun run`, `npm run`, `yarn`, `pnpm run`), Makefile or task-runner targets,
+ * repo-relative script paths, or tools that load executable project config —
+ * therefore runs whatever the PR head provides. Keep restored hooks
+ * self-contained: invoke the tool binary directly, pin its version, and pass
+ * config on the command line rather than reading it from the checkout.
+ *
  * @param baseBranch - PR base branch name. Must be pre-validated (branch.ts
  *   calls validateBranchName on it before returning).
  */

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -93,7 +93,11 @@ function ensureClaudePrExcludedFromGit(): void {
  * repo-relative script paths, or tools that load executable project config —
  * therefore runs whatever the PR head provides. Keep restored hooks
  * self-contained: invoke the tool binary directly, pin its version, and pass
- * config on the command line rather than reading it from the checkout.
+ * config on the command line rather than reading it from the checkout. This
+ * extends to the runtime itself: `bunx <tool>` runs the tool under `node` when
+ * `node` is on PATH, but on a Bun-only runner Bun executes the script and reads
+ * `bunfig.toml` (e.g. `preload`) from the checkout, so `bunfig.toml` and
+ * `.npmrc` there are PR-controlled runtime config too.
  *
  * @param baseBranch - PR base branch name. Must be pre-validated (branch.ts
  *   calls validateBranchName on it before returning).


### PR DESCRIPTION
## Summary

- Changes the repo's PostToolUse format hook from `bun run format` to `bunx prettier@3.5.3 --no-config --write .`, so the hook invokes prettier directly (same pinned version as the `package.json` devDependency) instead of resolving through the `scripts` entry in whatever `package.json` is checked out. Output is identical for the current config (both `.prettierrc` files are `{}`, and `.prettierignore` is still honored).
- Documents the existing behavior in `docs/security.md` and the `restoreConfigFromBase` doc comment: only the listed config paths are restored from the base branch on pull requests, so hooks/settings that come from the base branch should invoke tools directly rather than through package-manager scripts, Makefile targets, or repo-relative scripts. No runtime code change.

## Test plan

- [x] `bun test` (804 pass), `bun run typecheck`, `bun run format:check`
- [x] Ran the new hook command and the old `bun run format` against deliberately mis-formatted ts/yaml/md/json — byte-identical results