### PR TITLE
fix(images): bound attachment downloads with a size limit

### DIFF
--- a/src/github/utils/image-downloader.ts
+++ b/src/github/utils/image-downloader.ts
@@ -35,6 +35,9 @@ const SIGNED_URL_PATH_REGEX =
   /^\/[^/]+\/[^/]*-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\.[a-z0-9]+)?$/i;
 
 const DEFAULT_IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000;
+// GitHub caps issue/PR image attachments at 10 MB, so anything above that is
+// not something a comment could legitimately carry.
+const DEFAULT_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
 
 function extractSignedUrlAssetGuid(signedUrl: string): string | undefined {
   let parsed: URL;
@@ -89,6 +92,7 @@ export type CommentWithImages =
 
 type ImageDownloadOptions = {
   timeoutMs?: number;
+  maxBytes?: number;
 };
 
 export async function downloadCommentImages(
@@ -100,6 +104,7 @@ export async function downloadCommentImages(
 ): Promise<Map<string, string>> {
   const urlToPathMap = new Map<string, string>();
   const timeoutMs = options.timeoutMs ?? DEFAULT_IMAGE_DOWNLOAD_TIMEOUT_MS;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_IMAGE_BYTES;
   const downloadsDir = "/tmp/github-images";
 
   await fs.mkdir(downloadsDir, { recursive: true });
@@ -249,7 +254,7 @@ export async function downloadCommentImages(
         try {
           console.log(`Downloading ${originalUrl}...`);
 
-          const buffer = await fetchImage(signedUrl, timeoutMs);
+          const buffer = await fetchImage(signedUrl, timeoutMs, maxBytes);
 
           // GitHub user-attachment URLs (/user-attachments/assets/<uuid>) carry
           // no file extension, so the URL-based guess silently falls back to
@@ -289,7 +294,11 @@ export async function downloadCommentImages(
   return urlToPathMap;
 }
 
-async function fetchImage(url: string, timeoutMs: number): Promise<Buffer> {
+async function fetchImage(
+  url: string,
+  timeoutMs: number,
+  maxBytes: number,
+): Promise<Buffer> {
   const controller = new AbortController();
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
@@ -298,6 +307,9 @@ async function fetchImage(url: string, timeoutMs: number): Promise<Buffer> {
       reject(new Error(`Image download timed out after ${timeoutMs}ms`));
     }, timeoutMs);
   });
+
+  const tooLarge = (bytes: number | string) =>
+    new Error(`Image exceeds the ${maxBytes} byte limit (${bytes} bytes)`);
 
   try {
     const response = await Promise.race([
@@ -308,10 +320,51 @@ async function fetchImage(url: string, timeoutMs: number): Promise<Buffer> {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
 
+    // Reject on the advertised size before reading anything.
+    const contentLength = Number(response.headers?.get?.("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+      controller.abort();
+      throw tooLarge(contentLength);
+    }
+
+    // Stream when the body is available so an oversized (or lying) response is
+    // dropped mid-flight instead of being buffered in full.
+    const body = response.body;
+    if (body?.getReader) {
+      const reader = body.getReader();
+      const chunks: Uint8Array[] = [];
+      let received = 0;
+
+      try {
+        for (;;) {
+          const { done, value } = await Promise.race([
+            reader.read(),
+            timeoutPromise,
+          ]);
+          if (done) break;
+          if (!value) continue;
+
+          received += value.byteLength;
+          if (received > maxBytes) {
+            controller.abort();
+            throw tooLarge(received);
+          }
+          chunks.push(value);
+        }
+      } finally {
+        reader.releaseLock?.();
+      }
+
+      return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+    }
+
     const arrayBuffer = await Promise.race([
       response.arrayBuffer(),
       timeoutPromise,
     ]);
+    if (arrayBuffer.byteLength > maxBytes) {
+      throw tooLarge(arrayBuffer.byteLength);
+    }
     return Buffer.from(arrayBuffer);
   } finally {
     if (timeoutHandle !== undefined) {

--- a/test/image-downloader.test.ts
+++ b/test/image-downloader.test.ts
@@ -1233,4 +1233,175 @@ describe("downloadCommentImages", () => {
       "Found 1 image(s) in issue_comment 1001",
     );
   });
+
+  test("should reject an image whose content-length exceeds the limit", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl = assetUrl(GUID_1);
+    const signedUrl = signedUrlFor(GUID_1, ".png");
+    let signal: AbortSignal | null | undefined;
+    const arrayBufferSpy = jest.fn();
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl}">`,
+      },
+    });
+
+    fetchSpy = spyOn(global, "fetch");
+    fetchSpy.mockImplementation((_input: unknown, init?: RequestInit) => {
+      signal = init?.signal;
+      return Promise.resolve({
+        ok: true,
+        headers: {
+          get: (name: string) => (name === "content-length" ? "2048" : null),
+        },
+        arrayBuffer: arrayBufferSpy,
+      } as unknown as Response);
+    });
+
+    const result = await downloadCommentImages(
+      mockOctokit,
+      "owner",
+      "repo",
+      [
+        {
+          type: "issue_comment",
+          id: "447",
+          body: `Huge image: ![huge](${imageUrl})`,
+        },
+      ],
+      { maxBytes: 1024 },
+    );
+
+    expect(result.size).toBe(0);
+    // Rejected on the advertised size, without reading the body at all.
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
+    expect(signal?.aborted).toBe(true);
+    expect(fsWriteFileSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to download"),
+      expect.objectContaining({
+        message: "Image exceeds the 1024 byte limit (2048 bytes)",
+      }),
+    );
+  });
+
+  test("should abort a streamed body that grows past the limit", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl = assetUrl(GUID_1);
+    const signedUrl = signedUrlFor(GUID_1, ".png");
+    let signal: AbortSignal | null | undefined;
+    let chunksRead = 0;
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl}">`,
+      },
+    });
+
+    fetchSpy = spyOn(global, "fetch");
+    fetchSpy.mockImplementation((_input: unknown, init?: RequestInit) => {
+      signal = init?.signal;
+      return Promise.resolve({
+        ok: true,
+        // No content-length: the response lies about (or omits) its size.
+        headers: { get: () => null },
+        body: {
+          getReader: () => ({
+            read: async () => {
+              chunksRead += 1;
+              return { done: false, value: new Uint8Array(64) };
+            },
+            releaseLock: () => {},
+          }),
+        },
+      } as unknown as Response);
+    });
+
+    const result = await downloadCommentImages(
+      mockOctokit,
+      "owner",
+      "repo",
+      [
+        {
+          type: "issue_comment",
+          id: "448",
+          body: `Endless image: ![endless](${imageUrl})`,
+        },
+      ],
+      { maxBytes: 128 },
+    );
+
+    expect(result.size).toBe(0);
+    // Stopped mid-stream instead of buffering the whole body.
+    expect(chunksRead).toBe(3);
+    expect(signal?.aborted).toBe(true);
+    expect(fsWriteFileSpy).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to download"),
+      expect.objectContaining({
+        message: "Image exceeds the 128 byte limit (192 bytes)",
+      }),
+    );
+  });
+
+  test("should save a streamed image that stays within the limit", async () => {
+    const mockOctokit = createMockOctokit();
+    const imageUrl = assetUrl(GUID_1);
+    const signedUrl = signedUrlFor(GUID_1, ".png");
+    const png = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+    let delivered = false;
+
+    // @ts-expect-error Mock implementation doesn't match full type signature
+    mockOctokit.rest.issues.getComment = jest.fn().mockResolvedValue({
+      data: {
+        body_html: `<img src="${signedUrl}">`,
+      },
+    });
+
+    fetchSpy = spyOn(global, "fetch");
+    fetchSpy.mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        headers: {
+          get: (name: string) =>
+            name === "content-length" ? String(png.byteLength) : null,
+        },
+        body: {
+          getReader: () => ({
+            read: async () => {
+              if (delivered) return { done: true, value: undefined };
+              delivered = true;
+              return { done: false, value: png };
+            },
+            releaseLock: () => {},
+          }),
+        },
+      } as unknown as Response),
+    );
+
+    const result = await downloadCommentImages(
+      mockOctokit,
+      "owner",
+      "repo",
+      [
+        {
+          type: "issue_comment",
+          id: "449",
+          body: `Small image: ![small](${imageUrl})`,
+        },
+      ],
+      { maxBytes: 1024 },
+    );
+
+    expect(result.size).toBe(1);
+    expect(fsWriteFileSpy).toHaveBeenCalledWith(
+      expect.stringContaining("/tmp/github-images/image-"),
+      Buffer.from(png),
+    );
+  });
 });


### PR DESCRIPTION
Fixes #1628

## Problem

`downloadCommentImages` reads every attachment with `response.arrayBuffer()` and writes it to disk without ever checking how big it is. An oversized (or deliberately hostile) attachment is buffered in full before the action can decide anything about it, so a comment can drive the runner's memory usage with untrusted content. #1625 bounded these downloads in *time*; this bounds them in *size*.

## Solution

`fetchImage` now takes a `maxBytes` budget (`DEFAULT_MAX_IMAGE_BYTES` = 10 MiB, which is GitHub's own cap for issue/PR image attachments; overridable through the existing options bag as `maxBytes`, next to `timeoutMs`):

1. **Advertised size first** — if `content-length` exceeds the budget, abort and throw without reading the body at all.
2. **Streamed, bounded read** — when `response.body` is available, consume it chunk by chunk and abort as soon as the accumulated size passes the budget, so a response that under-reports or omits `content-length` still can't be buffered in full.
3. **Fallback** — if the response exposes no stream, fall back to the previous `arrayBuffer()` path and reject afterwards if it came back oversized.

Failures surface through the existing per-image `catch`, so one rejected attachment skips that image and leaves the rest of the run untouched, exactly like a timeout does today.

## Test Plan

- Three new tests in `test/image-downloader.test.ts`:
  - oversized `content-length` ⇒ rejected before the body is touched (asserts `arrayBuffer` is never called, the request is aborted, and nothing is written);
  - a body with no `content-length` that keeps yielding chunks ⇒ aborted mid-stream after exactly 3 reads at `maxBytes: 128`, nothing written;
  - a small streamed PNG ⇒ saved unchanged, with the exact bytes asserted.
- `bun test` on the file: 30 pass (27 pre-existing, unchanged).
- Full suite: **923 pass, 0 fail** (52 files).
- `bun run typecheck` and `bun run format:check` clean.
