### PR TITLE
docs: OAuth token auth includes Team and Enterprise plans

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -7,7 +7,7 @@
 1. Install the Claude GitHub app to your repository: https://github.com/apps/claude
 2. Add authentication to your repository secrets ([Learn how to use secrets in GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions)):
    - Either `ANTHROPIC_API_KEY` for API key authentication
-   - Or `CLAUDE_CODE_OAUTH_TOKEN` for OAuth token authentication (Pro and Max users can generate this by running `claude setup-token` locally)
+   - Or `CLAUDE_CODE_OAUTH_TOKEN` for OAuth token authentication (available on Pro, Max, Team, and Enterprise plans; generate one by running `claude setup-token` locally)
 3. Copy the workflow file from [`examples/claude.yml`](../examples/claude.yml) into your repository's `.github/workflows/`
 
 > Don't want to store a static API key at all? See [Workload Identity Federation](#workload-identity-federation) below.
@@ -220,7 +220,7 @@ We also recommend that you always use short-lived tokens when possible
 3. Click "New repository secret"
 4. For authentication, choose one:
    - API Key: Name: `ANTHROPIC_API_KEY`, Value: Your Anthropic API key (starting with `sk-ant-`)
-   - OAuth Token: Name: `CLAUDE_CODE_OAUTH_TOKEN`, Value: Your Claude Code OAuth token (Pro and Max users can generate this by running `claude setup-token` locally)
+   - OAuth Token: Name: `CLAUDE_CODE_OAUTH_TOKEN`, Value: Your Claude Code OAuth token (available on Pro, Max, Team, and Enterprise plans; generate one by running `claude setup-token` locally)
 5. Click "Add secret"
 
 ### Best Practices for Authentication


### PR DESCRIPTION
## Summary

`docs/setup.md` describes `CLAUDE_CODE_OAUTH_TOKEN` as something "Pro and Max users" can generate (two occurrences). The official Claude Code documentation is broader — [GitHub Actions → Manual setup, step 2](https://code.claude.com/docs/en/github-actions#manual-setup) says:

> `CLAUDE_CODE_OAUTH_TOKEN`: an OAuth token that authenticates with your Claude subscription, **available on Pro, Max, Team, and Enterprise plans**. Generate one by running `claude setup-token` locally.

This PR aligns both mentions in `setup.md` with that wording. As written today, the doc steers Team/Enterprise seat holders — who often have no Anthropic API organization at all — away from the one auth path that works for them.

## Changes

- `docs/setup.md` line 10 (quick setup) and line 223 (manual secret setup): "(Pro and Max users can generate this by running `claude setup-token` locally)" → "(available on Pro, Max, Team, and Enterprise plans; generate one by running `claude setup-token` locally)"

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)