### PR TITLE
Harden delete_files MCP tool: validate paths within repo root (consistency with commit_files)

### DIFF
--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -435,21 +435,18 @@ server.tool(
         throw new Error("GITHUB_TOKEN environment variable is required");
       }
 
-      // Convert absolute paths to relative if they match CWD
-      const cwd = process.cwd();
-      const processedPaths = paths.map((filePath) => {
-        if (filePath.startsWith("/")) {
-          if (filePath.startsWith(cwd)) {
-            // Strip CWD from absolute path
-            return filePath.slice(cwd.length + 1);
-          } else {
-            throw new Error(
-              `Path '${filePath}' must be relative to repository root or within current working directory`,
-            );
-          }
-        }
-        return filePath;
-      });
+      // Validate all paths are within the repository root and normalize them to
+      // repo-relative paths for the git tree entries. This mirrors the validation
+      // already performed by the commit_files tool and rejects path traversal
+      // ("../") and symlinked escapes as defense-in-depth.
+      const resolvedRepoDir = resolve(REPO_DIR);
+      const processedPaths = await Promise.all(
+        paths.map(async (filePath) => {
+          await validatePathWithinRepo(filePath, REPO_DIR);
+          const normalizedPath = resolve(resolvedRepoDir, filePath);
+          return normalizedPath.slice(resolvedRepoDir.length + 1);
+        }),
+      );
 
       // 1. Get the branch reference (create if doesn't exist)
       const baseSha = await getOrCreateBranchRef(


### PR DESCRIPTION
## What

The `delete_files` MCP tool does not validate that the paths it operates on stay within the repository root. It only strips CWD from absolute paths and passes relative paths (including ones containing `../`) through unchecked.

The sibling `commit_files` tool already validates every path via `validatePathWithinRepo`, which rejects `../` traversal and symlinked escapes. This PR applies the same validation to `delete_files` for consistency and defense-in-depth.

## This is hardening, not a security fix

I could **not** find a way to exploit the missing validation. `delete_files` builds a git tree via GitHub's `POST /git/trees` API, and that API rejects any tree entry whose path contains a `..` component:

```
HTTP 422 - "tree.path contains a malformed path component"
```

(verified against a test repo). So `../` never reaches anything outside the repository today. This change is purely about keeping path handling **consistent** across the two tools that write to the repo, so a future refactor — or a backend without GitHub's server-side check — can't silently reintroduce traversal.

## Behavior

- Relative paths: unchanged (accepted, now normalized/validated).
- Absolute paths within the repo: unchanged (normalized to repo-relative).
- `../` traversal / absolute paths outside the repo / symlink escapes: now rejected with a clear error, matching `commit_files`.

## Testing

- `bun run typecheck` — passes
- `bun test` — 893 pass / 0 fail
- `prettier --check .` — clean
