### PR TITLE
feat: add config validation for settings.json and claude_args

### DIFF
--- a/base-action/src/setup-claude-code-settings.ts
+++ b/base-action/src/setup-claude-code-settings.ts
@@ -39,7 +39,7 @@ export async function setupClaudeCodeSettings(
       // First try to parse as JSON
       inputSettings = JSON.parse(settingsInput);
       console.log(`Parsed settings input as JSON`);
-    } catch (e) {
+    } catch (jsonError) {
       // If not JSON, treat as file path
       console.log(
         `Settings input is not JSON, treating as file path: ${settingsInput}`,
@@ -49,6 +49,20 @@ export async function setupClaudeCodeSettings(
         inputSettings = JSON.parse(fileContent);
         console.log(`Successfully read and parsed settings from file`);
       } catch (fileError) {
+        // If the input looks like it was meant to be JSON, provide a better error
+        const trimmed = settingsInput.trim();
+        if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+          const msg =
+            jsonError instanceof Error ? jsonError.message : String(jsonError);
+          console.error(
+            `Settings input appears to be malformed JSON: ${msg}\n` +
+              `Hint: Check for trailing commas, missing quotes, or unescaped characters.`,
+          );
+          throw new Error(
+            `Failed to parse settings as JSON: ${msg}. ` +
+              `Check for trailing commas, missing quotes, or unescaped characters.`,
+          );
+        }
         console.error(`Failed to read or parse settings file: ${fileError}`);
         throw new Error(`Failed to process settings input: ${fileError}`);
       }

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -44,6 +44,7 @@ import { preparePrompt } from "../../base-action/src/prepare-prompt";
 import { runClaude } from "../../base-action/src/run-claude";
 import type { ClaudeRunResult } from "../../base-action/src/run-claude-sdk";
 import { setExecutionFileOutputIfPresent } from "../../base-action/src/execution-file";
+import { validateAndAnnotateConfig } from "../utils/config-validation";
 
 // Exported for unit testing. `set -o pipefail` makes curl's non-zero exit
 // propagate through the pipe so the install retry logic actually triggers
@@ -269,6 +270,17 @@ async function run() {
       if (restoreBase) {
         restoreConfigFromBase(restoreBase);
       }
+    }
+
+    // Validate configuration files early so users see clear error messages
+    const configValid = await validateAndAnnotateConfig({
+      settingsInput: process.env.INPUT_SETTINGS,
+      claudeArgs: process.env.CLAUDE_ARGS,
+    });
+    if (!configValid) {
+      throw new Error(
+        "Configuration validation failed. Check the annotations above for details.",
+      );
     }
 
     await setupClaudeCodeSettings(process.env.INPUT_SETTINGS);

--- a/src/utils/config-validation.ts
+++ b/src/utils/config-validation.ts
@@ -1,0 +1,287 @@
+import * as core from "@actions/core";
+import { readFile } from "fs/promises";
+
+/**
+ * Validation result for configuration checks.
+ */
+export type ValidationResult = {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+};
+
+/**
+ * Try to extract a line number and contextual information from a JSON parse error.
+ * JSON.parse error messages vary by runtime; this handles the common Bun/V8 patterns.
+ */
+function extractJsonErrorDetails(
+  rawJson: string,
+  error: unknown,
+): { line: number; column: number; context: string } | null {
+  const message = error instanceof Error ? error.message : String(error);
+
+  // Bun / V8 typically include "at position <N>" or "at line <L> column <C>"
+  const posMatch = message.match(/position\s+(\d+)/i);
+  const lineColMatch = message.match(/line\s+(\d+)\s+column\s+(\d+)/i);
+
+  let line = -1;
+  let column = -1;
+
+  if (lineColMatch) {
+    line = parseInt(lineColMatch[1]!, 10);
+    column = parseInt(lineColMatch[2]!, 10);
+  } else if (posMatch) {
+    const position = parseInt(posMatch[1]!, 10);
+    // Convert byte offset to line/column
+    const upToPos = rawJson.slice(0, position);
+    const lines = upToPos.split("\n");
+    line = lines.length;
+    column = (lines[lines.length - 1]?.length ?? 0) + 1;
+  }
+
+  if (line < 1) return null;
+
+  // Build a short context snippet around the error line
+  const allLines = rawJson.split("\n");
+  const errorLineIdx = Math.min(line - 1, allLines.length - 1);
+  const contextLines: string[] = [];
+  for (
+    let i = Math.max(0, errorLineIdx - 1);
+    i <= Math.min(allLines.length - 1, errorLineIdx + 1);
+    i++
+  ) {
+    const prefix = i === errorLineIdx ? ">>>" : "   ";
+    contextLines.push(`${prefix} ${i + 1} | ${allLines[i]}`);
+  }
+
+  return { line, column, context: contextLines.join("\n") };
+}
+
+/**
+ * Validate a JSON string intended for `.claude/settings.json`.
+ *
+ * Returns a structured result with errors/warnings instead of throwing,
+ * so the caller can decide how to surface them (annotation, log, or throw).
+ */
+export function validateSettingsJson(jsonString: string): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const trimmed = jsonString.trim();
+  if (!trimmed) {
+    return { valid: true, errors, warnings };
+  }
+
+  // Attempt to parse
+  try {
+    const parsed = JSON.parse(trimmed);
+
+    // Must be an object, not an array or primitive
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      errors.push(
+        "settings.json must be a JSON object (e.g. { ... }), " +
+          `but got ${Array.isArray(parsed) ? "an array" : typeof parsed}.`,
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const details = extractJsonErrorDetails(trimmed, error);
+
+    if (details) {
+      errors.push(
+        `Invalid JSON in settings configuration (line ${details.line}, column ${details.column}): ${message}\n\n${details.context}`,
+      );
+    } else {
+      errors.push(`Invalid JSON in settings configuration: ${message}`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Validate a settings input that may be a JSON string or a file path.
+ *
+ * This mirrors the logic in `setupClaudeCodeSettings` but performs
+ * validation only (no side effects) and returns actionable error messages.
+ */
+export async function validateSettingsInput(
+  settingsInput: string | undefined,
+): Promise<ValidationResult> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!settingsInput || !settingsInput.trim()) {
+    return { valid: true, errors, warnings };
+  }
+
+  const trimmed = settingsInput.trim();
+
+  // Try parsing as JSON first
+  try {
+    JSON.parse(trimmed);
+    // If it parses, validate its structure
+    const jsonResult = validateSettingsJson(trimmed);
+    errors.push(...jsonResult.errors);
+    warnings.push(...jsonResult.warnings);
+  } catch {
+    // Not valid JSON -- treat as file path
+    try {
+      const fileContent = await readFile(trimmed, "utf-8");
+      const jsonResult = validateSettingsJson(fileContent);
+      if (!jsonResult.valid) {
+        // Prefix errors with the file path for clarity
+        for (const err of jsonResult.errors) {
+          errors.push(`In settings file "${trimmed}": ${err}`);
+        }
+      }
+      warnings.push(...jsonResult.warnings);
+    } catch (fileError) {
+      const fileMessage =
+        fileError instanceof Error ? fileError.message : String(fileError);
+      // Check if it looks like it was intended to be JSON (starts with { or [)
+      if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+        errors.push(
+          `Settings input looks like JSON but failed to parse: ${fileMessage}\n` +
+            `Hint: Check for trailing commas, missing quotes, or unescaped characters.`,
+        );
+      } else {
+        errors.push(
+          `Settings input is not valid JSON and could not be read as a file path: ${fileMessage}`,
+        );
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+/**
+ * Detect common mistakes in the `claude_args` value that relate to allowed_tools.
+ *
+ * A frequent mistake is using YAML block-scalar pipe (`|`) notation with list
+ * syntax (leading hyphens) inside `claude_args`. For example:
+ *
+ * ```yaml
+ * claude_args: |
+ *   --allowed-tools
+ *   - Read
+ *   - Grep
+ * ```
+ *
+ * The hyphens become part of the argument tokens and are interpreted as flags
+ * rather than tool names, silently producing wrong results.
+ */
+export function validateClaudeArgs(claudeArgs: string): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  if (!claudeArgs?.trim()) {
+    return { valid: true, errors, warnings };
+  }
+
+  const lines = claudeArgs.split("\n");
+
+  // Pattern 1: Detect YAML-list-style entries after --allowed-tools / --allowedTools
+  // Look for lines that are just "- SomeTool" (YAML list items)
+  let inAllowedToolsBlock = false;
+  const yamlListLines: number[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+
+    // Track when we enter an allowed-tools flag
+    if (
+      line === "--allowed-tools" ||
+      line === "--allowedTools" ||
+      line.startsWith("--allowed-tools ") ||
+      line.startsWith("--allowedTools ")
+    ) {
+      inAllowedToolsBlock = true;
+      continue;
+    }
+
+    // Reset when we hit another flag
+    if (line.startsWith("--") && !line.startsWith("---")) {
+      inAllowedToolsBlock = false;
+      continue;
+    }
+
+    // If we're in an allowed-tools block and see "- something", that's a YAML list mistake
+    if (inAllowedToolsBlock && /^-\s+\S/.test(line)) {
+      yamlListLines.push(i + 1);
+    }
+  }
+
+  if (yamlListLines.length > 0) {
+    const lineNums = yamlListLines.join(", ");
+    warnings.push(
+      `claude_args appears to use YAML list syntax (leading "- ") for tool names on line(s) ${lineNums}. ` +
+        `This will not work correctly -- tool names will be interpreted as flags. ` +
+        `Use space-separated or comma-separated values instead:\n\n` +
+        `  claude_args: |\n` +
+        `    --allowed-tools "Read" "Grep" "Bash"\n\n` +
+        `  or:\n\n` +
+        `  claude_args: --allowed-tools "Read,Grep,Bash"`,
+    );
+  }
+
+  // Pattern 2: Detect tool names that start with a dash (likely "- Tool" that
+  // got concatenated into "-Tool" via YAML folding)
+  const toolFlagPattern =
+    /--(?:allowed-tools|allowedTools|disallowed-tools|disallowedTools)\s+/g;
+  let match;
+  while ((match = toolFlagPattern.exec(claudeArgs)) !== null) {
+    const afterFlag = claudeArgs.slice(match.index + match[0].length);
+    // Check if the first value token looks like a hyphenated list item
+    const firstToken = afterFlag.match(/^["']?(-\S+)/);
+    if (
+      firstToken &&
+      !firstToken[1]!.startsWith("--") &&
+      firstToken[1] !== "-"
+    ) {
+      warnings.push(
+        `A tool name "${firstToken[1]}" starts with a hyphen, which looks like a YAML list artifact. ` +
+          `Did you mean to write the tool name without the leading dash?`,
+      );
+    }
+  }
+
+  return { valid: errors.length === 0 && warnings.length === 0, errors, warnings };
+}
+
+/**
+ * Run all config validations and surface results via GitHub Actions annotations.
+ *
+ * Warnings are emitted as `core.warning()` (yellow annotation in the Actions UI).
+ * Errors are emitted as `core.error()` and the function returns false so the
+ * caller can decide whether to abort.
+ */
+export async function validateAndAnnotateConfig(options: {
+  settingsInput?: string;
+  claudeArgs?: string;
+}): Promise<boolean> {
+  let hasErrors = false;
+
+  // Validate settings input
+  const settingsResult = await validateSettingsInput(options.settingsInput);
+  for (const err of settingsResult.errors) {
+    core.error(`Configuration error: ${err}`);
+    hasErrors = true;
+  }
+  for (const warn of settingsResult.warnings) {
+    core.warning(`Configuration warning: ${warn}`);
+  }
+
+  // Validate claude_args
+  const argsResult = validateClaudeArgs(options.claudeArgs ?? "");
+  for (const err of argsResult.errors) {
+    core.error(`Configuration error: ${err}`);
+    hasErrors = true;
+  }
+  for (const warn of argsResult.warnings) {
+    core.warning(`Configuration warning: ${warn}`);
+  }
+
+  return !hasErrors;
+}

--- a/test/config-validation.test.ts
+++ b/test/config-validation.test.ts
@@ -1,0 +1,276 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { tmpdir } from "os";
+import { mkdir, writeFile, rm } from "fs/promises";
+import { join } from "path";
+import {
+  validateSettingsJson,
+  validateSettingsInput,
+  validateClaudeArgs,
+} from "../src/utils/config-validation";
+
+const testDir = join(
+  tmpdir(),
+  "config-validation-test",
+  Date.now().toString(),
+);
+
+describe("validateSettingsJson", () => {
+  test("accepts valid JSON object", () => {
+    const result = validateSettingsJson(
+      '{"model": "claude-sonnet-4-20250514", "permissions": {"allow": ["Read"]}}',
+    );
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("accepts empty string", () => {
+    const result = validateSettingsJson("");
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts whitespace-only string", () => {
+    const result = validateSettingsJson("   \n\t  ");
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects malformed JSON with trailing comma", () => {
+    const result = validateSettingsJson('{"model": "test",}');
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]).toContain("Invalid JSON");
+  });
+
+  test("rejects JSON with missing closing brace", () => {
+    const result = validateSettingsJson('{"model": "test"');
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]).toContain("Invalid JSON");
+  });
+
+  test("rejects JSON with single quotes", () => {
+    const result = validateSettingsJson("{'model': 'test'}");
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]).toContain("Invalid JSON");
+  });
+
+  test("rejects array as top-level value", () => {
+    const result = validateSettingsJson('["Read", "Grep"]');
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]).toContain("must be a JSON object");
+    expect(result.errors[0]).toContain("an array");
+  });
+
+  test("rejects string primitive", () => {
+    const result = validateSettingsJson('"just a string"');
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]).toContain("must be a JSON object");
+  });
+
+  test("rejects number primitive", () => {
+    const result = validateSettingsJson("42");
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]).toContain("must be a JSON object");
+  });
+
+  test("rejects null", () => {
+    const result = validateSettingsJson("null");
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]).toContain("must be a JSON object");
+  });
+
+  test("includes line number info for multiline JSON errors", () => {
+    const badJson = `{
+  "model": "test",
+  "permissions": {
+    "allow": ["Read",]
+  }
+}`;
+    const result = validateSettingsJson(badJson);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBe(1);
+    // Should mention "Invalid JSON" and contain line reference info
+    expect(result.errors[0]).toContain("Invalid JSON");
+  });
+
+  test("accepts complex valid settings", () => {
+    const settings = JSON.stringify({
+      model: "claude-sonnet-4-20250514",
+      permissions: {
+        allow: ["Read", "Grep", "Bash(git:*)"],
+        deny: [],
+      },
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [{ type: "command", command: "echo test" }],
+          },
+        ],
+      },
+      env: { API_KEY: "test" },
+      enableAllProjectMcpServers: true,
+    });
+    const result = validateSettingsJson(settings);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("validateSettingsInput", () => {
+  beforeEach(async () => {
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  test("accepts undefined input", async () => {
+    const result = await validateSettingsInput(undefined);
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts empty string input", async () => {
+    const result = await validateSettingsInput("");
+    expect(result.valid).toBe(true);
+  });
+
+  test("accepts valid JSON string input", async () => {
+    const result = await validateSettingsInput('{"model": "test"}');
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects malformed JSON string input", async () => {
+    const result = await validateSettingsInput("{bad json}");
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test("accepts valid JSON file path", async () => {
+    const filePath = join(testDir, "valid-settings.json");
+    await writeFile(filePath, '{"model": "test"}');
+    const result = await validateSettingsInput(filePath);
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects file with malformed JSON", async () => {
+    const filePath = join(testDir, "bad-settings.json");
+    await writeFile(filePath, '{"model": "test",}');
+    const result = await validateSettingsInput(filePath);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("settings file");
+  });
+
+  test("rejects non-existent file path", async () => {
+    const result = await validateSettingsInput("/no/such/file.json");
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test("gives helpful error for JSON-like input that fails to parse", async () => {
+    const result = await validateSettingsInput('{ "key": value }');
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    // Should have a hint about the issue
+    expect(result.errors[0]).toContain("JSON");
+  });
+});
+
+describe("validateClaudeArgs", () => {
+  test("accepts empty string", () => {
+    const result = validateClaudeArgs("");
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("accepts valid allowed-tools syntax with quotes", () => {
+    const result = validateClaudeArgs(
+      '--allowed-tools "Read" "Grep" "Bash"',
+    );
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("accepts valid allowed-tools with commas", () => {
+    const result = validateClaudeArgs("--allowed-tools Read,Grep,Bash");
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("accepts valid multiline allowed-tools", () => {
+    const args = `--allowed-tools "Read"
+--allowed-tools "Grep"
+--allowed-tools "Bash"`;
+    const result = validateClaudeArgs(args);
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("warns on YAML list syntax with hyphens after --allowed-tools", () => {
+    const args = `--allowed-tools
+- Read
+- Grep
+- Bash`;
+    const result = validateClaudeArgs(args);
+    expect(result.valid).toBe(false);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain("YAML list syntax");
+  });
+
+  test("warns on YAML list syntax with allowedTools camelCase", () => {
+    const args = `--allowedTools
+- Read
+- Grep`;
+    const result = validateClaudeArgs(args);
+    expect(result.valid).toBe(false);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain("YAML list syntax");
+  });
+
+  test("does not warn on hyphens that are flags", () => {
+    const args = `--allowed-tools "Read"
+--model claude-sonnet`;
+    const result = validateClaudeArgs(args);
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("warns on tool name starting with hyphen", () => {
+    const args = '--allowed-tools "-Read"';
+    const result = validateClaudeArgs(args);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain("starts with a hyphen");
+  });
+
+  test("does not false-positive on legitimate flags after tool args", () => {
+    const args = `--allowed-tools "Read,Grep"
+--model claude-sonnet-4-20250514
+--max-turns 10`;
+    const result = validateClaudeArgs(args);
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("handles args with no allowed-tools flags at all", () => {
+    const args = "--model claude-sonnet --max-turns 5";
+    const result = validateClaudeArgs(args);
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("detects YAML list mixed with valid tools", () => {
+    const args = `--allowed-tools "Read"
+- Grep
+- Bash`;
+    // After --allowed-tools "Read", the lines "- Grep" and "- Bash" are outside
+    // a new --allowed-tools block but still within it since no new flag resets it
+    const result = validateClaudeArgs(args);
+    expect(result.valid).toBe(false);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/utils/config-validation.ts` with validators for settings JSON and claude_args
- Catches malformed JSON with line/column numbers and context snippets
- Detects YAML-list-syntax mistakes in `--allowed-tools` (hyphens from pipe notation)
- Surfaces errors early via `core.error()` / `core.warning()` GitHub Actions annotations
- Integrated into `run.ts` before `setupClaudeCodeSettings()` for fail-fast behavior

## Test plan
- [x] 31 new tests covering valid configs, malformed JSON, incorrect allowed_tools syntax, file-based settings, edge cases
- [x] All 885 tests pass
- [x] TypeScript typecheck clean

Closes #242

Developed with Claude Code as a coding partner