### PR TITLE
ci: skip Claude-backed test jobs on fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   review:
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/test-base-action.yml
+++ b/.github/workflows/test-base-action.yml
@@ -19,6 +19,8 @@ permissions:
 
 jobs:
   test-inline-prompt:
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -70,6 +72,8 @@ jobs:
           fi
 
   test-prompt-file:
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-custom-executables.yml
+++ b/.github/workflows/test-custom-executables.yml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   test-custom-executables:
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-mcp-servers.yml
+++ b/.github/workflows/test-mcp-servers.yml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   test-mcp-integration:
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -94,6 +96,8 @@ jobs:
           echo "✓ All MCP server checks passed!"
 
   test-mcp-config-flag:
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/test-settings.yml
+++ b/.github/workflows/test-settings.yml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   test-settings-inline-allow:
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -65,6 +67,8 @@ jobs:
           fi
 
   test-settings-inline-deny:
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -99,6 +103,8 @@ jobs:
           fi
 
   test-settings-file-allow:
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -155,6 +161,8 @@ jobs:
           fi
 
   test-settings-file-deny:
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-structured-output.yml
+++ b/.github/workflows/test-structured-output.yml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   test-basic-types:
     name: Test Basic Type Conversions
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -76,6 +78,8 @@ jobs:
 
   test-complex-types:
     name: Test Arrays and Objects
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -129,6 +133,8 @@ jobs:
 
   test-edge-cases:
     name: Test Edge Cases
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -190,6 +196,8 @@ jobs:
 
   test-name-sanitization:
     name: Test Output Name Sanitization
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -232,6 +240,8 @@ jobs:
 
   test-execution-file-structure:
     name: Test Execution File Format
+    # Skip on fork PRs since they can't mint the OIDC token used for Claude API auth
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -284,7 +294,7 @@ jobs:
       - test-edge-cases
       - test-name-sanitization
       - test-execution-file-structure
-    if: always()
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - name: Generate Summary
         run: |

--- a/test/fetch-depth.test.ts
+++ b/test/fetch-depth.test.ts
@@ -28,7 +28,16 @@ describe("setupBranch fetch depth", () => {
     repoDir = join(tempDir, "repo");
     const remoteDir = join(tempDir, "origin.git");
 
-    execFileSync("git", ["init", "--bare", remoteDir], { stdio: "pipe" });
+    // Pin the remote's HEAD to main: with the default init.defaultBranch of
+    // master it would dangle, and `git clone --depth=1` (which implies
+    // --single-branch) then produces an empty, non-shallow clone.
+    execFileSync(
+      "git",
+      ["init", "--bare", "--initial-branch=main", remoteDir],
+      {
+        stdio: "pipe",
+      },
+    );
     execFileSync("git", ["init", repoDir], { stdio: "pipe" });
     git(["checkout", "-b", "main"]);
     git(["config", "user.email", "test@example.com"]);


### PR DESCRIPTION
## Summary

The `test-*` workflows and `claude-review.yml` run the action against the Claude API, authenticated via workload identity federation. Fork PRs can't mint the OIDC token that gets exchanged for an access token, so every one of those jobs failed on external contributions and buried the real signal from `ci.yml`.

This gates each such job on the PR head repo matching the base repo, the same way `claude-agent-sdk-python` does:

```yaml
if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
```

- The `event_name != 'pull_request'` arm keeps `push` and `workflow_dispatch` runs unaffected. Since `github.event_name` is inherited by `workflow_call`, this also covers the `ci-all.yml` path.
- `test-structured-output.yml`'s `test-summary` job folds the gate into its existing `always()` so it doesn't run and `exit 1` against all-skipped needs.
- `claude-review.yml` only fires on `pull_request`, so it uses the plain repo comparison.

`ci.yml` (test / prettier / typecheck) is unchanged and still runs on fork PRs. `claude.yml` and `issue-triage.yml` are comment/issue-event driven and run in the base repo context, so they're untouched too.

## Also: fix `test/fetch-depth.test.ts` on CI (unrelated, but it was red on main)

`setupBranch fetch depth > still limits the depth on an already shallow checkout` (added in #1647) fails on ubuntu-latest. The test creates its bare remote with a plain `git init --bare`, so the remote's `HEAD` points at `init.defaultBranch` (`master` on the runner) while the test only pushes `main`. `git clone --depth=1` implies `--single-branch`, and with a dangling remote HEAD git falls back to "You appear to have cloned an empty repository" — no commits, no `.git/shallow`, so `--is-shallow-repository` is `false`. It passed locally for anyone whose default branch is `main`.

Fixed by creating the bare remote with `--initial-branch=main`. Verified locally: fails 1/4 with `GIT_CONFIG_GLOBAL` set to `init.defaultBranch=master` before, 4/4 after.

## Test plan

- [x] `bun test` green locally, including under a simulated `init.defaultBranch=master`
- [ ] Same-repo PR: all Claude-backed jobs still run and `ci / test` is green (this PR)
- [ ] Fork PR: Claude-backed jobs show as skipped, `ci / *` still runs
- [ ] `push` to main via `ci-all.yml`: Claude-backed jobs still run