### PR TITLE
fix: enable full output on debug reruns

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -1,3 +1,4 @@
+import * as core from "@actions/core";
 import { parse as parseShellArgs } from "shell-quote";
 import type { ClaudeOptions } from "./run-claude";
 import type { Options as SdkOptions } from "@anthropic-ai/claude-agent-sdk";
@@ -152,7 +153,8 @@ function parseClaudeArgsToExtraArgs(
  */
 export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   // Determine output verbosity
-  const isDebugMode = process.env.ACTIONS_STEP_DEBUG === "true";
+  const isDebugMode =
+    process.env.ACTIONS_STEP_DEBUG === "true" || core.isDebug();
   const showFullOutput = options.showFullOutput === "true" || isDebugMode;
 
   // Parse claudeArgs into extraArgs for CLI pass-through

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -5,6 +5,40 @@ import { parseSdkOptions } from "../src/parse-sdk-options";
 import type { ClaudeOptions } from "../src/run-claude";
 
 describe("parseSdkOptions", () => {
+  describe("output verbosity", () => {
+    test("should show full output when ACTIONS_STEP_DEBUG is enabled", () => {
+      const originalActionsStepDebug = process.env.ACTIONS_STEP_DEBUG;
+
+      try {
+        process.env.ACTIONS_STEP_DEBUG = "true";
+
+        expect(parseSdkOptions({}).showFullOutput).toBe(true);
+      } finally {
+        if (originalActionsStepDebug === undefined) {
+          delete process.env.ACTIONS_STEP_DEBUG;
+        } else {
+          process.env.ACTIONS_STEP_DEBUG = originalActionsStepDebug;
+        }
+      }
+    });
+
+    test("should show full output when GitHub enables runner debug logging", () => {
+      const originalRunnerDebug = process.env.RUNNER_DEBUG;
+
+      try {
+        process.env.RUNNER_DEBUG = "1";
+
+        expect(parseSdkOptions({}).showFullOutput).toBe(true);
+      } finally {
+        if (originalRunnerDebug === undefined) {
+          delete process.env.RUNNER_DEBUG;
+        } else {
+          process.env.RUNNER_DEBUG = originalRunnerDebug;
+        }
+      }
+    });
+  });
+
   describe("allowedTools merging", () => {
     test("should extract allowedTools from claudeArgs", () => {
       const options: ClaudeOptions = {


### PR DESCRIPTION
Fixes #1604.

GitHub Actions debug reruns expose RUNNER_DEBUG=1 to step processes, while the action only checked ACTIONS_STEP_DEBUG. This preserves the existing signal and also uses @actions/core.isDebug().

Tests cover both debug signals.