### PR TITLE
fix(base-action): detect debug re-runs via RUNNER_DEBUG

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -1,3 +1,4 @@
+import * as core from "@actions/core";
 import { parse as parseShellArgs } from "shell-quote";
 import type { ClaudeOptions } from "./run-claude";
 import type { Options as SdkOptions } from "@anthropic-ai/claude-agent-sdk";
@@ -191,8 +192,15 @@ function parseClaudeArgsToExtraArgs(
  * Uses extraArgs for CLI pass-through instead of duplicating option parsing
  */
 export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
-  // Determine output verbosity
-  const isDebugMode = process.env.ACTIONS_STEP_DEBUG === "true";
+  // Determine output verbosity.
+  // `ACTIONS_STEP_DEBUG` is a repository secret read by the runner itself; it is
+  // never exported into the step environment, so checking it alone means a
+  // "Re-run with debug logging" never actually enables full output. The runner
+  // signals debug to the step by setting `RUNNER_DEBUG=1`, which is what
+  // `core.isDebug()` reads. The original check is kept for anyone who sets
+  // `ACTIONS_STEP_DEBUG` explicitly as a step-level env var.
+  const isDebugMode =
+    core.isDebug() || process.env.ACTIONS_STEP_DEBUG === "true";
   const showFullOutput = options.showFullOutput === "true" || isDebugMode;
 
   // Parse claudeArgs into extraArgs for CLI pass-through

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -621,4 +621,62 @@ describe("parseSdkOptions", () => {
       }
     });
   });
+
+  describe("showFullOutput debug detection", () => {
+    test("should enable full output when the runner signals debug via RUNNER_DEBUG", () => {
+      const originalEnv = { ...process.env };
+      delete process.env.ACTIONS_STEP_DEBUG;
+      process.env.RUNNER_DEBUG = "1";
+
+      try {
+        const result = parseSdkOptions({});
+
+        expect(result.showFullOutput).toBe(true);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    test("should still honor an explicitly set ACTIONS_STEP_DEBUG step env var", () => {
+      const originalEnv = { ...process.env };
+      delete process.env.RUNNER_DEBUG;
+      process.env.ACTIONS_STEP_DEBUG = "true";
+
+      try {
+        const result = parseSdkOptions({});
+
+        expect(result.showFullOutput).toBe(true);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    test("should not enable full output when neither debug signal is present", () => {
+      const originalEnv = { ...process.env };
+      delete process.env.RUNNER_DEBUG;
+      delete process.env.ACTIONS_STEP_DEBUG;
+
+      try {
+        const result = parseSdkOptions({});
+
+        expect(result.showFullOutput).toBe(false);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    test("should enable full output when show_full_output is set regardless of debug", () => {
+      const originalEnv = { ...process.env };
+      delete process.env.RUNNER_DEBUG;
+      delete process.env.ACTIONS_STEP_DEBUG;
+
+      try {
+        const result = parseSdkOptions({ showFullOutput: "true" });
+
+        expect(result.showFullOutput).toBe(true);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1604

## Problem

Re-running a job with **"Re-run jobs with debug logging"** never actually enables full Claude output, which is the one situation where a user most needs it.

`base-action/src/parse-sdk-options.ts` gated debug output on `ACTIONS_STEP_DEBUG`:

```ts
const isDebugMode = process.env.ACTIONS_STEP_DEBUG === "true";
const showFullOutput = options.showFullOutput === "true" || isDebugMode;
```

## Root cause

`ACTIONS_STEP_DEBUG` is a **repository secret read by the runner itself**. It is not exported into the step environment, so `process.env.ACTIONS_STEP_DEBUG` is `undefined` inside the action even on a debug re-run. The condition is effectively dead.

The runner communicates debug state to a step by setting **`RUNNER_DEBUG=1`**. That is precisely what [`core.isDebug()`](https://github.com/actions/toolkit/blob/main/packages/core/src/core.ts) reads:

```ts
export function isDebug(): boolean {
  return process.env['RUNNER_DEBUG'] === '1'
}
```

## Fix

Use `core.isDebug()`. `@actions/core` is already a dependency of `base-action` (`base-action/package.json`), so this adds no new dependency.

```ts
const isDebugMode =
  core.isDebug() || process.env.ACTIONS_STEP_DEBUG === "true";
```

The original `ACTIONS_STEP_DEBUG` check is deliberately **retained** rather than replaced, so that anyone who sets it explicitly as a step-level env var (a documented workaround for exactly this bug) keeps working. This makes the change strictly additive in behavior.

## Testing

Added four cases under a new `showFullOutput debug detection` describe block:

| Case | Expected |
|---|---|
| `RUNNER_DEBUG=1` (the real runner signal) | `showFullOutput === true` |
| `ACTIONS_STEP_DEBUG=true` set explicitly | `showFullOutput === true` |
| Neither set | `showFullOutput === false` |
| `show_full_output` input set, no debug | `showFullOutput === true` |

The first test **fails on `main` and passes with this change**, confirming it captures the actual defect rather than restating the implementation:

```
--- WITHOUT FIX ---
(fail) parseSdkOptions > showFullOutput debug detection >
       should enable full output when the runner signals debug via RUNNER_DEBUG
 43 pass, 1 fail

--- WITH FIX ---
 44 pass, 0 fail
```

## Checks

- `bun test base-action/test/parse-sdk-options.test.ts` — 44 pass, 0 fail
- `bun run typecheck` — exit 0
- `bun run format:check` — all matched files use Prettier code style

## Scope note

`base-action/` is published standalone as `@anthropic-ai/claude-code-base-action`. This change is internal to `parseSdkOptions` and does not alter its public API or the `ParsedSdkOptions` shape.
