### PR TITLE
fix(github): match bot actors in comment filters using GraphQL __typename

### DIFF
--- a/src/github/api/queries/github.ts
+++ b/src/github/api/queries/github.ts
@@ -7,6 +7,7 @@ export const PR_QUERY = `
         title
         body
         author {
+          __typename
           login
         }
         baseRefName
@@ -57,6 +58,7 @@ export const PR_QUERY = `
             databaseId
             body
             author {
+              __typename
               login
             }
             createdAt
@@ -70,6 +72,7 @@ export const PR_QUERY = `
             id
             databaseId
             author {
+              __typename
               login
             }
             body
@@ -85,6 +88,7 @@ export const PR_QUERY = `
                 path
                 line
                 author {
+                  __typename
                   login
                 }
                 createdAt
@@ -107,6 +111,7 @@ export const ISSUE_QUERY = `
         title
         body
         author {
+          __typename
           login
         }
         createdAt
@@ -124,6 +129,7 @@ export const ISSUE_QUERY = `
             databaseId
             body
             author {
+              __typename
               login
             }
             createdAt

--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -23,6 +23,7 @@ import type { CommentWithImages } from "../utils/image-downloader";
 import { downloadCommentImages } from "../utils/image-downloader";
 import {
   parseActorFilter,
+  resolveActorName,
   shouldIncludeCommentByActor,
 } from "../utils/actor-filter";
 
@@ -339,7 +340,7 @@ export function isBodySafeToUse(
  * @returns Filtered array of comments
  */
 export function filterCommentsByActor<
-  T extends { author: { login: string } | null },
+  T extends { author: { login: string; __typename?: string } | null },
 >(comments: T[], includeActors: string = "", excludeActors: string = ""): T[] {
   const includeParsed = parseActorFilter(includeActors);
   const excludeParsed = parseActorFilter(excludeActors);
@@ -351,9 +352,10 @@ export function filterCommentsByActor<
 
   return comments.filter((comment) =>
     shouldIncludeCommentByActor(
-      // author is null for comments from deleted ("ghost") accounts; treat them
-      // as the "ghost" login so filtering never dereferences null and crashes.
-      comment.author?.login ?? "ghost",
+      // Normalizes App actors to their "[bot]"-suffixed name, which is the form
+      // filter patterns are written in. Also maps deleted ("ghost") accounts,
+      // whose author is null, to "ghost" so filtering never dereferences null.
+      resolveActorName(comment.author),
       includeParsed,
       excludeParsed,
     ),

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -3,9 +3,14 @@
 // GitHub's GraphQL `author`/`actor` fields resolve to null when the underlying
 // account has been deleted (the "ghost" user). Any field typed as
 // `GitHubAuthor | null` can therefore be null at runtime and must be guarded.
+// `__typename` distinguishes an App/bot actor from a human. GraphQL's
+// `Actor.login` returns the bare name for bots ("dependabot"), unlike REST which
+// appends a suffix ("dependabot[bot]"), so the typename is the only reliable bot
+// signal on this data. See `resolveActorName` in `utils/actor-filter.ts`.
 export type GitHubAuthor = {
   login: string;
   name?: string;
+  __typename?: string;
 };
 
 export type GitHubComment = {

--- a/src/github/utils/actor-filter.ts
+++ b/src/github/utils/actor-filter.ts
@@ -12,6 +12,31 @@ export function parseActorFilter(filterString: string): string[] {
 }
 
 /**
+ * Resolves the name to match actor filter patterns against.
+ *
+ * GitHub's GraphQL API returns the bare login for App actors ("dependabot"),
+ * whereas REST and the GitHub UI use a "[bot]" suffix ("dependabot[bot]"). Users
+ * write filter patterns in the suffixed form, both the documented "*[bot]"
+ * wildcard and exact entries like "renovate[bot]", so GraphQL bot logins are
+ * normalized to that form before matching. Without this no "[bot]" pattern can
+ * ever match, because the suffix is simply absent from the data.
+ *
+ * @param author - Comment author; null for deleted ("ghost") accounts
+ * @returns Actor name, "[bot]"-suffixed for App actors
+ */
+export function resolveActorName(
+  author: { login: string; __typename?: string } | null | undefined,
+): string {
+  if (!author) return "ghost";
+
+  if (author.__typename === "Bot" && !author.login.endsWith("[bot]")) {
+    return `${author.login}[bot]`;
+  }
+
+  return author.login;
+}
+
+/**
  * Checks if an actor matches a pattern
  * Supports wildcards: "*[bot]" matches all bots, "dependabot[bot]" matches specific
  * @param actor - Actor username to check

--- a/test/actor-filter.test.ts
+++ b/test/actor-filter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   parseActorFilter,
   actorMatchesPattern,
+  resolveActorName,
   shouldIncludeCommentByActor,
 } from "../src/github/utils/actor-filter";
 
@@ -168,5 +169,51 @@ describe("shouldIncludeCommentByActor", () => {
     expect(
       shouldIncludeCommentByActor("user1", ["*[bot]"], ["dependabot[bot]"]),
     ).toBe(false);
+  });
+});
+
+describe("resolveActorName", () => {
+  test("appends the [bot] suffix to GraphQL App actors", () => {
+    // GraphQL returns the bare login for bots; REST would say "dependabot[bot]".
+    expect(resolveActorName({ __typename: "Bot", login: "dependabot" })).toBe(
+      "dependabot[bot]",
+    );
+  });
+
+  test("leaves human logins untouched", () => {
+    expect(resolveActorName({ __typename: "User", login: "octocat" })).toBe(
+      "octocat",
+    );
+  });
+
+  test("does not double-suffix a login that already ends with [bot]", () => {
+    expect(
+      resolveActorName({ __typename: "Bot", login: "dependabot[bot]" }),
+    ).toBe("dependabot[bot]");
+  });
+
+  test("maps deleted accounts to ghost", () => {
+    expect(resolveActorName(null)).toBe("ghost");
+    expect(resolveActorName(undefined)).toBe("ghost");
+  });
+
+  test("falls back to the login when __typename is absent", () => {
+    expect(resolveActorName({ login: "octocat" })).toBe("octocat");
+  });
+
+  test("a bot actor matches the *[bot] wildcard once resolved", () => {
+    const actor = resolveActorName({ __typename: "Bot", login: "renovate" });
+
+    expect(actorMatchesPattern(actor, "*[bot]")).toBe(true);
+    // The raw GraphQL login never matches, which is the bug being fixed.
+    expect(actorMatchesPattern("renovate", "*[bot]")).toBe(false);
+  });
+
+  test("a bot actor matches an exact [bot] pattern once resolved", () => {
+    const actor = resolveActorName({ __typename: "Bot", login: "dependabot" });
+
+    expect(shouldIncludeCommentByActor(actor, [], ["dependabot[bot]"])).toBe(
+      false,
+    );
   });
 });

--- a/test/data-fetcher.test.ts
+++ b/test/data-fetcher.test.ts
@@ -1215,7 +1215,10 @@ describe("fetchGitHubData integration with time filtering", () => {
                 {
                   id: "2",
                   databaseId: "2",
-                  author: { login: "scanner[bot]" },
+                  // GraphQL returns the bare login for App actors plus
+                  // __typename: "Bot". It does NOT append a "[bot]" suffix the
+                  // way REST does, so this mirrors a real payload.
+                  author: { __typename: "Bot", login: "scanner" },
                   body: "Pre-trigger bot review",
                   state: "COMMENTED",
                   submittedAt: "2024-01-15T11:00:00Z",


### PR DESCRIPTION
Fixes #1514

## Problem

`exclude_comments_by_actor` and `include_comments_by_actor` never match **any** bot. This is broader than the issue title suggests: not only does the documented `*[bot]` wildcard fail, so does an exact entry like `dependabot[bot]`. Users configure bot filtering, see no error, and every bot comment still reaches the prompt.

## Root cause

The two GitHub APIs disagree on bot logins:

| API | `login` for the Dependabot app |
|---|---|
| REST | `dependabot[bot]` |
| **GraphQL** | **`dependabot`** (no suffix; identified by `__typename: "Bot"`) |

`src/github/data/fetcher.ts` filters comments from **GraphQL** data, but the patterns users write follow the REST/UI convention. So this check in `actorMatchesPattern` was dead code:

```ts
if (pattern === "*[bot]" && actor.endsWith("[bot]")) return true;
```

`actor` is `dependabot`, never `dependabot[bot]`. The suffix simply is not present in the data, which also breaks exact matches.

## Why it was not caught

`test/data-fetcher.test.ts` mocked a payload GraphQL never produces:

```ts
author: { login: "scanner[bot]" }   // REST shape, not GraphQL
```

The test passed against fiction. It now mocks the real shape and **fails without this fix**.

## Fix

1. Request `__typename` on the six **Actor**-typed `author` selections in `src/github/api/queries/github.ts`.
2. Add `resolveActorName()` to `src/github/utils/actor-filter.ts`, mapping an App actor to its suffixed name.
3. Use it at the single filtering choke point, `filterCommentsByActor`.

```ts
export function resolveActorName(
  author: { login: string; __typename?: string } | null | undefined,
): string {
  if (!author) return "ghost";
  if (author.__typename === "Bot" && !author.login.endsWith("[bot]")) {
    return `${author.login}[bot]`;
  }
  return author.login;
}
```

Normalizing **at the filter boundary** (rather than mutating fetched data) fixes the wildcard and exact-match cases in one place and leaves author names shown in the prompt unchanged. `filterCommentsByActor` is the single choke point for issue comments, PR comments, reviews, and inline review comments, so all four paths are fixed together.

Two details worth flagging for review:

- The **commit** author selection is deliberately left alone. It is a `GitCommit` (`name`/`email`), not an `Actor`, so `__typename` there would be meaningless.
- The existing `?? "ghost"` behavior for deleted accounts is preserved inside `resolveActorName`, so null authors still never dereference.

## Testing

Added 7 cases for `resolveActorName` in `test/actor-filter.test.ts` (bot suffixing, human passthrough, no double-suffix, ghost handling, absent `__typename`, plus wildcard and exact-match integration), and corrected the misleading mock.

Reverting only the `src/` changes while keeping the corrected mock:

```
--- WITHOUT FIX ---
(fail) fetchGitHubData integration with time filtering >
       should filter reviews by both trigger time and actor
 93 pass, 1 fail

--- WITH FIX ---
 125 pass, 0 fail
```

## Checks

- `bun test test/data-fetcher.test.ts test/actor-filter.test.ts` — 125 pass, 0 fail
- `bun run typecheck` — exit 0
- `bun run format:check` — clean
- Full suite: no regressions. Local run went from 849 pass / 44 fail to 858 pass / 42 fail; the remaining failures are a strict subset of the pre-existing ones on my platform (POSIX-only suites: `downloadCommentImages`, `restoreConfigFromBase`, SSH signing, path validation) and are unrelated to this change.
