### PR TITLE
fix(restore): gracefully handle git fetch failures when credentials unavailable

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -304,20 +304,35 @@ export function restoreConfigFromBase(baseBranch: string): void {
 
   // --no-recurse-submodules: explicitly suppress submodule fetching regardless of
   // fetch.recurseSubmodules config. Defense-in-depth alongside the delete above.
-  execFileSync(
-    "git",
-    [
-      "fetch",
-      "origin",
-      baseBranch,
-      ...fetchDepthArgs(1),
-      "--no-recurse-submodules",
-    ],
-    {
-      stdio: "inherit",
-      env: process.env,
-    },
-  );
+  //
+  // Wrap fetch in try/catch: when credentials are unavailable (e.g., commit
+  // signing mode + persist-credentials=false), git fetch will fail. In that case,
+  // fall back to the already-safe behavior of leaving sensitive paths deleted
+  // rather than fatal-exiting the action.
+  try {
+    execFileSync(
+      "git",
+      [
+        "fetch",
+        "origin",
+        baseBranch,
+        ...fetchDepthArgs(1),
+        "--no-recurse-submodules",
+      ],
+      {
+        stdio: "inherit",
+        env: process.env,
+      },
+    );
+  } catch (error) {
+    console.warn(
+      `Warning: git fetch origin/${baseBranch} failed (likely missing credentials). ` +
+        `Sensitive paths will remain deleted (safe fallback).`,
+    );
+    // When fetch fails, skip checkout attempts below — base content is unavailable,
+    // so sensitive paths stay deleted, which is the safe outcome.
+    return;
+  }
 
   for (const p of SENSITIVE_PATHS) {
     try {

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -425,6 +425,22 @@ describe("restoreConfigFromBase", () => {
     ).toEqual([".claude/settings.json", "CLAUDE.md"]);
   });
 
+  test("gracefully handles git fetch failures and leaves sensitive paths deleted", () => {
+    // Simulate a private repo scenario where credentials are unavailable by
+    // removing the remote. The git fetch will fail, but the action should not
+    // fatal-exit; it should leave sensitive paths deleted (safe fallback).
+    git(["remote", "remove", "origin"]);
+
+    expect(() => restoreConfigFromBase("main")).not.toThrow();
+
+    expect(existsRepoFile("CLAUDE.md")).toBe(false);
+    expect(existsRepoFile(".claude/settings.json")).toBe(false);
+    expect(existsRepoFile(".claude-pr/CLAUDE.md")).toBe(true);
+    expect(readRepoFile(".claude-pr/CLAUDE.md")).toBe(
+      "pr claude instructions\n",
+    );
+  });
+
   function git(args: string[]): string {
     return execFileSync("git", args, {
       cwd: repoDir,


### PR DESCRIPTION
## Problem

When `use_commit_signing: true` is set and the workflow checks out with `persist-credentials: false`, a mode fails during config restore with a fatal git fetch error on private repositories. The action has a design inconsistency: commit signing mode intentionally avoids embedding tokens into git remotes (commits go through GitHub API), but the config restore step in `restoreConfigFromBase` still performs a git-level network operation that requires authentication.

## Fix

Wrapped the git fetch call in `src/github/operations/restore-config.ts` with try/catch error handling. When git fetch fails due to missing credentials, the action now logs a warning and returns early, falling back to the already-safe behavior of leaving sensitive paths deleted rather than fatal-exiting. This preserves the security guarantee (PR-controlled sensitive config never executes) while preventing the action from crashing in environments where git credentials are unavailable.

## Testing

Added a regression test that simulates fetch failure by removing the git remote before calling `restoreConfigFromBase`. The test verifies that the function completes without throwing and leaves sensitive paths deleted while preserving the PR snapshot in `.pr/`.

Fixes #1559