### PR TITLE
Scope the config snapshot to files inside the working tree

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -5,9 +5,10 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
 } from "fs";
-import { dirname } from "path";
+import { dirname, join, sep } from "path";
 
 // Paths that are both PR-controllable and read from cwd at CLI startup.
 //
@@ -30,18 +31,86 @@ const SENSITIVE_PATHS = [
 
 const CLAUDE_PR_EXCLUDE_PATTERN = "/.claude-pr/";
 
-function snapshotSensitivePath(src: string, dest: string): void {
+function isSameOrInside(child: string, parent: string): boolean {
+  return child === parent || child.startsWith(`${parent}${sep}`);
+}
+
+// The snapshot is scoped to repository content. An entry is copied with its
+// content only when its real target (through any symlinks) lies inside the
+// working tree, is not git metadata or the snapshot itself, and does not lead
+// back into a directory already on the entry's own path (which would recurse).
+// Anything else — targets outside the working tree, dangling or looping links —
+// is recorded as a link only, so the target is never followed.
+function shouldSnapshotContent(
+  entryPath: string,
+  workTreeRealPath: string,
+): boolean {
   try {
-    cpSync(src, dest, { recursive: true, dereference: true });
+    const targetRealPath = realpathSync(entryPath);
+    if (!isSameOrInside(targetRealPath, workTreeRealPath)) {
+      return false;
+    }
+    for (const excluded of [".git", ".claude-pr"]) {
+      if (isSameOrInside(targetRealPath, join(workTreeRealPath, excluded))) {
+        return false;
+      }
+    }
+    for (let dir = dirname(entryPath); ; dir = dirname(dir)) {
+      if (isSameOrInside(realpathSync(dir), targetRealPath)) {
+        return false;
+      }
+      if (dir === dirname(dir)) {
+        return true;
+      }
+    }
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Copies a sensitive path into the review snapshot. Entries whose targets
+ * pass the confinement check above are copied dereferenced (reviewers see
+ * the effective content); all other symlinks are preserved as link nodes and
+ * their targets are never copied. Applies per entry, including symlinks nested
+ * inside a real directory.
+ */
+function snapshotSensitivePath(
+  src: string,
+  dest: string,
+  workTreeRealPath: string,
+): void {
+  const linksToPreserve: Array<{ src: string; dest: string }> = [];
+  try {
+    cpSync(src, dest, {
+      recursive: true,
+      dereference: true,
+      filter: (entrySrc, entryDest) => {
+        if (shouldSnapshotContent(entrySrc, workTreeRealPath)) {
+          return true;
+        }
+        linksToPreserve.push({ src: entrySrc, dest: entryDest });
+        return false;
+      },
+    });
   } catch (error) {
-    // Symlinks whose targets are absent on the PR head (e.g. `.claude/CLAUDE.md`
-    // -> `../AGENTS.md` when the PR deleted the target) make dereferenced
-    // copies throw ENOENT. Preserve the symlink for the review snapshot instead.
+    // Dangling symlinks are normally caught by the filter above and recorded
+    // as links. If a target disappears between that check and the copy, the
+    // dereferenced copy throws ENOENT; preserve the symlinks for the review
+    // snapshot instead of failing the restore.
     if (error instanceof Error && "code" in error && error.code === "ENOENT") {
       cpSync(src, dest, { recursive: true });
       return;
     }
     throw error;
+  }
+
+  for (const link of linksToPreserve) {
+    console.warn(
+      `Snapshot: ${link.src} points outside the snapshot scope; recording the link only`,
+    );
+    mkdirSync(dirname(link.dest), { recursive: true });
+    cpSync(link.src, link.dest, { recursive: true, verbatimSymlinks: true });
   }
 }
 
@@ -97,11 +166,13 @@ export function restoreConfigFromBase(baseBranch: string): void {
   // Snapshot every PR-authored sensitive path into .claude-pr/ before deletion
   // so review agents can inspect what the PR changes without those files ever
   // being executed. Captured before the security delete so it reflects the
-  // PR-authored version.
+  // PR-authored version. Symlink targets outside the working tree are recorded
+  // as links only, keeping the snapshot scoped to repository content.
   rmSync(".claude-pr", { recursive: true, force: true });
+  const workTreeRealPath = realpathSync(process.cwd());
   for (const p of SENSITIVE_PATHS) {
     if (existsSync(p)) {
-      snapshotSensitivePath(p, `.claude-pr/${p}`);
+      snapshotSensitivePath(p, `.claude-pr/${p}`, workTreeRealPath);
     }
   }
   if (existsSync(".claude-pr")) {

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -12,7 +12,7 @@ import {
   statSync,
   writeFileSync,
 } from "fs";
-import { dirname, join, relative, sep } from "path";
+import { dirname, join, posix, relative, sep } from "path";
 
 // Paths that are both PR-controllable and read from cwd at CLI startup.
 //
@@ -39,6 +39,46 @@ function isSameOrInside(child: string, parent: string): boolean {
   return child === parent || child.startsWith(`${parent}${sep}`);
 }
 
+// Repository paths (relative to cwd, `/`-separated) that a link may resolve
+// to: `files` are tracked files whose working-tree content is unchanged from
+// HEAD, `dirs` are directories that contain at least one tracked file.
+type TrackedPaths = { files: Set<string>; dirs: Set<string> };
+
+// Built from the superproject only: `git ls-files` reports a submodule as a
+// single entry, so paths inside a checked-out submodule are in neither set and
+// links into one are recorded as placeholders.
+function listTrackedPaths(): TrackedPaths {
+  const gitPathList = (args: string[]) =>
+    execFileSync("git", args, { encoding: "utf8", maxBuffer: Infinity })
+      .split("\0")
+      .filter(Boolean);
+  const modified = new Set(
+    gitPathList([
+      "diff",
+      "--name-only",
+      "-z",
+      "--relative",
+      "--ignore-submodules",
+      "HEAD",
+      "--",
+    ]),
+  );
+  const tracked: TrackedPaths = { files: new Set(), dirs: new Set() };
+  for (const file of gitPathList(["ls-files", "-z"])) {
+    if (!modified.has(file)) {
+      tracked.files.add(file);
+    }
+    for (
+      let dir = posix.dirname(file);
+      dir !== "." && !tracked.dirs.has(dir);
+      dir = posix.dirname(dir)
+    ) {
+      tracked.dirs.add(dir);
+    }
+  }
+  return tracked;
+}
+
 // The snapshot is scoped to tracked repository content and never contains
 // links. An entry is copied with its content only when all of these hold:
 //   1. its real target (through any links) lies inside the working tree;
@@ -48,17 +88,20 @@ function isSameOrInside(child: string, parent: string): boolean {
 //      path (which would recurse);
 //   4. if the entry is reached through a link (it is one, or a directory above
 //      it inside the sensitive path is), a file target must be tracked in the
-//      checkout. Directory targets reached through a link are descended into
-//      and their children are checked individually.
+//      checkout with its content unchanged from HEAD, and a directory target
+//      must contain at least one tracked file (see listTrackedPaths). Directory
+//      targets that pass are descended into and their children are checked
+//      individually.
 // Files and directories at their literal, non-linked location are unaffected
 // by rule 4 and are copied as-is. Every other entry — targets outside the
-// tree, dangling or looping links, git metadata, untracked files reached
-// through a link — is recorded as a placeholder file (see recordPlaceholder),
-// so nothing in the snapshot resolves anywhere else.
+// tree, dangling or looping links, git metadata, submodule contents, untracked
+// or locally modified files reached through a link — is recorded as a
+// placeholder file (see recordPlaceholder), so nothing in the snapshot
+// resolves anywhere else.
 function shouldSnapshotContent(
   entryPath: string,
   workTreeRealPath: string,
-  trackedFiles: Set<string>,
+  tracked: TrackedPaths,
 ): boolean {
   try {
     const targetRealPath = realpathSync(entryPath);
@@ -81,11 +124,13 @@ function shouldSnapshotContent(
       workTreeRealPath,
       relative(process.cwd(), entryPath),
     );
-    return (
-      targetRealPath === literalPath ||
-      statSync(targetRealPath).isDirectory() ||
-      trackedFiles.has(targetParts.join("/"))
-    );
+    if (targetRealPath === literalPath) {
+      return true;
+    }
+    const targetRepoPath = targetParts.join("/");
+    return statSync(targetRealPath).isDirectory()
+      ? tracked.dirs.has(targetRepoPath)
+      : tracked.files.has(targetRepoPath);
   } catch {
     return false;
   }
@@ -117,7 +162,7 @@ function snapshotSensitivePath(
   src: string,
   dest: string,
   workTreeRealPath: string,
-  trackedFiles: Set<string>,
+  tracked: TrackedPaths,
 ): void {
   const excluded: Array<{ src: string; dest: string }> = [];
   const keepOrExclude =
@@ -134,7 +179,7 @@ function snapshotSensitivePath(
       recursive: true,
       dereference: true,
       filter: keepOrExclude((entry) =>
-        shouldSnapshotContent(entry, workTreeRealPath, trackedFiles),
+        shouldSnapshotContent(entry, workTreeRealPath, tracked),
       ),
     });
   } catch (error) {
@@ -212,25 +257,15 @@ export function restoreConfigFromBase(baseBranch: string): void {
   // Snapshot every PR-authored sensitive path into .claude-pr/ before deletion
   // so review agents can inspect what the PR changes without those files ever
   // being executed. Captured before the security delete so it reflects the
-  // PR-authored version. Links are followed only to tracked content inside the
-  // working tree; anything else is recorded as a placeholder file, so the
-  // snapshot itself never contains links.
+  // PR-authored version. Links are followed only to tracked, unmodified content
+  // inside the working tree; anything else is recorded as a placeholder file,
+  // so the snapshot itself never contains links.
   rmSync(".claude-pr", { recursive: true, force: true });
   const workTreeRealPath = realpathSync(process.cwd());
-  const trackedFiles = new Set(
-    execFileSync("git", ["ls-files", "-z"], {
-      encoding: "utf8",
-      maxBuffer: Infinity,
-    }).split("\0"),
-  );
+  const tracked = listTrackedPaths();
   for (const p of SENSITIVE_PATHS) {
     if (lstatSync(p, { throwIfNoEntry: false })) {
-      snapshotSensitivePath(
-        p,
-        `.claude-pr/${p}`,
-        workTreeRealPath,
-        trackedFiles,
-      );
+      snapshotSensitivePath(p, `.claude-pr/${p}`, workTreeRealPath, tracked);
     }
   }
   if (existsSync(".claude-pr")) {

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -3,12 +3,16 @@ import {
   appendFileSync,
   cpSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  readlinkSync,
   realpathSync,
   rmSync,
+  statSync,
+  writeFileSync,
 } from "fs";
-import { dirname, join, sep } from "path";
+import { dirname, join, relative, sep } from "path";
 
 // Paths that are both PR-controllable and read from cwd at CLI startup.
 //
@@ -35,82 +39,124 @@ function isSameOrInside(child: string, parent: string): boolean {
   return child === parent || child.startsWith(`${parent}${sep}`);
 }
 
-// The snapshot is scoped to repository content. An entry is copied with its
-// content only when its real target (through any symlinks) lies inside the
-// working tree, is not git metadata or the snapshot itself, and does not lead
-// back into a directory already on the entry's own path (which would recurse).
-// Anything else — targets outside the working tree, dangling or looping links —
-// is recorded as a link only, so the target is never followed.
+// The snapshot is scoped to tracked repository content and never contains
+// links. An entry is copied with its content only when all of these hold:
+//   1. its real target (through any links) lies inside the working tree;
+//   2. no component of the target's path inside the tree is `.git`, and the
+//      target is not inside the snapshot directory itself;
+//   3. the target does not contain a directory already on the entry's own
+//      path (which would recurse);
+//   4. if the entry is reached through a link (it is one, or a directory above
+//      it inside the sensitive path is), a file target must be tracked in the
+//      checkout. Directory targets reached through a link are descended into
+//      and their children are checked individually.
+// Files and directories at their literal, non-linked location are unaffected
+// by rule 4 and are copied as-is. Every other entry — targets outside the
+// tree, dangling or looping links, git metadata, untracked files reached
+// through a link — is recorded as a placeholder file (see recordPlaceholder),
+// so nothing in the snapshot resolves anywhere else.
 function shouldSnapshotContent(
   entryPath: string,
   workTreeRealPath: string,
+  trackedFiles: Set<string>,
 ): boolean {
   try {
     const targetRealPath = realpathSync(entryPath);
     if (!isSameOrInside(targetRealPath, workTreeRealPath)) {
       return false;
     }
-    for (const excluded of [".git", ".claude-pr"]) {
-      if (isSameOrInside(targetRealPath, join(workTreeRealPath, excluded))) {
-        return false;
-      }
+    const targetParts = relative(workTreeRealPath, targetRealPath).split(sep);
+    if (targetParts.includes(".git") || targetParts[0] === ".claude-pr") {
+      return false;
     }
     for (let dir = dirname(entryPath); ; dir = dirname(dir)) {
       if (isSameOrInside(realpathSync(dir), targetRealPath)) {
         return false;
       }
       if (dir === dirname(dir)) {
-        return true;
+        break;
       }
     }
+    const literalPath = join(
+      workTreeRealPath,
+      relative(process.cwd(), entryPath),
+    );
+    return (
+      targetRealPath === literalPath ||
+      statSync(targetRealPath).isDirectory() ||
+      trackedFiles.has(targetParts.join("/"))
+    );
   } catch {
     return false;
   }
 }
 
+// Writes a short regular file at `dest` describing the entry that was left
+// out, so the snapshot records that something was there without linking to it.
+function recordPlaceholder(src: string, dest: string): void {
+  console.warn(
+    `Snapshot: ${src} not included in snapshot; recording a placeholder`,
+  );
+  let description = "is not included in this snapshot";
+  try {
+    description = `was a symbolic link to ${JSON.stringify(readlinkSync(src))}; the link target is not included in this snapshot`;
+  } catch {
+    // Not a link (or no longer present).
+  }
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, `Snapshot placeholder: ${src} ${description}.\n`);
+}
+
 /**
- * Copies a sensitive path into the review snapshot. Entries whose targets
- * pass the confinement check above are copied dereferenced (reviewers see
- * the effective content); all other symlinks are preserved as link nodes and
- * their targets are never copied. Applies per entry, including symlinks nested
- * inside a real directory.
+ * Copies a sensitive path into the review snapshot. Entries that pass the
+ * check above are copied dereferenced (reviewers see the effective content);
+ * every other entry is recorded as a placeholder file, never as a link.
+ * Applies per entry, including links nested inside a real directory.
  */
 function snapshotSensitivePath(
   src: string,
   dest: string,
   workTreeRealPath: string,
+  trackedFiles: Set<string>,
 ): void {
-  const linksToPreserve: Array<{ src: string; dest: string }> = [];
+  const excluded: Array<{ src: string; dest: string }> = [];
+  const keepOrExclude =
+    (keep: (entry: string) => boolean) =>
+    (entrySrc: string, entryDest: string) => {
+      if (keep(entrySrc)) {
+        return true;
+      }
+      excluded.push({ src: entrySrc, dest: entryDest });
+      return false;
+    };
   try {
     cpSync(src, dest, {
       recursive: true,
       dereference: true,
-      filter: (entrySrc, entryDest) => {
-        if (shouldSnapshotContent(entrySrc, workTreeRealPath)) {
-          return true;
-        }
-        linksToPreserve.push({ src: entrySrc, dest: entryDest });
-        return false;
-      },
+      filter: keepOrExclude((entry) =>
+        shouldSnapshotContent(entry, workTreeRealPath, trackedFiles),
+      ),
     });
   } catch (error) {
-    // Dangling symlinks are normally caught by the filter above and recorded
-    // as links. If a target disappears between that check and the copy, the
-    // dereferenced copy throws ENOENT; preserve the symlinks for the review
-    // snapshot instead of failing the restore.
-    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-      cpSync(src, dest, { recursive: true });
-      return;
+    // Dangling links are normally caught by the filter above. If a target
+    // disappears between that check and the copy, the dereferencing copy
+    // throws ENOENT; start over without following links, recording every link
+    // as a placeholder, instead of failing the restore.
+    if (
+      !(error instanceof Error && "code" in error && error.code === "ENOENT")
+    ) {
+      throw error;
     }
-    throw error;
+    rmSync(dest, { recursive: true, force: true });
+    excluded.length = 0;
+    cpSync(src, dest, {
+      recursive: true,
+      filter: keepOrExclude((entry) => !lstatSync(entry).isSymbolicLink()),
+    });
   }
 
-  for (const link of linksToPreserve) {
-    console.warn(
-      `Snapshot: ${link.src} points outside the snapshot scope; recording the link only`,
-    );
-    mkdirSync(dirname(link.dest), { recursive: true });
-    cpSync(link.src, link.dest, { recursive: true, verbatimSymlinks: true });
+  for (const entry of excluded) {
+    recordPlaceholder(entry.src, entry.dest);
   }
 }
 
@@ -166,13 +212,25 @@ export function restoreConfigFromBase(baseBranch: string): void {
   // Snapshot every PR-authored sensitive path into .claude-pr/ before deletion
   // so review agents can inspect what the PR changes without those files ever
   // being executed. Captured before the security delete so it reflects the
-  // PR-authored version. Symlink targets outside the working tree are recorded
-  // as links only, keeping the snapshot scoped to repository content.
+  // PR-authored version. Links are followed only to tracked content inside the
+  // working tree; anything else is recorded as a placeholder file, so the
+  // snapshot itself never contains links.
   rmSync(".claude-pr", { recursive: true, force: true });
   const workTreeRealPath = realpathSync(process.cwd());
+  const trackedFiles = new Set(
+    execFileSync("git", ["ls-files", "-z"], {
+      encoding: "utf8",
+      maxBuffer: Infinity,
+    }).split("\0"),
+  );
   for (const p of SENSITIVE_PATHS) {
-    if (existsSync(p)) {
-      snapshotSensitivePath(p, `.claude-pr/${p}`, workTreeRealPath);
+    if (lstatSync(p, { throwIfNoEntry: false })) {
+      snapshotSensitivePath(
+        p,
+        `.claude-pr/${p}`,
+        workTreeRealPath,
+        trackedFiles,
+      );
     }
   }
   if (existsSync(".claude-pr")) {

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -295,6 +295,77 @@ describe("restoreConfigFromBase", () => {
     expectNoLinksInSnapshot();
   });
 
+  test("records links to tracked files modified after checkout as placeholders", () => {
+    writeRepoFile(".env", "PLACEHOLDER=1\n");
+    symlinkRepoFile(".claude/env", "../.env");
+    git(["add", ".env", ".claude/env"]);
+    git(["commit", "-m", "pr links to a tracked file"]);
+    writeRepoFile(".env", "written after checkout\n");
+
+    restoreConfigFromBase("main");
+
+    expectPlaceholder(".claude-pr/.claude/env");
+    expect(snapshotRegularFileContents()).not.toContain(
+      "written after checkout\n",
+    );
+    expectNoLinksInSnapshot();
+  });
+
+  test("snapshots a sensitive path that links to a tracked in-tree directory", () => {
+    rmSync(join(repoDir, ".claude"), { recursive: true, force: true });
+    writeRepoFile(
+      "config/claude/settings.json",
+      `${JSON.stringify({ source: "linked-dir" })}\n`,
+    );
+    writeRepoFile("config/claude/agents/reviewer.md", "reviewer agent\n");
+    writeRepoFile("docs/agents/writer.md", "writer agent\n");
+    symlinkRepoFile("config/claude/more-agents", "../../docs/agents");
+    symlinkRepoFile(".claude", "config/claude");
+    git(["add", "-A"]);
+    git(["commit", "-m", "pr links .claude to a tracked directory"]);
+    writeRepoFile("config/claude/local.txt", "untracked file\n");
+    writeRepoFile("config/claude/cache/entry.txt", "untracked dir entry\n");
+
+    restoreConfigFromBase("main");
+
+    expect(lstatRepoFile(".claude-pr/.claude").isDirectory()).toBe(true);
+    expect(readRepoFile(".claude-pr/.claude/settings.json")).toBe(
+      `${JSON.stringify({ source: "linked-dir" })}\n`,
+    );
+    expect(readRepoFile(".claude-pr/.claude/agents/reviewer.md")).toBe(
+      "reviewer agent\n",
+    );
+    expect(readRepoFile(".claude-pr/.claude/more-agents/writer.md")).toBe(
+      "writer agent\n",
+    );
+    expectPlaceholder(".claude-pr/.claude/local.txt");
+    expectPlaceholder(".claude-pr/.claude/cache");
+    const contents = snapshotRegularFileContents();
+    expect(contents).not.toContain("untracked file\n");
+    expect(contents).not.toContain("untracked dir entry\n");
+    expectNoLinksInSnapshot();
+    expect(lstatRepoFile(".claude").isDirectory()).toBe(true);
+    expect(readRepoFile(".claude/settings.json")).toBe(
+      `${JSON.stringify({ source: "base" })}\n`,
+    );
+  });
+
+  test("records links to untracked in-tree directories as a single placeholder", () => {
+    writeRepoFile("build/out/a.js", "generated a\n");
+    writeRepoFile("build/out/b.js", "generated b\n");
+    symlinkRepoFile(".claude/build", "../build");
+    git(["add", ".claude/build"]);
+    git(["commit", "-m", "pr links to an untracked directory"]);
+
+    restoreConfigFromBase("main");
+
+    expectPlaceholder(".claude-pr/.claude/build");
+    const contents = snapshotRegularFileContents();
+    expect(contents).not.toContain("generated a\n");
+    expect(contents).not.toContain("generated b\n");
+    expectNoLinksInSnapshot();
+  });
+
   test("records links back into a parent directory as placeholders", () => {
     symlinkRepoFile(".claude/parent-dir", "..");
     git(["add", "-A"]);

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -7,7 +7,6 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
-  readlinkSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -149,7 +148,7 @@ describe("restoreConfigFromBase", () => {
     );
   });
 
-  test("snapshots symlinked sensitive paths even when the PR head target is missing", () => {
+  test("records dangling links as placeholders, including top-level ones", () => {
     setupSymlinkedMainBranch();
 
     git(["checkout", "pr"]);
@@ -159,15 +158,15 @@ describe("restoreConfigFromBase", () => {
 
     restoreConfigFromBase("main");
 
-    expect(lstatRepoFile(".claude-pr/.claude/CLAUDE.md").isSymbolicLink()).toBe(
-      true,
-    );
+    expectPlaceholder(".claude-pr/CLAUDE.md");
+    expectPlaceholder(".claude-pr/.claude/CLAUDE.md");
+    expectNoLinksInSnapshot();
     expect(readRepoFile(".claude/settings.json")).toBe(
       `${JSON.stringify({ source: "base" })}\n`,
     );
   });
 
-  test("snapshots in-tree symlink targets as dereferenced content", () => {
+  test("snapshots links to tracked in-tree files as dereferenced content", () => {
     setupSymlinkedMainBranch();
 
     git(["checkout", "pr"]);
@@ -182,9 +181,10 @@ describe("restoreConfigFromBase", () => {
     expect(readRepoFile(".claude-pr/.claude/CLAUDE.md")).toBe(
       "shared agent instructions\n",
     );
+    expectNoLinksInSnapshot();
   });
 
-  test("records CLAUDE.md links to targets outside the working tree as links only", () => {
+  test("records CLAUDE.md links to targets outside the working tree as placeholders", () => {
     const outsideFile = writeOutsideFile("notes.md", "outside notes\n");
 
     rmSync(join(repoDir, "CLAUDE.md"), { force: true });
@@ -194,15 +194,14 @@ describe("restoreConfigFromBase", () => {
 
     restoreConfigFromBase("main");
 
-    expect(lstatRepoFile(".claude-pr/CLAUDE.md").isSymbolicLink()).toBe(true);
-    expect(readlinkSync(join(repoDir, ".claude-pr/CLAUDE.md"))).toBe(
-      outsideFile,
-    );
+    expectPlaceholder(".claude-pr/CLAUDE.md");
+    expect(readRepoFile(".claude-pr/CLAUDE.md")).not.toBe("outside notes\n");
     expect(snapshotRegularFileContents()).not.toContain("outside notes\n");
+    expectNoLinksInSnapshot();
     expect(readRepoFile("CLAUDE.md")).toBe("base claude instructions\n");
   });
 
-  test("records nested links to targets outside the working tree as links only", () => {
+  test("records nested links to targets outside the working tree as placeholders", () => {
     const outsideFile = writeOutsideFile(
       "secret.txt",
       "outside file content\n",
@@ -220,49 +219,95 @@ describe("restoreConfigFromBase", () => {
     expect(readRepoFile(".claude-pr/.claude/settings.json")).toBe(
       `${JSON.stringify({ source: "pr" })}\n`,
     );
-    expect(
-      lstatRepoFile(".claude-pr/.claude/linked-file.md").isSymbolicLink(),
-    ).toBe(true);
-    expect(
-      lstatRepoFile(".claude-pr/.claude/linked-dir").isSymbolicLink(),
-    ).toBe(true);
+    expectPlaceholder(".claude-pr/.claude/linked-file.md");
+    expectPlaceholder(".claude-pr/.claude/linked-dir");
     const contents = snapshotRegularFileContents();
     expect(contents).not.toContain("outside file content\n");
     expect(contents).not.toContain("outside dir content\n");
+    expectNoLinksInSnapshot();
     expect(readRepoFile(".claude/settings.json")).toBe(
       `${JSON.stringify({ source: "base" })}\n`,
     );
   });
 
-  test("records links into git metadata as links only", () => {
+  test("records links into git metadata as placeholders", () => {
     symlinkRepoFile(".claude/git-config", "../.git/config");
     git(["add", "-A"]);
     git(["commit", "-m", "pr links into git metadata"]);
 
     restoreConfigFromBase("main");
 
-    expect(
-      lstatRepoFile(".claude-pr/.claude/git-config").isSymbolicLink(),
-    ).toBe(true);
+    expectPlaceholder(".claude-pr/.claude/git-config");
     expect(snapshotRegularFileContents()).not.toContain(
       readRepoFile(".git/config"),
     );
+    expectNoLinksInSnapshot();
   });
 
-  test("records links back into a parent directory as links only", () => {
+  test("records relative links that only resolve from inside the snapshot as placeholders", () => {
+    // Both targets dangle at their source location but would resolve to the
+    // repository's .git/config if re-created one directory deeper.
+    symlinkRepoFile(".claude/x", "../../.git/config");
+    rmSync(join(repoDir, "CLAUDE.md"), { force: true });
+    symlinkRepoFile("CLAUDE.md", "../.git/config");
+    git(["add", "-A"]);
+    git(["commit", "-m", "pr adds relative links"]);
+
+    restoreConfigFromBase("main");
+
+    const gitConfig = readRepoFile(".git/config");
+    for (const path of [".claude-pr/.claude/x", ".claude-pr/CLAUDE.md"]) {
+      expectPlaceholder(path);
+      expect(readRepoFile(path)).not.toBe(gitConfig);
+    }
+    expect(snapshotRegularFileContents()).not.toContain(gitConfig);
+    expectNoLinksInSnapshot();
+  });
+
+  test("records links into nested git metadata inside the working tree as placeholders", () => {
+    writeRepoFile("other/.git/config", "nested checkout config\n");
+    symlinkRepoFile(".claude/x", "../other/.git/config");
+
+    restoreConfigFromBase("main");
+
+    expectPlaceholder(".claude-pr/.claude/x");
+    expect(snapshotRegularFileContents()).not.toContain(
+      "nested checkout config\n",
+    );
+    expectNoLinksInSnapshot();
+  });
+
+  test("records links to untracked in-tree files as placeholders", () => {
+    writeRepoFile(".env", "untracked env contents\n");
+    symlinkRepoFile(".claude/env", "../.env");
+    git(["add", ".claude/env"]);
+    git(["commit", "-m", "pr links to an untracked file"]);
+
+    restoreConfigFromBase("main");
+
+    expectPlaceholder(".claude-pr/.claude/env");
+    expect(snapshotRegularFileContents()).not.toContain(
+      "untracked env contents\n",
+    );
+    expect(readRepoFile(".claude-pr/.claude/settings.json")).toBe(
+      `${JSON.stringify({ source: "pr" })}\n`,
+    );
+    expectNoLinksInSnapshot();
+  });
+
+  test("records links back into a parent directory as placeholders", () => {
     symlinkRepoFile(".claude/parent-dir", "..");
     git(["add", "-A"]);
     git(["commit", "-m", "pr adds a link back to the repo root"]);
 
     restoreConfigFromBase("main");
 
-    expect(
-      lstatRepoFile(".claude-pr/.claude/parent-dir").isSymbolicLink(),
-    ).toBe(true);
+    expectPlaceholder(".claude-pr/.claude/parent-dir");
     expect(existsRepoFile(".claude-pr/.claude/parent-dir/src")).toBe(false);
     expect(readRepoFile(".claude-pr/.claude/settings.json")).toBe(
       `${JSON.stringify({ source: "pr" })}\n`,
     );
+    expectNoLinksInSnapshot();
   });
 
   test("does not modify an existing .gitignore", () => {
@@ -320,6 +365,29 @@ describe("restoreConfigFromBase", () => {
     };
     visit(join(repoDir, ".claude-pr"));
     return contents;
+  }
+
+  // The snapshot must never contain links: every entry is a regular file or a
+  // real directory.
+  function expectNoLinksInSnapshot(): void {
+    const visit = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const entryPath = join(dir, entry);
+        const stats = lstatSync(entryPath);
+        expect(stats.isSymbolicLink()).toBe(false);
+        if (stats.isDirectory()) {
+          visit(entryPath);
+        }
+      }
+    };
+    visit(join(repoDir, ".claude-pr"));
+  }
+
+  function expectPlaceholder(path: string): void {
+    const stats = lstatRepoFile(path);
+    expect(stats.isSymbolicLink()).toBe(false);
+    expect(stats.isFile()).toBe(true);
+    expect(readRepoFile(path)).toStartWith("Snapshot placeholder: ");
   }
 
   function existsRepoFile(path: string): boolean {

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -5,7 +5,9 @@ import {
   lstatSync,
   mkdtempSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
+  readlinkSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -165,6 +167,104 @@ describe("restoreConfigFromBase", () => {
     );
   });
 
+  test("snapshots in-tree symlink targets as dereferenced content", () => {
+    setupSymlinkedMainBranch();
+
+    git(["checkout", "pr"]);
+
+    restoreConfigFromBase("main");
+
+    expect(lstatRepoFile(".claude-pr/CLAUDE.md").isFile()).toBe(true);
+    expect(lstatRepoFile(".claude-pr/.claude/CLAUDE.md").isFile()).toBe(true);
+    expect(readRepoFile(".claude-pr/CLAUDE.md")).toBe(
+      "shared agent instructions\n",
+    );
+    expect(readRepoFile(".claude-pr/.claude/CLAUDE.md")).toBe(
+      "shared agent instructions\n",
+    );
+  });
+
+  test("records CLAUDE.md links to targets outside the working tree as links only", () => {
+    const outsideFile = writeOutsideFile("notes.md", "outside notes\n");
+
+    rmSync(join(repoDir, "CLAUDE.md"), { force: true });
+    symlinkRepoFile("CLAUDE.md", outsideFile);
+    git(["add", "-A"]);
+    git(["commit", "-m", "pr links CLAUDE.md outside the repo"]);
+
+    restoreConfigFromBase("main");
+
+    expect(lstatRepoFile(".claude-pr/CLAUDE.md").isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(repoDir, ".claude-pr/CLAUDE.md"))).toBe(
+      outsideFile,
+    );
+    expect(snapshotRegularFileContents()).not.toContain("outside notes\n");
+    expect(readRepoFile("CLAUDE.md")).toBe("base claude instructions\n");
+  });
+
+  test("records nested links to targets outside the working tree as links only", () => {
+    const outsideFile = writeOutsideFile(
+      "secret.txt",
+      "outside file content\n",
+    );
+    writeOutsideFile("dir/inner.txt", "outside dir content\n");
+    const outsideDir = join(tempDir, "outside", "dir");
+
+    symlinkRepoFile(".claude/linked-file.md", outsideFile);
+    symlinkRepoFile(".claude/linked-dir", outsideDir);
+    git(["add", "-A"]);
+    git(["commit", "-m", "pr adds nested links outside the repo"]);
+
+    restoreConfigFromBase("main");
+
+    expect(readRepoFile(".claude-pr/.claude/settings.json")).toBe(
+      `${JSON.stringify({ source: "pr" })}\n`,
+    );
+    expect(
+      lstatRepoFile(".claude-pr/.claude/linked-file.md").isSymbolicLink(),
+    ).toBe(true);
+    expect(
+      lstatRepoFile(".claude-pr/.claude/linked-dir").isSymbolicLink(),
+    ).toBe(true);
+    const contents = snapshotRegularFileContents();
+    expect(contents).not.toContain("outside file content\n");
+    expect(contents).not.toContain("outside dir content\n");
+    expect(readRepoFile(".claude/settings.json")).toBe(
+      `${JSON.stringify({ source: "base" })}\n`,
+    );
+  });
+
+  test("records links into git metadata as links only", () => {
+    symlinkRepoFile(".claude/git-config", "../.git/config");
+    git(["add", "-A"]);
+    git(["commit", "-m", "pr links into git metadata"]);
+
+    restoreConfigFromBase("main");
+
+    expect(
+      lstatRepoFile(".claude-pr/.claude/git-config").isSymbolicLink(),
+    ).toBe(true);
+    expect(snapshotRegularFileContents()).not.toContain(
+      readRepoFile(".git/config"),
+    );
+  });
+
+  test("records links back into a parent directory as links only", () => {
+    symlinkRepoFile(".claude/parent-dir", "..");
+    git(["add", "-A"]);
+    git(["commit", "-m", "pr adds a link back to the repo root"]);
+
+    restoreConfigFromBase("main");
+
+    expect(
+      lstatRepoFile(".claude-pr/.claude/parent-dir").isSymbolicLink(),
+    ).toBe(true);
+    expect(existsRepoFile(".claude-pr/.claude/parent-dir/src")).toBe(false);
+    expect(readRepoFile(".claude-pr/.claude/settings.json")).toBe(
+      `${JSON.stringify({ source: "pr" })}\n`,
+    );
+  });
+
   test("does not modify an existing .gitignore", () => {
     writeRepoFile(".gitignore", "node_modules\n");
     git(["add", ".gitignore"]);
@@ -194,6 +294,32 @@ describe("restoreConfigFromBase", () => {
 
   function readRepoFile(path: string): string {
     return readFileSync(join(repoDir, path), "utf8");
+  }
+
+  function writeOutsideFile(path: string, contents: string): string {
+    const fullPath = join(tempDir, "outside", path);
+    mkdirSync(dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, contents);
+    return fullPath;
+  }
+
+  // Contents of every regular file recorded in the snapshot, without following
+  // links, so tests can assert what actually got copied into the repository.
+  function snapshotRegularFileContents(): string[] {
+    const contents: string[] = [];
+    const visit = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const entryPath = join(dir, entry);
+        const stats = lstatSync(entryPath);
+        if (stats.isDirectory()) {
+          visit(entryPath);
+        } else if (stats.isFile()) {
+          contents.push(readFileSync(entryPath, "utf8"));
+        }
+      }
+    };
+    visit(join(repoDir, ".claude-pr"));
+    return contents;
   }
 
   function existsRepoFile(path: string): boolean {


### PR DESCRIPTION
## Summary

- The `.claude-pr/` snapshot taken by `restoreConfigFromBase` copies the PR-authored versions of the sensitive config paths with `dereference: true`, so review agents see effective content. It followed symlinks regardless of where they pointed, so a symlink under one of those paths resolving outside the checkout ended up copying that outside content into `.claude-pr/`.
- The snapshot is now scoped to tracked repository content and never contains links. An entry is copied with its content only when its real target lies inside the working tree, has no `.git` path component, isn't the snapshot itself or a directory on the entry's own path, and — when reached through a link — is a tracked file unchanged from `HEAD` (or a directory containing tracked files, whose children are then checked individually). Everything else (outside targets, dangling/looping links, git metadata, submodule contents, untracked or locally modified files reached through a link) is recorded as a small placeholder file naming the entry and its literal link target.
- Files and directories at their literal, non-linked location copy exactly as before, and in-tree symlinks to tracked content are still dereferenced. The top-level gate uses `lstat` so dangling top-level links are recorded too. `SENSITIVE_PATHS` and the delete-then-fetch/restore ordering are untouched.

## Test plan

- [x] `bun test` (815 pass) — temp-repo cases: in-tree link to tracked file still dereferenced; `CLAUDE.md` → outside file, `.claude/x -> ../../.git/config`, `CLAUDE.md -> ../.git/config`, nested `other/.git/config`, untracked `.env`, tracked-but-modified file, untracked directory, and sensitive path linking to a tracked directory — all recorded as expected; a recursive walk asserts no symlinks remain under `.claude-pr/`; existing ENOENT case
- [x] `bun run typecheck`
- [x] `bun run format:check`