### PR TITLE
fix(base-action): add ~/.local/bin to GITHUB_PATH after default install

### DIFF
--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -165,6 +165,8 @@ runs:
             sleep 5
           done
           echo "Claude Code installed successfully"
+          # Add the directory containing the installed binary to PATH (install.sh places it in ~/.local/bin)
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         else
           echo "Using custom Claude Code executable: $PATH_TO_CLAUDE_CODE_EXECUTABLE"
           # Add the directory containing the custom executable to PATH


### PR DESCRIPTION
The default install branch (curl | install.sh) never adds the installed binary's directory to $GITHUB_PATH, unlike the custom-executable branch which appends $CLAUDE_DIR. install.sh places claude in ~/.local/bin, and the next step runs with bash --noprofile --norc, so 'claude' was not on PATH -> 'Executable not found in /Users/ali/.kimi-code/bin:/Users/ali/.bun/bin:/Users/ali/.bun/bin:/Users/ali/bin:/Users/ali/Downloads/google-cloud-sdk/bin:/Users/ali/Coding:/Users/ali/.local/bin:/Users/ali/Library/Python/3.9/bin:/Users/ali/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/ali/.lmstudio/bin'.

Mirrors the custom-executable branch's existing style. The top-level action already does this in src/entrypoints/run.ts installClaudeCode(); only base-action/action.yml was missing it.

Fixes #1634. YAML parse + prettier pass; full test suite has pre-existing failures unrelated to this YAML-only change (confirmed on pristine upstream/main).