### PR TITLE
fix(images): bound attachment download size

### DIFF
--- a/src/github/utils/image-downloader.ts
+++ b/src/github/utils/image-downloader.ts
@@ -28,6 +28,9 @@ function extractAssetGuid(url: string): string | undefined {
 
 const SIGNED_URL_HOST = "private-user-images.githubusercontent.com";
 
+/** Maximum size of one downloaded image, enforced before it is written. */
+export const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
+
 // Signed download URLs have the shape /<owner-id>/<asset-id>-<guid>.<ext>.
 // The GUID must come from the resolved filename, not from anywhere in the raw
 // string, so text that merely embeds a GUID cannot claim another asset.
@@ -248,8 +251,7 @@ export async function downloadCommentImages(
             );
           }
 
-          const arrayBuffer = await imageResponse.arrayBuffer();
-          const buffer = Buffer.from(arrayBuffer);
+          const buffer = await readImageResponse(imageResponse);
 
           // GitHub user-attachment URLs (/user-attachments/assets/<uuid>) carry
           // no file extension, so the URL-based guess silently falls back to
@@ -287,6 +289,72 @@ export async function downloadCommentImages(
   }
 
   return urlToPathMap;
+}
+
+async function readImageResponse(response: Response): Promise<Buffer> {
+  const contentLength = response.headers?.get("content-length");
+  if (contentLength) {
+    const declaredLength = Number(contentLength);
+    if (
+      Number.isSafeInteger(declaredLength) &&
+      declaredLength > MAX_IMAGE_SIZE_BYTES
+    ) {
+      throw new Error(
+        `Image exceeds the ${MAX_IMAGE_SIZE_BYTES}-byte size limit`,
+      );
+    }
+  }
+
+  const responseBody = (
+    response as Response & {
+      body?: ReadableStream<Uint8Array> | null;
+    }
+  ).body;
+
+  if (responseBody === undefined) {
+    // Some test doubles do not expose a ReadableStream. Keep this fallback
+    // bounded by checking the completed body before returning it.
+    const arrayBuffer = await response.arrayBuffer();
+    if (arrayBuffer.byteLength > MAX_IMAGE_SIZE_BYTES) {
+      throw new Error(
+        `Image exceeds the ${MAX_IMAGE_SIZE_BYTES}-byte size limit`,
+      );
+    }
+    return Buffer.from(arrayBuffer);
+  }
+
+  if (responseBody === null) {
+    throw new Error("Image response has no body");
+  }
+
+  const reader = responseBody.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_IMAGE_SIZE_BYTES) {
+        try {
+          await reader.cancel();
+        } catch {
+          // Preserve the size-limit error if cancellation also fails.
+        }
+        throw new Error(
+          `Image exceeds the ${MAX_IMAGE_SIZE_BYTES}-byte size limit`,
+        );
+      }
+
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return Buffer.concat(chunks);
 }
 
 function getImageExtension(url: string): string {

--- a/test/image-downloader.test.ts
+++ b/test/image-downloader.test.ts
@@ -9,7 +9,10 @@ import {
   setSystemTime,
 } from "bun:test";
 import fs from "fs/promises";
-import { downloadCommentImages } from "../src/github/utils/image-downloader";
+import {
+  downloadCommentImages,
+  MAX_IMAGE_SIZE_BYTES,
+} from "../src/github/utils/image-downloader";
 import type { CommentWithImages } from "../src/github/utils/image-downloader";
 import type { Octokits } from "../src/github/api/client";
 
@@ -760,6 +763,84 @@ describe("downloadCommentImages", () => {
     );
 
     expect(result.size).toBe(0);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `✗ Failed to download ${imageUrl}:`,
+      expect.any(Error),
+    );
+  });
+
+  test("should skip an image whose declared size exceeds the limit", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl = assetUrl(GUID_1);
+    const signedUrl = signedUrlFor(GUID_1, ".png");
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl}">`,
+      },
+    });
+
+    const arrayBufferSpy = jest.fn();
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      headers: new Headers({
+        "content-length": String(MAX_IMAGE_SIZE_BYTES + 1),
+      }),
+      arrayBuffer: arrayBufferSpy,
+    } as unknown as Response);
+
+    const result = await downloadCommentImages(mockOctokit, "owner", "repo", [
+      {
+        type: "issue_comment",
+        id: "445",
+        body: `Oversized image: ![image](${imageUrl})`,
+      },
+    ]);
+
+    expect(result.size).toBe(0);
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
+    expect(fsWriteFileSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `✗ Failed to download ${imageUrl}:`,
+      expect.any(Error),
+    );
+  });
+
+  test("should skip a streamed image that exceeds the limit", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl = assetUrl(GUID_1);
+    const signedUrl = signedUrlFor(GUID_1, ".png");
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl}">`,
+      },
+    });
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(MAX_IMAGE_SIZE_BYTES));
+        controller.enqueue(new Uint8Array(1));
+      },
+    });
+    fetchSpy = spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      body: stream,
+    } as unknown as Response);
+
+    const result = await downloadCommentImages(mockOctokit, "owner", "repo", [
+      {
+        type: "issue_comment",
+        id: "446",
+        body: `Streamed oversized image: ![image](${imageUrl})`,
+      },
+    ]);
+
+    expect(result.size).toBe(0);
+    expect(fsWriteFileSpy).not.toHaveBeenCalled();
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       `✗ Failed to download ${imageUrl}:`,
       expect.any(Error),


### PR DESCRIPTION
## Summary

- enforce a documented 10 MiB maximum per image download
- reject oversized `Content-Length` responses before reading them
- consume streamed responses incrementally and cancel when the limit is exceeded
- skip oversized images through the existing per-image error handling
- add declared-length and chunked-response regression tests

Fixes #1628

## Why

Image attachment responses are external input. The downloader previously awaited `arrayBuffer()` without a size check, allowing a large attachment to consume unbounded memory and disk space. The new streaming reader keeps accumulation bounded and never writes an oversized response.

## Testing

- `bun test test/image-downloader.test.ts -t "size|streamed"`
- `bun run typecheck`
- targeted Prettier check for changed files
- `git diff --check`
- `bun test` — 851 passed, 44 pre-existing Windows/platform/environment failures
- `bun run format:check` — pre-existing repository-wide formatting failures in 182 unchanged files; changed files pass targeted Prettier checks