### PR TITLE
fix(file-ops): preserve binary file contents

### DIFF
--- a/src/mcp/github-file-content.ts
+++ b/src/mcp/github-file-content.ts
@@ -1,0 +1,6 @@
+export function createBase64BlobPayload(content: Uint8Array) {
+  return {
+    content: Buffer.from(content).toString("base64"),
+    encoding: "base64" as const,
+  };
+}

--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -9,6 +9,7 @@ import { constants } from "fs";
 import fetch from "node-fetch";
 import { GITHUB_API_URL } from "../github/api/config";
 import { validatePathWithinRepo } from "./path-validation";
+import { createBase64BlobPayload } from "./github-file-content";
 import { updateGitReference } from "./update-git-reference";
 
 type GitHubRef = {
@@ -258,58 +259,36 @@ server.tool(
           // Get the proper file mode based on file permissions
           const fileMode = await getFileMode(fullPath);
 
-          // Check if file is binary (images, etc.)
-          const isBinaryFile =
-            /\.(png|jpg|jpeg|gif|webp|ico|pdf|zip|tar|gz|exe|bin|woff|woff2|ttf|eot)$/i.test(
-              relativePath,
+          // Create a blob from the raw bytes so every file is committed without
+          // relying on a filename extension to identify binary content.
+          const fileContent = await readFile(fullPath);
+          const blobUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/blobs`;
+          const blobResponse = await fetch(blobUrl, {
+            method: "POST",
+            headers: {
+              Accept: "application/vnd.github+json",
+              Authorization: `Bearer ${githubToken}`,
+              "X-GitHub-Api-Version": "2022-11-28",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(createBase64BlobPayload(fileContent)),
+          });
+
+          if (!blobResponse.ok) {
+            const errorText = await blobResponse.text();
+            throw new Error(
+              `Failed to create blob for ${relativePath}: ${blobResponse.status} - ${errorText}`,
             );
-
-          if (isBinaryFile) {
-            // For binary files, create a blob first using the Blobs API
-            const binaryContent = await readFile(fullPath);
-
-            // Create blob using Blobs API (supports encoding parameter)
-            const blobUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/blobs`;
-            const blobResponse = await fetch(blobUrl, {
-              method: "POST",
-              headers: {
-                Accept: "application/vnd.github+json",
-                Authorization: `Bearer ${githubToken}`,
-                "X-GitHub-Api-Version": "2022-11-28",
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                content: binaryContent.toString("base64"),
-                encoding: "base64",
-              }),
-            });
-
-            if (!blobResponse.ok) {
-              const errorText = await blobResponse.text();
-              throw new Error(
-                `Failed to create blob for ${relativePath}: ${blobResponse.status} - ${errorText}`,
-              );
-            }
-
-            const blobData = (await blobResponse.json()) as { sha: string };
-
-            // Return tree entry with blob SHA
-            return {
-              path: relativePath,
-              mode: fileMode,
-              type: "blob",
-              sha: blobData.sha,
-            };
-          } else {
-            // For text files, include content directly in tree
-            const content = await readFile(fullPath, "utf-8");
-            return {
-              path: relativePath,
-              mode: fileMode,
-              type: "blob",
-              content: content,
-            };
           }
+
+          const blobData = (await blobResponse.json()) as { sha: string };
+
+          return {
+            path: relativePath,
+            mode: fileMode,
+            type: "blob",
+            sha: blobData.sha,
+          };
         }),
       );
 

--- a/test/github-file-content.test.ts
+++ b/test/github-file-content.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { createBase64BlobPayload } from "../src/mcp/github-file-content";
+
+describe("GitHub blob content", () => {
+  test("preserves bytes for binary files with unlisted extensions", () => {
+    const binaryContent = Uint8Array.from([
+      0x00, 0xff, 0xd8, 0x80, 0x1a, 0x7f, 0xc3, 0x28,
+    ]);
+
+    expect(createBase64BlobPayload(binaryContent)).toEqual({
+      content: Buffer.from(binaryContent).toString("base64"),
+      encoding: "base64",
+    });
+  });
+
+  test("encodes text files without changing their bytes", () => {
+    const textContent = new TextEncoder().encode("line 1\nline 2\n");
+
+    expect(createBase64BlobPayload(textContent)).toEqual({
+      content: Buffer.from(textContent).toString("base64"),
+      encoding: "base64",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- remove extension-based binary detection from `commit_files`
- read every file as raw bytes and create a base64 Git blob
- add regression coverage for binary bytes with an unlisted extension

Fixes #1627

## Why

`commit_files` previously decoded files outside a short binary extension allowlist as UTF-8 text. Invalid bytes were replaced before being sent to GitHub, silently corrupting committed assets. All files now use the Git blob API with base64 encoding, preserving their bytes regardless of filename.

## Testing

- `bun test test/github-file-content.test.ts`
- `bun run typecheck`
- targeted Prettier check for changed files
- `git diff --check`
- `bun test` — 851 passed, 44 pre-existing Windows/platform/environment failures
- `bun run format:check` — pre-existing repository-wide formatting failures in 183 files; changed files pass targeted Prettier checks