### PR TITLE
fix(summary): keep every text block in structured tool results

### DIFF
--- a/src/entrypoints/format-turns.ts
+++ b/src/entrypoints/format-turns.ts
@@ -164,9 +164,15 @@ export function formatResultContent(content: any): string {
       typeof parsedContent[0] === "object" &&
       parsedContent[0]?.type === "text"
     ) {
-      // Extract the text field from the first item. Tool output is arbitrary,
-      // so `text` is not guaranteed to be a string.
-      contentStr = String(parsedContent[0]?.text || "");
+      // Keep every text block, not just the first: a tool result may split its
+      // output across several, and dropping the rest silently loses findings,
+      // file paths and follow-up instructions from the rendered summary. Blocks
+      // of other types (for example images) are skipped. Tool output is
+      // arbitrary, so `text` is not guaranteed to be a string.
+      contentStr = parsedContent
+        .filter((block: any) => block?.type === "text")
+        .map((block: any) => String(block?.text || ""))
+        .join("\n");
     } else {
       contentStr = String(content).trim();
     }

--- a/test/format-turns.test.ts
+++ b/test/format-turns.test.ts
@@ -111,6 +111,42 @@ describe("formatResultContent", () => {
     const result = formatResultContent(JSON.stringify(structuredContent));
     expect(result).toBe("**→** Hello world\n\n");
   });
+
+  test("keeps every text block, not just the first", () => {
+    const structuredContent = [
+      { type: "text", text: "first line" },
+      { type: "text", text: "second line" },
+      { type: "text", text: "third line" },
+    ];
+    const result = formatResultContent(JSON.stringify(structuredContent));
+
+    expect(result).toContain("first line");
+    expect(result).toContain("second line");
+    expect(result).toContain("third line");
+  });
+
+  test("keeps every text block when given an array directly", () => {
+    const result = formatResultContent([
+      { type: "text", text: "alpha" },
+      { type: "text", text: "beta" },
+    ]);
+
+    expect(result).toContain("alpha");
+    expect(result).toContain("beta");
+  });
+
+  test("skips non-text blocks while keeping the text ones", () => {
+    const structuredContent = [
+      { type: "text", text: "visible" },
+      { type: "image", source: { data: "ignored-binary" } },
+      { type: "text", text: "also visible" },
+    ];
+    const result = formatResultContent(JSON.stringify(structuredContent));
+
+    expect(result).toContain("visible");
+    expect(result).toContain("also visible");
+    expect(result).not.toContain("ignored-binary");
+  });
 });
 
 describe("formatToolWithResult", () => {


### PR DESCRIPTION
Fixes #1572

## Problem

`formatResultContent` in `src/entrypoints/format-turns.ts` detects structured tool output shaped like `[{ type: "text", text: "..." }]`, then reads only the first element:

```ts
contentStr = String(parsedContent[0]?.text || "");
```

When a successful `tool_result.content` carries several text blocks, the GitHub Actions step summary renders the first and silently discards the rest. The dropped text is still in the execution transcript, so the `Claude Code Report` a user actually reads is quietly less complete than the run really was. Extra findings, file paths, and follow-up instructions are exactly the kind of thing that lands in later blocks.

## Fix

Collect every text block rather than just the first:

```ts
contentStr = parsedContent
  .filter((block: any) => block?.type === "text")
  .map((block: any) => String(block?.text || ""))
  .join("\n");
```

Two deliberate details:

- **Filtering on `type === "text"`.** The surrounding guard only checks `parsedContent[0].type`, so a mixed array (text followed by an image block) reaches this path. Mapping without the filter would stringify an image block's binary payload into the summary. There is a test pinning that.
- **Keeping `|| ""` rather than switching to `??`.** Tool output is arbitrary and `text` is not guaranteed to be a string. `??` would change how falsy non-null values render, which is unrelated to this bug, so the existing coercion is left as-is.

## Testing

Three cases added to `test/format-turns.test.ts`:

| Case | Asserts |
|---|---|
| three text blocks (the issue's exact repro) | all three survive |
| array passed directly, not JSON-stringified | both branches of the input handling work |
| text / image / text | text kept, image payload not leaked into the summary |

All three **fail on `main` and pass with this change**:

```
--- WITHOUT FIX ---
(fail) formatResultContent > keeps every text block, not just the first
(fail) formatResultContent > keeps every text block when given an array directly
(fail) formatResultContent > skips non-text blocks while keeping the text ones
 42 pass, 4 fail

--- WITH FIX ---
 45 pass, 1 fail
```

## Checks

- `bun test test/format-turns.test.ts` — 45 pass, 1 fail
- `bun run typecheck` — exit 0
- `bun run format:check` — clean

The one remaining failure is `integration tests > formats real conversation data correctly`. It is **pre-existing and unrelated**: it fails identically on a clean `main` on my platform (Windows), which I verified by stashing this change and re-running. It is one of a set of POSIX-assuming suites that fail locally for me and pass in CI.
