### PR TITLE
fix: resync collect-inputs map with action.yml and guard against drift

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -287,7 +287,6 @@ runs:
           run ${GITHUB_ACTION_PATH}/src/entrypoints/run.ts
       env:
         # Prepare inputs
-        MODE: ${{ inputs.mode }}
         PROMPT: ${{ inputs.prompt }}
         TRIGGER_PHRASE: ${{ inputs.trigger_phrase }}
         ASSIGNEE_TRIGGER: ${{ inputs.assignee_trigger }}

--- a/src/entrypoints/collect-inputs.ts
+++ b/src/entrypoints/collect-inputs.ts
@@ -1,38 +1,58 @@
-export function collectActionInputsPresence(): string {
-  const inputDefaults: Record<string, string> = {
-    trigger_phrase: "@claude",
-    assignee_trigger: "",
-    label_trigger: "claude",
-    base_branch: "",
-    branch_prefix: "claude/",
-    allowed_bots: "",
-    mode: "tag",
-    model: "",
-    anthropic_model: "",
-    fallback_model: "",
-    allowed_tools: "",
-    disallowed_tools: "",
-    custom_instructions: "",
-    direct_prompt: "",
-    override_prompt: "",
-    additional_permissions: "",
-    claude_env: "",
-    settings: "",
-    anthropic_api_key: "",
-    claude_code_oauth_token: "",
-    anthropic_federation_rule_id: "",
-    anthropic_organization_id: "",
-    anthropic_service_account_id: "",
-    anthropic_workspace_id: "",
-    anthropic_oidc_audience: "",
-    github_token: "",
-    max_turns: "",
-    use_sticky_comment: "false",
-    classify_inline_comments: "true",
-    use_commit_signing: "false",
-    ssh_signing_key: "",
-  };
+/**
+ * Declared defaults for every input in action.yml, in declaration order.
+ *
+ * Used to report which inputs a workflow actually set (see
+ * collectActionInputsPresence). An input is considered "set" when its value
+ * differs from the default declared here, so both the key set and the values
+ * must track action.yml — a default that drifts silently inverts the signal
+ * for that input.
+ *
+ * test/action-metadata.test.ts parses action.yml and asserts this map matches
+ * it exactly. Update both together.
+ */
+export const INPUT_DEFAULTS: Record<string, string> = {
+  trigger_phrase: "@claude",
+  assignee_trigger: "",
+  label_trigger: "claude",
+  base_branch: "",
+  branch_prefix: "claude/",
+  branch_name_template: "",
+  allowed_bots: "",
+  allowed_non_write_users: "",
+  include_comments_by_actor: "",
+  exclude_comments_by_actor: "",
+  prompt: "",
+  settings: "",
+  anthropic_api_key: "",
+  claude_code_oauth_token: "",
+  anthropic_federation_rule_id: "",
+  anthropic_organization_id: "",
+  anthropic_service_account_id: "",
+  anthropic_workspace_id: "",
+  anthropic_oidc_audience: "",
+  github_token: "",
+  use_bedrock: "false",
+  use_vertex: "false",
+  use_foundry: "false",
+  claude_args: "",
+  additional_permissions: "",
+  use_sticky_comment: "false",
+  classify_inline_comments: "true",
+  use_commit_signing: "false",
+  ssh_signing_key: "",
+  bot_id: "41898282",
+  bot_name: "claude[bot]",
+  track_progress: "false",
+  include_fix_links: "true",
+  path_to_claude_code_executable: "",
+  path_to_bun_executable: "",
+  display_report: "false",
+  show_full_output: "false",
+  plugins: "",
+  plugin_marketplaces: "",
+};
 
+export function collectActionInputsPresence(): string {
   const allInputsJson = process.env.ALL_INPUTS;
   if (!allInputsJson) {
     console.log("ALL_INPUTS environment variable not found");
@@ -49,7 +69,7 @@ export function collectActionInputsPresence(): string {
 
   const presentInputs: Record<string, boolean> = {};
 
-  for (const [name, defaultValue] of Object.entries(inputDefaults)) {
+  for (const [name, defaultValue] of Object.entries(INPUT_DEFAULTS)) {
     const actualValue = allInputs[name] || "";
 
     const isSet = actualValue !== defaultValue;

--- a/test/action-metadata.test.ts
+++ b/test/action-metadata.test.ts
@@ -1,15 +1,109 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, test } from "bun:test";
+import { INPUT_DEFAULTS } from "../src/entrypoints/collect-inputs";
+
+const metadata = readFileSync(
+  new URL("../action.yml", import.meta.url),
+  "utf8",
+);
+
+/**
+ * Extract the declared inputs and their defaults from action.yml.
+ *
+ * Parsed with regexes rather than a YAML library: the repo has no YAML
+ * dependency, the existing assertion below already matches against the raw
+ * text, and CI pins a Bun version that predates Bun.YAML.
+ *
+ * An input is a two-space-indented key inside the `inputs:` block; its default
+ * is the first four-space-indented `default:` that follows. Description bodies
+ * are indented deeper, so they cannot be mistaken for either.
+ */
+function parseDeclaredInputs(actionYml: string): Record<string, string> {
+  const start = actionYml.indexOf("\ninputs:");
+  const end = actionYml.indexOf("\noutputs:");
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error("Could not locate the inputs block in action.yml");
+  }
+
+  const declared: Record<string, string> = {};
+  let current: string | null = null;
+
+  for (const line of actionYml.slice(start, end).split("\n")) {
+    const nameMatch = line.match(/^ {2}([a-z_][a-z0-9_]*):\s*$/);
+    if (nameMatch?.[1]) {
+      current = nameMatch[1];
+      // Inputs with no `default:` are unset-by-default, which GitHub Actions
+      // renders as an empty string in toJson(inputs).
+      declared[current] = "";
+      continue;
+    }
+
+    const defaultMatch = line.match(/^ {4}default:\s*(.*)$/);
+    if (
+      defaultMatch?.[1] !== undefined &&
+      current &&
+      declared[current] === ""
+    ) {
+      declared[current] = parseScalar(defaultMatch[1]);
+    }
+  }
+
+  return declared;
+}
+
+/** Unquote a YAML scalar, stripping a trailing comment from unquoted values. */
+function parseScalar(raw: string): string {
+  const value = raw.trim();
+  if (value.startsWith('"')) {
+    return value.slice(1, value.lastIndexOf('"'));
+  }
+  if (value.startsWith("'")) {
+    return value.slice(1, value.lastIndexOf("'"));
+  }
+  return value.split("#")[0]!.trim();
+}
 
 describe("action metadata", () => {
   test("should expose the conclusion output from the run step", () => {
-    const metadata = readFileSync(
-      new URL("../action.yml", import.meta.url),
-      "utf8",
-    );
-
     expect(metadata).toMatch(
       /^  conclusion:\n    description: .+\n    value: \$\{\{ steps\.run\.outputs\.conclusion \}\}$/m,
     );
+  });
+});
+
+describe("action input drift", () => {
+  const declared = parseDeclaredInputs(metadata);
+
+  test("parses a plausible number of inputs from action.yml", () => {
+    // Guards the parser itself: a regex that silently stops matching would
+    // otherwise make every assertion below vacuously pass.
+    expect(Object.keys(declared).length).toBeGreaterThan(30);
+    expect(declared.prompt).toBe("");
+    expect(declared.trigger_phrase).toBe("@claude");
+    expect(declared.bot_id).toBe("41898282");
+  });
+
+  test("INPUT_DEFAULTS tracks every input declared in action.yml", () => {
+    const missing = Object.keys(declared).filter((n) => !(n in INPUT_DEFAULTS));
+    expect(missing).toEqual([]);
+  });
+
+  test("INPUT_DEFAULTS contains no inputs action.yml no longer declares", () => {
+    const stale = Object.keys(INPUT_DEFAULTS).filter((n) => !(n in declared));
+    expect(stale).toEqual([]);
+  });
+
+  test("INPUT_DEFAULTS values match the defaults declared in action.yml", () => {
+    // A drifted default silently inverts the presence signal for that input,
+    // so the values are asserted alongside the key set.
+    expect(INPUT_DEFAULTS).toEqual(declared);
+  });
+
+  test("every inputs.* expression in action.yml refers to a declared input", () => {
+    const referenced = new Set(
+      [...metadata.matchAll(/inputs\.([a-z_][a-z0-9_]*)/g)].map((m) => m[1]!),
+    );
+    const undeclared = [...referenced].filter((n) => !(n in declared)).sort();
+    expect(undeclared).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #1664.

The input map in `src/entrypoints/collect-inputs.ts` had drifted across the v1.0 migration — tracking 11 inputs that no longer exist and omitting 19 that do. Since its output becomes `GITHUB_ACTION_INPUTS`, the usage signal could not observe `prompt`, the input that selects agent mode over tag mode.

## Changes

**Resynced the map** with all 39 declared inputs and their declared defaults, in `action.yml` declaration order so the two can be diffed by eye. Removed: `mode`, `model`, `anthropic_model`, `fallback_model`, `allowed_tools`, `disallowed_tools`, `custom_instructions`, `direct_prompt`, `override_prompt`, `claude_env`, `max_turns`. Added: `prompt`, `claude_args`, `track_progress`, `plugins`, `plugin_marketplaces`, `use_bedrock`, `use_vertex`, `use_foundry`, `allowed_non_write_users`, `include_fix_links`, `branch_name_template`, `bot_id`, `bot_name`, `display_report`, `show_full_output`, `include_comments_by_actor`, `exclude_comments_by_actor`, `path_to_claude_code_executable`, `path_to_bun_executable`.

Defaults were extracted from `action.yml` programmatically rather than transcribed by hand.

**Promoted the map to an exported `INPUT_DEFAULTS`** so it can be asserted against. `collectActionInputsPresence` is otherwise untouched — the only change inside the function is the identifier.

**Removed `MODE: ${{ inputs.mode }}`** from `action.yml`. That input was dropped when mode detection became automatic; the expression resolved to the empty string and nothing reads `process.env.MODE`.

**Added drift guards** to `test/action-metadata.test.ts`:

| Guard | Catches |
|---|---|
| Every declared input appears in `INPUT_DEFAULTS` | A new input added to `action.yml` and not tracked |
| No entry in `INPUT_DEFAULTS` is undeclared | An input removed from `action.yml` and left behind |
| Values match `action.yml`'s defaults exactly | A drifted default, which silently inverts the presence signal |
| Every `inputs.*` expression refers to a declared input | Exactly what the stale `MODE` reference violated |
| The parser finds >30 inputs and spot-checks three | The parser itself breaking and making the rest vacuously pass |

## On the question I raised in the issue

I asked whether the guard should assert exact set equality or allow an opt-out list for deliberately-excluded inputs. I went with **exact equality**, because the existing map already tracked `anthropic_api_key` and `github_token` — so secrets were evidently intended to be in scope, and the signal is presence-only (a boolean), never a value. Easy to relax if you'd rather exclude some.

I also assert the **default values**, not just the key set. That wasn't in the issue, but a default drifting in `action.yml` without the map following would flip that input's reported presence, which seemed worth closing at the same time.

## Verification

- `bun test` — 925 pass, 0 fail
- `bun run typecheck` — clean
- `bun run format:check` — clean

The guards were mutation-tested rather than assumed:

| Mutation | Result |
|---|---|
| Removed `claude_args` from the map | 2 failed |
| Re-added stale `direct_prompt` key | 2 failed |
| Drifted `label_trigger` default to `"triage"` | 1 failed |
| Reintroduced `MODE: ${{ inputs.mode }}` | 1 failed |

## Notes for review

- **Parsed with regexes, not a YAML library.** The repo has no YAML dependency, the pre-existing assertion in this file already matches against raw text, and `ci.yml` pins Bun 1.2.12 — which predates `Bun.YAML`. Adding a parser dependency for one test seemed the worse trade; happy to switch if you'd prefer it.
- **No behavioural change** to `collectActionInputsPresence` beyond the map contents it iterates.
- Unrelated, so deliberately left out of this PR: `bun.lock` still records `shell-quote@^1.8.3` while `package.json` was bumped to `^1.8.4` in 5da4c76. Running `bun install` resyncs it. Happy to send that separately if it's not already known.
