### PR TITLE
fix(base-action): add ~/.local/bin to GITHUB_PATH after install

### DIFF
--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -165,6 +165,9 @@ runs:
             sleep 5
           done
           echo "Claude Code installed successfully"
+          # Persist default install location for subsequent steps.
+          # install.sh places the native binary in ~/.local/bin.
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
         else
           echo "Using custom Claude Code executable: $PATH_TO_CLAUDE_CODE_EXECUTABLE"
           # Add the directory containing the custom executable to PATH


### PR DESCRIPTION
## Summary
- add `~/.local/bin` to `$GITHUB_PATH` after the default Claude Code install path succeeds
- keep behavior unchanged for `path_to_claude_code_executable` (already appends custom directory)

## Why
`install.sh` installs `claude` under `~/.local/bin`. Without adding that directory to `$GITHUB_PATH`, subsequent steps can fail with `Executable not found in $PATH: "claude"` on runners where `~/.local/bin` is not preconfigured.

Closes #1634.
