### PR TITLE
fix(examples): change pull-requests permission from read to write in PR review examples

### DIFF
--- a/examples/pr-review-filtered-authors.yml
+++ b/examples/pr-review-filtered-authors.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout repository

--- a/examples/pr-review-filtered-paths.yml
+++ b/examples/pr-review-filtered-paths.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Problem

The PR review example workflows in `examples/pr-review-filtered-authors.yml` and `examples/pr-review-filtered-paths.yml` declare `pull-requests: read` permissions. These workflows use `gh pr comment` bash commands to post review feedback, which requires write access to pull requests. With read-only permissions, the workflows complete successfully but fail silently when attempting to post comments.

## Fix

Changed `pull-requests: read` to `pull-requests: write` in both example files. This matches the permissions in other review examples like `pr-review-comprehensive.yml` and ensures the bash tools (`gh pr comment`) can actually post their output.

## Testing

Verified the permission blocks now match the working examples and align with the action's requirement for write access when posting comments or reviews.

Fixes #1562
