### PR TITLE
release: push tags with the release deploy key (enables tag-ruleset enforcement)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,9 @@ jobs:
       next_version: ${{ steps.next_version.outputs.next_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA-pinned (same pin as sync-base-action.yml): this step is handed
+        # the ruleset-bypass deploy key, so it must not resolve a mutable tag.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           # Tag pushes below authenticate as the release deploy key (a
@@ -110,7 +112,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        # SHA-pinned (same pin as sync-base-action.yml): this step is handed
+        # the ruleset-bypass deploy key, so it must not resolve a mutable tag.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           # Tag pushes below authenticate as the release deploy key (a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # Tag pushes below authenticate as the release deploy key (a
+          # bypass actor on the "Protect release tags" ruleset) instead of
+          # GITHUB_TOKEN, which can never bypass a ruleset. The key lives
+          # only in the main-restricted `production` environment.
+          ssh-key: ${{ secrets.RELEASE_TAG_DEPLOY_KEY }}
 
       - name: Get latest tag
         id: get_latest_tag
@@ -108,6 +113,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # Tag pushes below authenticate as the release deploy key (a
+          # bypass actor on the "Protect release tags" ruleset) instead of
+          # GITHUB_TOKEN, which can never bypass a ruleset. The key lives
+          # only in the main-restricted `production` environment.
+          ssh-key: ${{ secrets.RELEASE_TAG_DEPLOY_KEY }}
 
       - name: Update major version tag
         run: |


### PR DESCRIPTION
## What

`release.yml`'s two tag-pushing jobs (`create-release`, `update-major-tag`) now check out with `ssh-key: ${{ secrets.RELEASE_TAG_DEPLOY_KEY }}`, so `git push origin vX.Y.Z` and `git push origin v1 --force` authenticate as a **write deploy key** instead of `GITHUB_TOKEN`. Nothing else changes: same trigger (Run workflow / auto after "CI All" on a bump commit), same jobs, same commands, same `production` environment. `gh release create` still uses `GITHUB_TOKEN` (creating the Release object isn't a ref push).

**Before:** tags are pushed as `github-actions[bot]` via `GITHUB_TOKEN`.
**After:** tags are pushed over SSH as the `release-tag-pusher` deploy key.

## Why

`uses: anthropics/claude-code-action@v1` is resolved at run time in every customer's CI, so whoever can move `v1` gets code execution in all of them (the tj-actions / CVE-2025-30066 shape). anthropics/terraform-config#81310 adds tag rulesets to this repo: published `vX.Y.Z` tags become immutable, and creating tags / moving `v0`/`v1` is restricted to a bypass actor. GitHub **never** lets `GITHUB_TOKEN` bypass a ruleset, so with the current workflow that second ruleset can only run in `evaluate` (log-only). A deploy key *is* a valid bypass actor — this is the same mechanism `sync-base-action.yml` already uses (`CLAUDE_CODE_BASE_ACTION_REPO_DEPLOY_KEY`) and that `claude-cli-internal` uses to push version bumps here.

Once this is merged and one release has gone out on the deploy key (visible in Settings → Rules → Insights), DevSec flips the ruleset from `evaluate` to `active` in terraform-config, after which only this workflow (running from `main`, in `production`) can create tags or move `v1`; a human `git push -f origin v1` is rejected with GH013.

Tracks Security Vitals finding 9f945156.

## Already done (repo settings, @chrisnorman 2026-08-14)

- Deploy key `release-tag-pusher` (ed25519, write) added to this repo.
- Private half stored as **environment** secret `RELEASE_TAG_DEPLOY_KEY` on `production`.
- `production` environment restricted to deployment branch `main`; admin bypass disabled. No required reviewers (so neither this workflow nor `sync-base-action.yml` gains a manual gate).

## Risk / rollback

- If the secret were missing/empty, `actions/checkout` falls back to `GITHUB_TOKEN` and the release behaves exactly as today (and keeps working while the ruleset is still `evaluate`).
- Rollback = revert this PR; nothing else depends on it until the terraform flip, which is gated on seeing a successful deploy-key release first.
- Note for the future: the ruleset's DeployKey bypass covers *every* write deploy key on the repo (GitHub API limitation), so please avoid adding further write deploy keys here.

## Test plan

- `dry_run: true` dispatch after merge → checkout succeeds with the key (no push).
- Next real release → `vX.Y.Z` created and `v1` moved; Rules → Insights shows actor = deploy key.
- After the tf flip: manual `git push -f origin v1` from a writer's clone → `GH013: Repository rule violations`.
