### PR TITLE
fix: report neutral conclusion when workflow validation is skipped

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -168,7 +168,7 @@ inputs:
 
 outputs:
   conclusion:
-    description: "Execution status of Claude Code ('success' or 'failure')"
+    description: "Execution status of Claude Code ('success', 'failure', or 'neutral' when skipped by workflow validation)"
     value: ${{ steps.run.outputs.conclusion }}
   execution_file:
     description: "Path to the Claude Code execution output file"

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -175,6 +175,9 @@ async function run() {
     } catch (error) {
       if (error instanceof WorkflowValidationSkipError) {
         core.setOutput("skipped_due_to_workflow_validation_mismatch", "true");
+        // Report a distinct conclusion ("neutral") so a skipped review is not
+        // indistinguishable from a real pass. See #1632.
+        core.setOutput("conclusion", "neutral");
         console.log("Exiting due to workflow validation skip");
         return;
       }


### PR DESCRIPTION
When workflow validation is skipped, the action returned without setting a conclusion, so the run read as an indistinguishable green pass. Now sets conclusion=neutral on the skip path, matching the repo's existing conclusion model (success/failure/neutral). action.yml output description updated accordingly.

Note: an action step can't change the GitHub check-run conclusion itself (only ::error+exit-1 or exit-0); neutral is reported via the action's conclusion output, which is what tooling and downstream steps can consume. If maintainers want the check itself to not satisfy branch protection, that needs a workflow-level conditional.

Fixes #1632. typecheck + targeted tests pass; 7 pre-existing network-timeout flakes in restoreConfigFromBase confirmed on pristine upstream/main.