### PR TITLE
fix(mcp): support mcp__github aggregate selector

### DIFF
--- a/src/mcp/install-mcp-server.ts
+++ b/src/mcp/install-mcp-server.ts
@@ -87,8 +87,8 @@ export async function prepareMcpConfig(
       tool.startsWith("mcp__github_comment__"),
     );
 
-    const hasGitHubMcpTools = allowedToolsList.some((tool) =>
-      tool.startsWith("mcp__github__"),
+    const hasGitHubMcpTools = allowedToolsList.some(
+      (tool) => tool === "mcp__github" || tool.startsWith("mcp__github__"),
     );
 
     const hasInlineCommentTools = allowedToolsList.some((tool) =>

--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -121,8 +121,8 @@ export async function prepareTagMode({
   );
 
   const userClaudeArgs = process.env.CLAUDE_ARGS || "";
-  const userAllowedMCPTools = parseAllowedTools(userClaudeArgs).filter((tool) =>
-    tool.startsWith("mcp__github_"),
+  const userAllowedMCPTools = parseAllowedTools(userClaudeArgs).filter(
+    (tool) => tool === "mcp__github" || tool.startsWith("mcp__github_"),
   );
 
   const gitPushWrapper = `${process.env.GITHUB_ACTION_PATH}/scripts/git-push.sh`;

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -154,6 +154,39 @@ describe("prepareMcpConfig", () => {
     );
   });
 
+  test("should include github MCP server when mcp__github is allowed", async () => {
+    const result = await prepareMcpConfig({
+      githubToken: "test-token",
+      owner: "test-owner",
+      repo: "test-repo",
+      branch: "test-branch",
+      baseBranch: "main",
+      allowedTools: ["mcp__github"],
+      mode: "agent",
+      context: mockContext,
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.mcpServers.github).toBeDefined();
+    expect(parsed.mcpServers.github.command).toBe("docker");
+  });
+
+  test("should not treat look-alike tool names as github MCP tools", async () => {
+    const result = await prepareMcpConfig({
+      githubToken: "test-token",
+      owner: "test-owner",
+      repo: "test-repo",
+      branch: "test-branch",
+      baseBranch: "main",
+      allowedTools: ["mcp__githubish", "mcp__github-actions__get_status"],
+      mode: "agent",
+      context: mockContext,
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.mcpServers.github).not.toBeDefined();
+  });
+
   test("should include inline comment server for PRs when tools are allowed", async () => {
     const result = await prepareMcpConfig({
       githubToken: "test-token",

--- a/test/modes/tag.test.ts
+++ b/test/modes/tag.test.ts
@@ -18,8 +18,11 @@ describe("Tag Mode", () => {
     let spies: Array<{ mockRestore: () => void }>;
     let configureGitAuthSpy: any;
     let replaceCheckoutCredentialsSpy: any;
+    let prepareMcpConfigSpy: any;
+    let originalClaudeArgs: string | undefined;
 
     beforeEach(() => {
+      originalClaudeArgs = process.env.CLAUDE_ARGS;
       configureGitAuthSpy = spyOn(
         gitConfig,
         "configureGitAuth",
@@ -47,11 +50,19 @@ describe("Tag Mode", () => {
             }) as any,
         ),
         spyOn(createPrompt, "createPrompt").mockImplementation(async () => {}),
-        spyOn(mcp, "prepareMcpConfig").mockImplementation(async () => "{}"),
+        (prepareMcpConfigSpy = spyOn(
+          mcp,
+          "prepareMcpConfig",
+        ).mockImplementation(async () => "{}")),
       ];
     });
 
     afterEach(() => {
+      if (originalClaudeArgs === undefined) {
+        delete process.env.CLAUDE_ARGS;
+      } else {
+        process.env.CLAUDE_ARGS = originalClaudeArgs;
+      }
       for (const spy of spies) {
         spy.mockRestore();
       }
@@ -93,6 +104,21 @@ describe("Tag Mode", () => {
       expect(replaceCheckoutCredentialsSpy).toHaveBeenCalledWith(
         "test-token",
         context,
+      );
+    });
+
+    test("forwards the mcp__github aggregate selector to MCP setup", async () => {
+      process.env.CLAUDE_ARGS = "--allowedTools mcp__github";
+
+      await prepareTagMode({
+        context: { ...mockIssueCommentContext },
+        octokit: {} as any,
+        githubToken: "test-token",
+      });
+
+      expect(prepareMcpConfigSpy).toHaveBeenCalledTimes(1);
+      expect(prepareMcpConfigSpy.mock.calls[0]?.[0].allowedTools).toContain(
+        "mcp__github",
       );
     });
   });


### PR DESCRIPTION
## Summary

- recognize the documented `mcp__github` aggregate selector when deciding whether to install the GitHub MCP server
- preserve that selector when tag mode forwards user-approved GitHub MCP tools
- add regression coverage for agent mode, tag mode, qualified tool names, and look-alike names

Fixes #723.

## Testing

- `bun test` (913 passed)
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`
