### PR TITLE
fix(wif): prevent credential refresh after cleanup

### DIFF
--- a/base-action/src/workload-identity.ts
+++ b/base-action/src/workload-identity.ts
@@ -142,9 +142,13 @@ export async function setupWorkloadIdentity(): Promise<
     "claude-workload-identity",
   );
   const tokenFile = join(tokenDir, "identity-token");
+  let stopped = false;
 
   const writeIdentityToken = async () => {
     const identityToken = await fetchIdentityToken(audience);
+    // A refresh can still be awaiting GitHub when the action enters cleanup.
+    // Do not recreate credential material after stop() has removed it.
+    if (stopped) return;
     core.setSecret(identityToken);
     mkdirSync(tokenDir, { recursive: true, mode: 0o700 });
     writeFileSync(tokenFile, identityToken, { mode: 0o600 });
@@ -186,6 +190,7 @@ export async function setupWorkloadIdentity(): Promise<
   return {
     tokenFile,
     stop: () => {
+      stopped = true;
       clearInterval(refreshInterval);
       // RUNNER_TEMP is per-job, not per-step: remove the identity token, the
       // profile, and the cached exchanged credential so they don't outlive

--- a/base-action/test/workload-identity.test.ts
+++ b/base-action/test/workload-identity.test.ts
@@ -254,5 +254,47 @@ describe("workload identity federation", () => {
 
       expect(existsSync(tokenDir)).toBe(false);
     });
+
+    test("does not recreate credentials when a refresh finishes after stop", async () => {
+      process.env.ANTHROPIC_FEDERATION_RULE_ID = "fdrl_test";
+      process.env.ANTHROPIC_ORGANIZATION_ID =
+        "00000000-0000-0000-0000-000000000000";
+
+      let resolveRefresh: ((token: string) => void) | undefined;
+      let tokenCalls = 0;
+      getIDTokenSpy.mockImplementation(() => {
+        tokenCalls += 1;
+        if (tokenCalls === 1) return Promise.resolve("initial-token");
+        return new Promise((resolve) => {
+          resolveRefresh = resolve;
+        });
+      });
+
+      let refresh: (() => void) | undefined;
+      const intervalSpy = spyOn(globalThis, "setInterval").mockImplementation(((
+        callback: () => void,
+      ) => {
+        refresh = callback;
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      }) as typeof setInterval);
+
+      try {
+        const handle = await setupWorkloadIdentity();
+        expect(handle).toBeDefined();
+        expect(refresh).toBeDefined();
+
+        refresh!();
+        handle!.stop();
+        resolveRefresh!("refreshed-token");
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(existsSync(join(tempDir, "claude-workload-identity"))).toBe(
+          false,
+        );
+      } finally {
+        intervalSpy.mockRestore();
+      }
+    });
   });
 });


### PR DESCRIPTION
﻿## Summary

- prevent an in-flight WIF refresh from recreating credential material after action cleanup
- add a regression test for a refresh that resolves after stop()

## Audit finding

base-action/src/workload-identity.ts starts asynchronous OIDC refreshes with setInterval. Cleanup previously called clearInterval() and removed RUNNER_TEMP/claude-workload-identity, but did not cancel a refresh already awaiting core.getIDToken().

Reproduction:

1. Configure workload identity federation.
2. Let a scheduled refresh enter fetchIdentityToken().
3. Finish the action while that request is still pending.
4. The stop() cleanup removes the credential directory.
5. The pending refresh resolves and writes a new identity token and cache directory.

Expected: after stop(), no identity token or exchanged-credential cache is recreated.

Actual before this change: the asynchronous refresh could recreate credential material after cleanup, leaving secret-bearing files in the runner's per-job temporary directory.

The fix marks the handle stopped before cleanup and checks that state after the awaited token request, before calling setSecret() or writing files.

This is distinct from #1406/#1407, which addressed repeated OIDC exchanges across spawned Claude processes. I found no existing issue or PR covering this post-stop refresh race.

Fixes #1621

## Validation

- bun test test/workload-identity.test.ts -t "does not recreate credentials when a refresh finishes after stop"
- bun test test/parse-sdk-options.test.ts
- bun run typecheck (root)
- bun run typecheck (base-action)
- bunx prettier --check base-action/src/workload-identity.ts base-action/test/workload-identity.test.ts
- git diff --check

Full repository test runs were also attempted; the checkout has several pre-existing platform/environment failures on Windows (CRLF-sensitive metadata tests, POSIX symlink/permission assertions, network image fixtures, and base README parsing), documented in the audit handoff.
