### PR TITLE
fix(base-action): add ~/.local/bin to $GITHUB_PATH after auto-install

### DIFF
--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -165,6 +165,8 @@ runs:
             sleep 5
           done
           echo "Claude Code installed successfully"
+          # Add ~/.local/bin to PATH so the claude executable is available in subsequent steps
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         else
           echo "Using custom Claude Code executable: $PATH_TO_CLAUDE_CODE_EXECUTABLE"
           # Add the directory containing the custom executable to PATH


### PR DESCRIPTION
## Problem

The "Install Claude Code" step in base-action/action.yml has an asymmetry: the custom-executable branch correctly adds the binary's directory to `$GITHUB_PATH`, but the default auto-install branch (via `curl https://claude.ai/install.sh | bash`) does not. The install.sh script places the claude binary in `~/.local/bin` and prints instructions to modify shell config files, which are ineffective in GitHub Actions' non-interactive bash environment where each step runs with `--noprofile --norc` and PATH persistence only works via `$GITHUB_PATH`. This causes the next step to fail with "Executable not found in $PATH: 'claude'" on runners where `~/.local/bin` isn't already in PATH.

## Fix

After the curl install succeeds in the default branch (line 167), add `echo "$HOME/.local/bin" >> "$GITHUB_PATH"` to mirror the custom-executable branch's behavior. This makes the claude executable available in subsequent steps.

## Testing

The fix mirrors the existing pattern used in the custom-executable branch (lines 171-174) and matches the suggested fix from the issue report. The change ensures PATH propagation works correctly on self-hosted runners and any environment where `~/.local/bin` isn't pre-configured in PATH.

Fixes #1634
