### PR TITLE
feat: surface active model and effort in tracking comments

### DIFF
--- a/src/entrypoints/update-comment-link.ts
+++ b/src/entrypoints/update-comment-link.ts
@@ -16,6 +16,7 @@ import type { ParsedGitHubContext } from "../github/context";
 import { GITHUB_SERVER_URL } from "../github/api/config";
 import { checkAndCommitOrDeleteBranch } from "../github/operations/branch-cleanup";
 import { updateClaudeComment } from "../github/operations/comments/update-claude-comment";
+import { resolveModel, resolveEffort } from "../utils/claude-args";
 
 export type UpdateCommentLinkParams = {
   commentId: number;
@@ -205,6 +206,7 @@ export async function updateCommentLink(
   }
 
   // Prepare input for updateCommentBody function
+  const claudeArgs = process.env.CLAUDE_ARGS || "";
   const commentInput: CommentUpdateInput = {
     currentBody,
     actionFailed,
@@ -215,6 +217,8 @@ export async function updateCommentLink(
     branchName: shouldDeleteBranch || !branchLink ? undefined : claudeBranch,
     triggerUsername,
     errorDetails,
+    model: resolveModel(claudeArgs),
+    effort: resolveEffort(claudeArgs),
   };
 
   const updatedBody = updateCommentBody(commentInput);

--- a/src/github/operations/comment-logic.ts
+++ b/src/github/operations/comment-logic.ts
@@ -1,5 +1,6 @@
 import { GITHUB_SERVER_URL } from "../api/config";
 import { redactSecrets } from "../utils/sanitizer";
+import { buildModelEffortLine } from "./comments/common";
 
 export type ExecutionDetails = {
   total_cost_usd?: number;
@@ -17,6 +18,8 @@ export type CommentUpdateInput = {
   branchName?: string;
   triggerUsername?: string;
   errorDetails?: string;
+  model?: string;
+  effort?: string;
 };
 
 export function ensureProperlyEncodedUrl(url: string): string | null {
@@ -78,6 +81,8 @@ export function updateCommentBody(input: CommentUpdateInput): string {
     branchName,
     triggerUsername,
     errorDetails,
+    model,
+    effort,
   } = input;
 
   // Extract content from the original comment body
@@ -182,6 +187,12 @@ export function updateCommentBody(input: CommentUpdateInput): string {
   // Build the new body with blank line between header and separator
   let newBody = `${header}${links}`;
 
+  // Surface the active model/effort when configured.
+  const modelEffortLine = buildModelEffortLine(model, effort);
+  if (modelEffortLine) {
+    newBody += `\n\n${modelEffortLine}`;
+  }
+
   // Add error details if available. The message may embed runtime credentials
   // (e.g. a token in a git remote URL) that are not registered as workflow
   // secrets, so redact known formats before posting.
@@ -198,6 +209,12 @@ export function updateCommentBody(input: CommentUpdateInput): string {
 
   // Remove any existing duration info at the bottom
   bodyContent = bodyContent.replace(/\n*---\n*Duration: [0-9]+m? [0-9]+s/g, "");
+
+  // Remove the model/effort line the initial tracking comment carried over so
+  // it isn't duplicated below the separator (we re-render it in the header).
+  if (modelEffortLine) {
+    bodyContent = bodyContent.split(modelEffortLine).join("");
+  }
 
   // Add the cleaned body content
   newBody += bodyContent;

--- a/src/github/operations/comments/common.ts
+++ b/src/github/operations/comments/common.ts
@@ -21,13 +21,30 @@ export function createBranchLink(
   return `\n[View branch](${branchUrl})`;
 }
 
+/**
+ * Build the optional "Model: … · Effort: …" line shown in tracking comments.
+ * Returns an empty string when neither value is set so callers can omit the
+ * line entirely rather than rendering empty fields.
+ */
+export function buildModelEffortLine(model?: string, effort?: string): string {
+  const parts: string[] = [];
+  if (model) parts.push(`**Model:** ${model}`);
+  if (effort) parts.push(`**Effort:** ${effort}`);
+  return parts.join(" · ");
+}
+
 export function createCommentBody(
   jobRunLink: string,
   branchLink: string = "",
+  model?: string,
+  effort?: string,
 ): string {
+  const modelEffortLine = buildModelEffortLine(model, effort);
+  const configSection = modelEffortLine ? `${modelEffortLine}\n\n` : "";
+
   return `Claude Code is working… ${SPINNER_HTML}
 
-I'll analyze this and get back to you.
+${configSection}I'll analyze this and get back to you.
 
 ${jobRunLink}${branchLink}`;
 }

--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -7,6 +7,7 @@
 
 import { appendFileSync } from "fs";
 import { createJobRunLink, createCommentBody } from "./common";
+import { resolveModel, resolveEffort } from "../../../utils/claude-args";
 import {
   isPullRequestReviewCommentEvent,
   isPullRequestEvent,
@@ -23,7 +24,13 @@ export async function createInitialComment(
   const { owner, repo } = context.repository;
 
   const jobRunLink = createJobRunLink(owner, repo, context.runId);
-  const initialBody = createCommentBody(jobRunLink);
+  const claudeArgs = process.env.CLAUDE_ARGS || "";
+  const initialBody = createCommentBody(
+    jobRunLink,
+    "",
+    resolveModel(claudeArgs),
+    resolveEffort(claudeArgs),
+  );
 
   try {
     let response;

--- a/src/utils/claude-args.ts
+++ b/src/utils/claude-args.ts
@@ -1,0 +1,77 @@
+import { parse as parseShellArgs } from "shell-quote";
+
+// Flags accepted for the model and effort values shown in tracking comments.
+// "reasoning-effort" is kept as an alias for older CLI spellings.
+const MODEL_FLAGS = ["model"];
+const EFFORT_FLAGS = ["effort", "reasoning-effort"];
+
+/**
+ * Tokenize a claude_args string the same way base-action/src/parse-sdk-options.ts
+ * does. shell-quote returns unquoted glob patterns (e.g. `mcp__github__*`) as
+ * `{ op: "glob", pattern }` objects and control operators (`|`, `>`, `;`, …) as
+ * bare `{ op }` objects. Recover the glob pattern text and drop operators so we
+ * are left with a flat list of argument strings.
+ */
+function tokenize(claudeArgs: string): string[] {
+  return parseShellArgs(claudeArgs)
+    .map((token) => {
+      if (typeof token === "string") return token;
+      if (token && typeof token === "object" && "pattern" in token) {
+        return (token as { pattern: string }).pattern;
+      }
+      return null;
+    })
+    .filter((token): token is string => token !== null);
+}
+
+/**
+ * Return the value for the first of `flags` present in a claude_args string,
+ * or `undefined` if none of them are set. Supports both `--flag value` and
+ * `--flag=value` spellings.
+ */
+export function parseFlagValue(
+  claudeArgs: string | undefined,
+  flags: string[],
+): string | undefined {
+  if (!claudeArgs?.trim()) return undefined;
+
+  const args = tokenize(claudeArgs);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (!arg.startsWith("--")) continue;
+
+    const eqIndex = arg.indexOf("=");
+    const name = (eqIndex >= 0 ? arg.slice(2, eqIndex) : arg.slice(2)).trim();
+    if (!flags.includes(name)) continue;
+
+    // `--flag=value` — return the inline value.
+    if (eqIndex >= 0) {
+      const value = arg.slice(eqIndex + 1);
+      return value ? value : undefined;
+    }
+
+    // `--flag value` — return the next token when it is not another flag.
+    const next = args[i + 1];
+    if (next && !next.startsWith("--")) return next;
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve the active model: the `ANTHROPIC_MODEL` env var takes precedence
+ * (mirroring base-action's `options.model || modelFromClaudeArgs`), then
+ * `--model` from claude_args. Returns `undefined` when neither is set so the
+ * comment can omit the field instead of showing an empty value.
+ */
+export function resolveModel(claudeArgs?: string): string | undefined {
+  return process.env.ANTHROPIC_MODEL || parseFlagValue(claudeArgs, MODEL_FLAGS);
+}
+
+/**
+ * Resolve the active reasoning-effort level from `--effort` (or its
+ * `--reasoning-effort` alias) in claude_args, or `undefined` when unset.
+ */
+export function resolveEffort(claudeArgs?: string): string | undefined {
+  return parseFlagValue(claudeArgs, EFFORT_FLAGS);
+}

--- a/test/claude-args.test.ts
+++ b/test/claude-args.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import {
+  parseFlagValue,
+  resolveModel,
+  resolveEffort,
+} from "../src/utils/claude-args";
+
+describe("parseFlagValue", () => {
+  it("returns undefined for empty or missing args", () => {
+    expect(parseFlagValue(undefined, ["model"])).toBeUndefined();
+    expect(parseFlagValue("", ["model"])).toBeUndefined();
+    expect(parseFlagValue("   ", ["model"])).toBeUndefined();
+  });
+
+  it("extracts a space-separated flag value", () => {
+    expect(parseFlagValue("--model claude-sonnet-4-6", ["model"])).toBe(
+      "claude-sonnet-4-6",
+    );
+  });
+
+  it("extracts an equals-form flag value", () => {
+    expect(parseFlagValue("--model=claude-sonnet-4-6", ["model"])).toBe(
+      "claude-sonnet-4-6",
+    );
+  });
+
+  it("handles quoted values", () => {
+    expect(parseFlagValue(`--model "claude sonnet"`, ["model"])).toBe(
+      "claude sonnet",
+    );
+  });
+
+  it("returns undefined when the flag has no value", () => {
+    expect(parseFlagValue("--model", ["model"])).toBeUndefined();
+    expect(parseFlagValue("--model --effort high", ["model"])).toBeUndefined();
+  });
+
+  it("returns undefined when the flag is not present", () => {
+    expect(parseFlagValue("--effort high", ["model"])).toBeUndefined();
+  });
+
+  it("returns the value of the first matching flag", () => {
+    expect(
+      parseFlagValue("--reasoning-effort low --effort high", [
+        "effort",
+        "reasoning-effort",
+      ]),
+    ).toBe("low");
+  });
+
+  it("does not treat a following flag as the value", () => {
+    expect(parseFlagValue("--model --effort", ["model"])).toBeUndefined();
+  });
+});
+
+describe("resolveEffort", () => {
+  it("returns effort from --effort", () => {
+    expect(resolveEffort("--effort high")).toBe("high");
+  });
+
+  it("falls back to --reasoning-effort", () => {
+    expect(resolveEffort("--reasoning-effort xhigh")).toBe("xhigh");
+  });
+
+  it("returns undefined when no effort flag is present", () => {
+    expect(resolveEffort("--model claude-sonnet-4-6")).toBeUndefined();
+  });
+});
+
+describe("resolveModel", () => {
+  const original = process.env.ANTHROPIC_MODEL;
+  afterEach(() => {
+    if (original === undefined) delete process.env.ANTHROPIC_MODEL;
+    else process.env.ANTHROPIC_MODEL = original;
+  });
+
+  it("returns --model from claude_args when env is unset", () => {
+    delete process.env.ANTHROPIC_MODEL;
+    expect(resolveModel("--model claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
+  });
+
+  it("prefers ANTHROPIC_MODEL env over claude_args", () => {
+    process.env.ANTHROPIC_MODEL = "claude-opus-4-7";
+    expect(resolveModel("--model claude-sonnet-4-6")).toBe("claude-opus-4-7");
+  });
+
+  it("returns undefined when neither is set", () => {
+    delete process.env.ANTHROPIC_MODEL;
+    expect(resolveModel("")).toBeUndefined();
+  });
+});

--- a/test/comment-logic.test.ts
+++ b/test/comment-logic.test.ts
@@ -443,4 +443,46 @@ describe("updateCommentBody", () => {
       expect(result).not.toContain("tree/claude/issue-123");
     });
   });
+
+  describe("model and effort", () => {
+    it("renders the model/effort line when provided", () => {
+      const input = {
+        ...baseInput,
+        model: "claude-sonnet-4-6",
+        effort: "high",
+      };
+
+      const result = updateCommentBody(input);
+      expect(result).toContain(
+        "**Model:** claude-sonnet-4-6 · **Effort:** high",
+      );
+    });
+
+    it("omits the model/effort line when not provided", () => {
+      const result = updateCommentBody(baseInput);
+      expect(result).not.toContain("**Model:**");
+      expect(result).not.toContain("**Effort:**");
+    });
+
+    it("renders effort without model", () => {
+      const input = { ...baseInput, effort: "xhigh" };
+      const result = updateCommentBody(input);
+      expect(result).toContain("**Effort:** xhigh");
+      expect(result).not.toContain("**Model:**");
+    });
+
+    it("strips a carried-over model/effort line from the initial body", () => {
+      const line = "**Model:** claude-sonnet-4-6 · **Effort:** high";
+      const input = {
+        ...baseInput,
+        currentBody: `Claude Code is working…\n\n${line}\n\nI'll analyze this and get back to you.`,
+        model: "claude-sonnet-4-6",
+        effort: "high",
+      };
+
+      const result = updateCommentBody(input);
+      const occurrences = result.split(line).length - 1;
+      expect(occurrences).toBe(1);
+    });
+  });
 });

--- a/test/comments-common.test.ts
+++ b/test/comments-common.test.ts
@@ -4,6 +4,7 @@ import {
   createJobRunLink,
   createBranchLink,
   createCommentBody,
+  buildModelEffortLine,
 } from "../src/github/operations/comments/common";
 import { GITHUB_SERVER_URL } from "../src/github/api/config";
 
@@ -51,6 +52,25 @@ describe("comments/common", () => {
       expect(body).toContain(jobRunLink);
     });
 
+    test("includes model and effort when provided", () => {
+      const body = createCommentBody(
+        createJobRunLink("o", "r", "7"),
+        "",
+        "claude-sonnet-4-6",
+        "high",
+      );
+
+      expect(body).toContain(
+        "**Model:** claude-sonnet-4-6 · **Effort:** high",
+      );
+    });
+
+    test("omits model/effort fields when not provided", () => {
+      const body = createCommentBody(createJobRunLink("o", "r", "7"));
+      expect(body).not.toContain("**Model:**");
+      expect(body).not.toContain("**Effort:**");
+    });
+
     test("omits the branch link when none is provided (defaults to empty)", () => {
       const body = createCommentBody(createJobRunLink("o", "r", "7"));
       expect(body).not.toContain("View branch");
@@ -68,6 +88,29 @@ describe("comments/common", () => {
       // The branch link (with its leading newline) comes after the job run link.
       expect(body.indexOf(branchLink)).toBeGreaterThan(
         body.indexOf(jobRunLink),
+      );
+    });
+  });
+
+  describe("buildModelEffortLine", () => {
+    test("returns an empty string when neither value is set", () => {
+      expect(buildModelEffortLine()).toBe("");
+      expect(buildModelEffortLine(undefined, undefined)).toBe("");
+    });
+
+    test("shows only the model when effort is unset", () => {
+      expect(buildModelEffortLine("claude-sonnet-4-6")).toBe(
+        "**Model:** claude-sonnet-4-6",
+      );
+    });
+
+    test("shows only the effort when model is unset", () => {
+      expect(buildModelEffortLine(undefined, "high")).toBe("**Effort:** high");
+    });
+
+    test("joins model and effort with a separator", () => {
+      expect(buildModelEffortLine("claude-sonnet-4-6", "high")).toBe(
+        "**Model:** claude-sonnet-4-6 · **Effort:** high",
       );
     });
   });


### PR DESCRIPTION
  ## Summary

  This PR surfaces the **active model** and **reasoning-effort level** in the progress ("working") and completion ("finished") tracking comments that Claude Code posts to issues
  and pull requests. Previously these comments showed only a spinner, a canned message, and a job-run link; now they also report *which model is running* and *at what reasoning
  effort*.

  This resolves two related requests:

  - **Fixes #1555** — show the active model in progress comments
  - **Fixes #1556** — show the active effort level in progress comments

  ## What Changed

  - **`src/utils/claude-args.ts`** (new) — a small, dependency-free parser that extracts flag values from `claude_args`:
    - `parseFlagValue(args, flags)` — tokenizes the args (handling `--flag value`, `--flag=value`, and quoted values via `shell-quote`) and returns the first matching flag's
  value.
    - `resolveModel(claudeArgs)` — returns `ANTHROPIC_MODEL` when set, otherwise `--model` from `claude_args`. This mirrors the base action's own precedence (`options.model ||
  modelFromClaudeArgs`).
    - `resolveEffort(claudeArgs)` — returns `--effort` or `--reasoning-effort` from `claude_args`.

  - **`src/github/operations/comments/common.ts`** — added `buildModelEffortLine(model?, effort?)`, which renders a single `**Model:** … · **Effort:** …` line, omitting either
  field when it is unset. `createCommentBody` now accepts optional `model`/`effort` and prepends that line to the initial "Claude Code is working…" comment.

  - **`src/github/operations/comments/create-initial.ts`** — resolves model/effort from `CLAUDE_ARGS` and passes them into `createCommentBody`.

  - **`src/github/operations/comment-logic.ts`** — `CommentUpdateInput` gains optional `model`/`effort`; `updateCommentBody` renders the same line into the final "Claude
  finished…" comment and strips any model/effort line that was carried over from the initial body (so it never appears twice).

  - **`src/entrypoints/update-comment-link.ts`** — resolves model/effort from `CLAUDE_ARGS` and forwards them to `updateCommentBody`.

  ## Behavior

  | `claude_args` / env | Rendered |
  | --- | --- |
  | `--model claude-sonnet-4-6 --effort high` | `**Model:** claude-sonnet-4-6 · **Effort:** high` |
  | `ANTHROPIC_MODEL=claude-opus-4-7`, no effort flag | `**Model:** claude-opus-4-7` |
  | `--reasoning-effort xhigh` only | `**Effort:** xhigh` |
  | none set | *(line omitted entirely)* |

  Both fields are omitted rather than rendered empty, so existing users who don't pass model/effort see no change in comment format.

  ## Testing

  Added/updated unit tests under `test/`:

  - `test/claude-args.test.ts` — `parseFlagValue` (space/equals/quoted/no-value/missing), `resolveModel` (env precedence, `ANTHROPIC_MODEL` restore), `resolveEffort` (`--effort`
  vs `--reasoning-effort`).
  - `test/comments-common.test.ts` — `buildModelEffortLine` (empty / model-only / effort-only / joined) and `createCommentBody` with/without model-effort.
  - `test/comment-logic.test.ts` — rendering, omission, effort-only, and strip-of-carried-over-line (asserting exactly one occurrence).

  ```bash
  bun test
  bun run typecheck
  ```

  ## Notes

  - Runtime is Bun; the parser reuses the existing `shell-quote` dependency already in the tree, so no new deps are added.
  - `strict` TypeScript (`noUnusedLocals`/`noUnusedParameters`) and the repo's `moduleResolution: "bundler"` convention are respected.
  - This is comment-metadata only; it does not change model/effort selection or any execution behavior.