### PR TITLE
fix(github): keep the triggering review in pull_request_review context

### DIFF
--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -269,17 +269,58 @@ export function filterCommentsToTriggerTime<
 }
 
 /**
+ * Extracts the databaseId of the review that triggered this run, if any.
+ *
+ * Only a pull_request_review event has one. Returned as a string so it can be
+ * compared against GraphQL's databaseId without a numeric cast.
+ */
+export function extractTriggeringReviewId(
+  context: ParsedGitHubContext,
+): string | undefined {
+  if (isPullRequestReviewEvent(context)) {
+    return context.payload.review?.id?.toString();
+  }
+  return undefined;
+}
+
+/**
  * Filters reviews to only include those that existed in their final state before the trigger time.
  * Similar to filterCommentsToTriggerTime but for GitHubReview objects which use submittedAt instead of createdAt.
+ *
+ * On a pull_request_review event the trigger time IS the triggering review's
+ * submittedAt, so the strict "before the trigger" rule would always discard the
+ * very review that asked Claude to act, taking its inline comments with it.
+ * That one review is admitted by id. Everything else at or after the trigger is
+ * still excluded, so content that lands mid-run cannot slip into the prompt.
  */
 export function filterReviewsToTriggerTime<
-  T extends { submittedAt: string; updatedAt?: string; lastEditedAt?: string },
->(reviews: T[], triggerTime: string | undefined): T[] {
+  T extends {
+    databaseId?: string;
+    submittedAt: string;
+    updatedAt?: string;
+    lastEditedAt?: string;
+  },
+>(
+  reviews: T[],
+  triggerTime: string | undefined,
+  triggeringReviewId?: string,
+): T[] {
   if (!triggerTime) return reviews;
 
   const triggerTimestamp = new Date(triggerTime).getTime();
 
   return reviews.filter((review) => {
+    // The review that triggered this run is always in scope, whatever its
+    // timestamp: it is the request being answered, and its author already
+    // passed the actor/permission checks that gated the run.
+    if (
+      triggeringReviewId !== undefined &&
+      review.databaseId !== undefined &&
+      review.databaseId.toString() === triggeringReviewId
+    ) {
+      return true;
+    }
+
     // Review must have been submitted before trigger (not at or after)
     const submittedTimestamp = new Date(review.submittedAt).getTime();
     if (submittedTimestamp >= triggerTimestamp) {
@@ -367,6 +408,7 @@ type FetchDataParams = {
   isPR: boolean;
   triggerUsername?: string;
   triggerTime?: string;
+  triggeringReviewId?: string;
   originalTitle?: string;
   originalBody?: string | null;
   includeCommentsByActor?: string;
@@ -394,6 +436,7 @@ export async function fetchGitHubData({
   isPR,
   triggerUsername,
   triggerTime,
+  triggeringReviewId,
   originalTitle,
   originalBody,
   includeCommentsByActor,
@@ -527,16 +570,31 @@ export async function fetchGitHubData({
   if (reviewData && reviewData.nodes) {
     // Drop reviews submitted or edited after the trigger, then filter by actor.
     reviewData.nodes = filterCommentsByActor(
-      filterReviewsToTriggerTime(reviewData.nodes, triggerTime),
+      filterReviewsToTriggerTime(
+        reviewData.nodes,
+        triggerTime,
+        triggeringReviewId,
+      ),
       includeCommentsByActor,
       excludeCommentsByActor,
     );
 
     // Apply the same trigger-time + actor filtering to inline review comments.
+    // The triggering review's own inline comments are exempt from the
+    // trigger-time cut: they are created when the review is submitted, so their
+    // createdAt equals the trigger time and the strict rule would drop every
+    // one of them, leaving the review body with no line-level feedback attached.
+    // Actor filtering still applies to them.
     reviewData.nodes.forEach((review) => {
       if (review.comments?.nodes) {
+        const isTriggeringReview =
+          triggeringReviewId !== undefined &&
+          review.databaseId?.toString() === triggeringReviewId;
+
         review.comments.nodes = filterCommentsByActor(
-          filterCommentsToTriggerTime(review.comments.nodes, triggerTime),
+          isTriggeringReview
+            ? review.comments.nodes
+            : filterCommentsToTriggerTime(review.comments.nodes, triggerTime),
           includeCommentsByActor,
           excludeCommentsByActor,
         );

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -12,6 +12,7 @@ import {
   resolveTriggerTimestamp,
   extractOriginalTitle,
   extractOriginalBody,
+  extractTriggeringReviewId,
 } from "../../github/data/fetcher";
 import { createPrompt } from "../../create-prompt";
 import { isEntityContext } from "../../github/context";
@@ -57,6 +58,7 @@ export async function prepareTagMode({
     isPR: context.isPR,
     triggerUsername: context.actor,
     triggerTime,
+    triggeringReviewId: extractTriggeringReviewId(context),
     originalTitle,
     originalBody,
     includeCommentsByActor: context.inputs.includeCommentsByActor,

--- a/test/data-fetcher.test.ts
+++ b/test/data-fetcher.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, jest, test } from "bun:test";
 import {
   extractTriggerTimestamp,
+  extractTriggeringReviewId,
   resolveTriggerTimestamp,
   extractOriginalTitle,
   extractOriginalBody,
@@ -1953,5 +1954,67 @@ describe("filterCommentsByActor", () => {
     const onlyGhost = filterCommentsByActor(comments, "ghost", "");
     expect(onlyGhost).toHaveLength(1);
     expect(onlyGhost[0].body).toBe("from a deleted account");
+  });
+});
+
+describe("extractTriggeringReviewId", () => {
+  it("returns the review id for a pull_request_review event", () => {
+    expect(extractTriggeringReviewId(mockPullRequestReviewContext)).toBe(
+      String((mockPullRequestReviewContext.payload as any).review.id),
+    );
+  });
+
+  it("returns undefined for non-review events", () => {
+    expect(extractTriggeringReviewId(mockIssueCommentContext)).toBeUndefined();
+    expect(
+      extractTriggeringReviewId(mockPullRequestOpenedContext),
+    ).toBeUndefined();
+  });
+});
+
+describe("filterReviewsToTriggerTime with a triggering review", () => {
+  const triggerTime = "2024-01-15T12:00:00Z";
+
+  const reviews = [
+    {
+      databaseId: "1",
+      submittedAt: "2024-01-15T11:00:00Z",
+      body: "pre-trigger review",
+    },
+    {
+      // Submitted exactly at the trigger: this IS the review that invoked the run.
+      databaseId: "2",
+      submittedAt: triggerTime,
+      body: "triggering review",
+    },
+    {
+      databaseId: "3",
+      submittedAt: "2024-01-15T13:00:00Z",
+      body: "post-trigger review",
+    },
+  ];
+
+  it("drops the triggering review when no id is supplied (the bug)", () => {
+    const result = filterReviewsToTriggerTime(reviews, triggerTime);
+
+    expect(result.map((r) => r.databaseId)).toEqual(["1"]);
+  });
+
+  it("keeps the triggering review when its id is supplied", () => {
+    const result = filterReviewsToTriggerTime(reviews, triggerTime, "2");
+
+    expect(result.map((r) => r.databaseId)).toEqual(["1", "2"]);
+  });
+
+  it("still excludes other reviews at or after the trigger", () => {
+    const result = filterReviewsToTriggerTime(reviews, triggerTime, "2");
+
+    expect(result.map((r) => r.databaseId)).not.toContain("3");
+  });
+
+  it("does not admit an unrelated review when the id does not match", () => {
+    const result = filterReviewsToTriggerTime(reviews, triggerTime, "999");
+
+    expect(result.map((r) => r.databaseId)).toEqual(["1"]);
   });
 });


### PR DESCRIPTION
Fixes #1522

## Problem

On a `pull_request_review` event, the trigger timestamp is the triggering review's own `submitted_at`:

```ts
} else if (isPullRequestReviewEvent(context)) {
  return context.payload.review.submitted_at || undefined;
}
```

and reviews are then filtered with:

```ts
if (submittedTimestamp >= triggerTimestamp) return false;
```

The triggering review always compares **equal**, so it is always discarded. Never sometimes: every single `pull_request_review` run.

## Why this is worse than it looks

The review **body** still reaches Claude, because `extractUserRequestFromContext` surfaces it separately as the direct user request. That masked the real damage.

Filtering removes the whole review **node**, and the inline comments hang off that node. So the realistic workflow breaks:

> Reviewer leaves 6 line-level comments and submits the review with "@claude please address these"

Claude receives the sentence "please address these" and **none of the six comments it refers to**. It then has to guess, or asks what to address.

There is a second layer. Inline comments are filtered separately by `createdAt`:

```ts
review.comments.nodes = filterCommentsByActor(
  filterCommentsToTriggerTime(review.comments.nodes, triggerTime), ...
```

A pending review's comments are created **when the review is submitted**, so their `createdAt` also equals the trigger time. Admitting the review node alone would not have been enough; its comments would still have been dropped by this second filter. Both layers are handled here.

## Fix

Admit exactly one review, by id, rather than loosening the comparison:

```ts
if (
  triggeringReviewId !== undefined &&
  review.databaseId !== undefined &&
  review.databaseId.toString() === triggeringReviewId
) {
  return true;
}
```

`extractTriggeringReviewId(context)` returns `payload.review.id` for `pull_request_review` events and `undefined` otherwise, threaded through `fetchGitHubData` alongside the existing `triggerTime` / `originalTitle` params.

### Why by id, and not `>` instead of `>=`

Relaxing to `>` would also admit any *other* review that happened to land in the same second. Timestamps here have second granularity, so that is a real if narrow window, and this comparison is a security boundary: it exists to keep content that appears mid-run out of the prompt. Matching on id keeps that boundary exactly where it is and makes an exception for the one review that is, by definition, the request being answered, whose author already passed the actor and permission checks that gated the run.

Actor filtering (`include_comments_by_actor` / `exclude_comments_by_actor`) still applies to the triggering review and its comments. This only exempts the trigger-time cut.

## Testing

Six cases added to `test/data-fetcher.test.ts`:

| Case | Asserts |
|---|---|
| `extractTriggeringReviewId` on a review event | returns the review id |
| on comment / PR-opened events | returns `undefined` |
| no id supplied | triggering review dropped (**pins the bug**) |
| id supplied | triggering review kept |
| id supplied | a genuinely post-trigger review is still excluded |
| non-matching id | nothing extra is admitted |

The third case documents the old behavior explicitly, so the regression cannot silently return.

## Checks

- `bun test test/data-fetcher.test.ts test/modes/tag.test.ts` — 103 pass, 0 fail
- `bun run typecheck` — exit 0
- `bun run format:check` — clean

## Scope note

`filterReviewsToTriggerTime`'s new third parameter is optional, so existing callers and the `agent` mode path are unaffected. Only tag mode, which is the only mode that can be triggered by a review, passes it.
