### PR TITLE
fix: preserve full checkout when restoring trusted PR config

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -303,9 +303,21 @@ export function restoreConfigFromBase(baseBranch: string): void {
 
   // --no-recurse-submodules: explicitly suppress submodule fetching regardless of
   // fetch.recurseSubmodules config. Defense-in-depth alongside the delete above.
+  // Preserve the repository shallow/full state: use depth=1 only when the
+  // checkout is already shallow so we don't convert full checkouts into shallow.
+  const fetchArgs = [
+    "fetch",
+    "origin",
+    baseBranch,
+    "--no-recurse-submodules",
+  ];
+  if (isShallowRepository()) {
+    fetchArgs.push("--depth=1");
+  }
+
   execFileSync(
     "git",
-    ["fetch", "origin", baseBranch, "--depth=1", "--no-recurse-submodules"],
+    fetchArgs,
     {
       stdio: "inherit",
       env: process.env,
@@ -330,5 +342,17 @@ export function restoreConfigFromBase(baseBranch: string): void {
     });
   } catch {
     // Nothing was staged, or paths don't exist on HEAD — either is fine.
+  }
+}
+
+function isShallowRepository(): boolean {
+  try {
+    const output = execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+    return output.trim() === "true";
+  } catch {
+    return false;
   }
 }

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -394,6 +394,18 @@ describe("restoreConfigFromBase", () => {
     expect(countClaudePrExcludeEntries()).toBe(1);
   });
 
+  test("does not convert a full checkout into a shallow repository", () => {
+    expect(git(["rev-parse", "--is-shallow-repository"]).trim()).toBe(
+      "false",
+    );
+
+    restoreConfigFromBase("main");
+
+    expect(git(["rev-parse", "--is-shallow-repository"]).trim()).toBe(
+      "false",
+    );
+  });
+
   function git(args: string[]): string {
     return execFileSync("git", args, {
       cwd: repoDir,


### PR DESCRIPTION
## Summary
- preserve repository shallow/full state when restoring trusted config paths in PR runs
- use `git fetch ... --depth=1` only if the current checkout is already shallow
- keep `--no-recurse-submodules` behavior unchanged
- add a regression test asserting restore does not convert a full checkout into a shallow repo

## Why
`restoreConfigFromBase` always fetched with `--depth=1`, which can turn a full checkout (`fetch-depth: 0`) into a shallow one and break merge-base / three-dot diff operations later in the workflow.

## Validation
- `bun test test/restore-config.test.ts -t "does not convert a full checkout into a shallow repository"`

Closes #1642.
