### PR TITLE
perf(fetcher): hash changed-file SHAs in one batched git call

### DIFF
--- a/src/github/data/fetcher.ts
+++ b/src/github/data/fetcher.ts
@@ -377,6 +377,101 @@ export type GitHubFileWithSHA = GitHubFile & {
   sha: string;
 };
 
+/** Reported for files whose working-tree content could not be hashed. */
+const SHA_UNKNOWN = "unknown";
+/** Reported for files the PR deletes, which have no working-tree content. */
+const SHA_DELETED = "deleted";
+
+/**
+ * Hash every path in one `git hash-object --stdin-paths` call.
+ *
+ * Returns null if the batch did not produce exactly one SHA per input path.
+ * Two cases make that check load-bearing rather than defensive:
+ *
+ *   - git aborts the whole batch on the first unreadable path, emitting the
+ *     SHAs computed before it and then exiting non-zero. That partial result
+ *     must never be zipped back onto the input list.
+ *   - --stdin-paths is newline-delimited, so a path containing a newline is
+ *     read as two paths. If both happen to exist, git exits 0 and returns one
+ *     SHA too many — none of them the file's own. Only the count reveals it.
+ *
+ * Either way the caller falls back to hashing each path individually.
+ */
+function hashObjectBatch(paths: string[]): string[] | null {
+  try {
+    const stdout = execFileSync("git", ["hash-object", "--stdin-paths"], {
+      encoding: "utf-8",
+      input: `${paths.join("\n")}\n`,
+    });
+    const shas = stdout.split("\n").filter((line) => line.length > 0);
+    return shas.length === paths.length ? shas : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Hash a single path, preserving the per-file warning on failure. */
+function hashObjectSingle(path: string): string {
+  try {
+    // `--` keeps a path beginning with "-" from being parsed as an option.
+    return execFileSync("git", ["hash-object", "--", path], {
+      encoding: "utf-8",
+    }).trim();
+  } catch (error) {
+    console.warn(`Failed to compute SHA for ${path}:`, error);
+    return SHA_UNKNOWN;
+  }
+}
+
+/**
+ * Compute working-tree blob SHAs for a PR's changed files.
+ *
+ * Hashing is batched into a single git invocation rather than one process per
+ * file: the work itself is trivial, so process creation dominates, and a large
+ * PR would otherwise spawn hundreds of them serially.
+ *
+ * Deleted files never enter the batch — they have no working-tree content — so
+ * batch results are zipped back onto the hashable subset, not the full list.
+ * If the batch fails, every remaining file is hashed individually so that one
+ * unreadable path degrades only its own SHA rather than all of them.
+ */
+export function computeChangedFileSHAs(
+  changedFiles: GitHubFile[],
+): GitHubFileWithSHA[] {
+  const hashableIndices: number[] = [];
+  const filesWithSHA: GitHubFileWithSHA[] = changedFiles.map((file, index) => {
+    if (file.changeType === "DELETED") {
+      return { ...file, sha: SHA_DELETED };
+    }
+    hashableIndices.push(index);
+    return { ...file, sha: SHA_UNKNOWN };
+  });
+
+  if (hashableIndices.length === 0) {
+    return filesWithSHA;
+  }
+
+  const paths = hashableIndices.map((index) => changedFiles[index]!.path);
+  const shas = hashObjectBatch(paths);
+
+  if (shas) {
+    hashableIndices.forEach((fileIndex, batchIndex) => {
+      filesWithSHA[fileIndex]!.sha = shas[batchIndex]!;
+    });
+    return filesWithSHA;
+  }
+
+  console.warn(
+    "Batched git hash-object failed; falling back to hashing each file individually",
+  );
+  for (const fileIndex of hashableIndices) {
+    filesWithSHA[fileIndex]!.sha = hashObjectSingle(
+      changedFiles[fileIndex]!.path,
+    );
+  }
+  return filesWithSHA;
+}
+
 export type FetchDataResult = {
   contextData: GitHubPullRequest | GitHubIssue;
   comments: GitHubComment[];
@@ -479,33 +574,7 @@ export async function fetchGitHubData({
   // Compute SHAs for changed files
   let changedFilesWithSHA: GitHubFileWithSHA[] = [];
   if (isPR && changedFiles.length > 0) {
-    changedFilesWithSHA = changedFiles.map((file) => {
-      // Don't compute SHA for deleted files
-      if (file.changeType === "DELETED") {
-        return {
-          ...file,
-          sha: "deleted",
-        };
-      }
-
-      try {
-        // Use git hash-object to compute the SHA for the current file content
-        const sha = execFileSync("git", ["hash-object", file.path], {
-          encoding: "utf-8",
-        }).trim();
-        return {
-          ...file,
-          sha,
-        };
-      } catch (error) {
-        console.warn(`Failed to compute SHA for ${file.path}:`, error);
-        // Return original file without SHA if computation fails
-        return {
-          ...file,
-          sha: "unknown",
-        };
-      }
-    });
+    changedFilesWithSHA = computeChangedFileSHAs(changedFiles);
   }
 
   // Prepare all comments for image processing

--- a/test/compute-changed-file-shas.test.ts
+++ b/test/compute-changed-file-shas.test.ts
@@ -1,0 +1,250 @@
+#!/usr/bin/env bun
+
+/**
+ * Tests for computeChangedFileSHAs, which hashes a PR's changed files in a
+ * single batched `git hash-object --stdin-paths` call.
+ *
+ * These run against real git in a scratch repository rather than a mocked
+ * child_process. The behaviour under test *is* git's batch semantics — order
+ * preservation, and aborting the whole batch on the first unreadable path —
+ * so asserting against a mock would only re-state the assumptions the
+ * implementation already makes.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { computeChangedFileSHAs } from "../src/github/data/fetcher";
+import type { GitHubFile } from "../src/github/types";
+
+function file(path: string, changeType = "MODIFIED"): GitHubFile {
+  return { path, additions: 1, deletions: 0, changeType };
+}
+
+/** The SHA git reports for a path, computed independently of the batch path. */
+function expectedSHA(path: string): string {
+  return execFileSync("git", ["hash-object", "--", path], {
+    encoding: "utf-8",
+  }).trim();
+}
+
+let repoDir: string;
+let originalCwd: string;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  repoDir = mkdtempSync(join(tmpdir(), "hash-object-test-"));
+  execFileSync("git", ["init", "-q", repoDir]);
+  process.chdir(repoDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  rmSync(repoDir, { recursive: true, force: true });
+});
+
+function write(path: string, contents: string) {
+  const full = join(repoDir, path);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, contents);
+}
+
+describe("computeChangedFileSHAs", () => {
+  test("returns an empty list for no changed files", () => {
+    expect(computeChangedFileSHAs([])).toEqual([]);
+  });
+
+  test("hashes a single file", () => {
+    write("a.txt", "aaa\n");
+    const [result] = computeChangedFileSHAs([file("a.txt")]);
+    expect(result!.sha).toBe(expectedSHA("a.txt"));
+  });
+
+  test("preserves per-file ordering across the batch", () => {
+    write("a.txt", "aaa\n");
+    write("b.txt", "bbb\n");
+    write("c.txt", "ccc\n");
+
+    // Deliberately not in sorted order — a batch that returned SHAs in git's
+    // own order rather than input order would pass a sorted list by accident.
+    const results = computeChangedFileSHAs([
+      file("c.txt"),
+      file("a.txt"),
+      file("b.txt"),
+    ]);
+
+    expect(results.map((r) => r.path)).toEqual(["c.txt", "a.txt", "b.txt"]);
+    expect(results[0]!.sha).toBe(expectedSHA("c.txt"));
+    expect(results[1]!.sha).toBe(expectedSHA("a.txt"));
+    expect(results[2]!.sha).toBe(expectedSHA("b.txt"));
+  });
+
+  test("identical contents hash to the same SHA", () => {
+    write("a.txt", "same\n");
+    write("b.txt", "same\n");
+    const results = computeChangedFileSHAs([file("a.txt"), file("b.txt")]);
+    expect(results[0]!.sha).toBe(results[1]!.sha);
+  });
+
+  test("preserves the file's other fields", () => {
+    write("a.txt", "aaa\n");
+    const [result] = computeChangedFileSHAs([
+      { path: "a.txt", additions: 10, deletions: 3, changeType: "MODIFIED" },
+    ]);
+    expect(result).toEqual({
+      path: "a.txt",
+      additions: 10,
+      deletions: 3,
+      changeType: "MODIFIED",
+      sha: expectedSHA("a.txt"),
+    });
+  });
+
+  describe("deleted files", () => {
+    test("are reported as deleted without being hashed", () => {
+      // No file is written, so hashing would fail if it were attempted.
+      const [result] = computeChangedFileSHAs([file("gone.txt", "DELETED")]);
+      expect(result!.sha).toBe("deleted");
+    });
+
+    test("do not disturb the SHAs of surrounding files", () => {
+      // Regression guard for zipping batch output onto the full list rather
+      // than the hashable subset: a deleted file in the middle would shift
+      // every subsequent SHA by one.
+      write("a.txt", "aaa\n");
+      write("b.txt", "bbb\n");
+
+      const results = computeChangedFileSHAs([
+        file("a.txt"),
+        file("gone.txt", "DELETED"),
+        file("b.txt"),
+      ]);
+
+      expect(results[0]!.sha).toBe(expectedSHA("a.txt"));
+      expect(results[1]!.sha).toBe("deleted");
+      expect(results[2]!.sha).toBe(expectedSHA("b.txt"));
+    });
+
+    test("an all-deleted set needs no hashing at all", () => {
+      const results = computeChangedFileSHAs([
+        file("x.txt", "DELETED"),
+        file("y.txt", "DELETED"),
+      ]);
+      expect(results.map((r) => r.sha)).toEqual(["deleted", "deleted"]);
+    });
+  });
+
+  describe("failure isolation", () => {
+    test("one missing file does not degrade the others", () => {
+      // git aborts the whole batch on the first unreadable path, so without a
+      // per-file fallback every SHA here would come back "unknown".
+      write("a.txt", "aaa\n");
+      write("b.txt", "bbb\n");
+
+      const results = computeChangedFileSHAs([
+        file("a.txt"),
+        file("missing.txt"),
+        file("b.txt"),
+      ]);
+
+      expect(results[0]!.sha).toBe(expectedSHA("a.txt"));
+      expect(results[1]!.sha).toBe("unknown");
+      expect(results[2]!.sha).toBe(expectedSHA("b.txt"));
+    });
+
+    test("every file missing yields unknown for each", () => {
+      const results = computeChangedFileSHAs([
+        file("nope1.txt"),
+        file("nope2.txt"),
+      ]);
+      expect(results.map((r) => r.sha)).toEqual(["unknown", "unknown"]);
+    });
+
+    test("a directory path is reported unknown, not fatal", () => {
+      mkdirSync(join(repoDir, "adir"), { recursive: true });
+      write("a.txt", "aaa\n");
+
+      const results = computeChangedFileSHAs([file("adir"), file("a.txt")]);
+      expect(results[0]!.sha).toBe("unknown");
+      expect(results[1]!.sha).toBe(expectedSHA("a.txt"));
+    });
+  });
+
+  describe("awkward paths", () => {
+    test("a path beginning with a dash is hashed, not parsed as an option", () => {
+      write("-dash.txt", "dash\n");
+      const [result] = computeChangedFileSHAs([file("-dash.txt")]);
+      expect(result!.sha).toBe(expectedSHA("-dash.txt"));
+    });
+
+    test("a leading-dash path still works on the per-file fallback", () => {
+      // The missing file forces the fallback, which passes paths as arguments.
+      write("-dash.txt", "dash\n");
+      const results = computeChangedFileSHAs([
+        file("-dash.txt"),
+        file("missing.txt"),
+      ]);
+      expect(results[0]!.sha).toBe(expectedSHA("-dash.txt"));
+      expect(results[1]!.sha).toBe("unknown");
+    });
+
+    test("paths with spaces are hashed correctly", () => {
+      write("sp ace.txt", "space\n");
+      const [result] = computeChangedFileSHAs([file("sp ace.txt")]);
+      expect(result!.sha).toBe(expectedSHA("sp ace.txt"));
+    });
+
+    test("nested paths are hashed correctly", () => {
+      write("src/nested/deep.txt", "deep\n");
+      const [result] = computeChangedFileSHAs([file("src/nested/deep.txt")]);
+      expect(result!.sha).toBe(expectedSHA("src/nested/deep.txt"));
+    });
+
+    test("a path containing a newline is hashed correctly", () => {
+      // --stdin-paths is newline-delimited, so such a path is read as two.
+      // Both halves are missing here, so the batch aborts and the fallback
+      // hashes the real file.
+      const weird = "new\nline.txt";
+      write(weird, "weird\n");
+
+      const [result] = computeChangedFileSHAs([file(weird)]);
+      expect(result!.sha).toBe(expectedSHA(weird));
+    });
+
+    test("a newline path whose halves both exist is not silently mis-hashed", () => {
+      // The dangerous case: git splits "a\nb.txt" into "a" and "b.txt", finds
+      // both, exits 0, and returns two SHAs for one requested path — neither
+      // belonging to the real file. Only the one-SHA-per-path count check
+      // catches this; without it the file silently gets the SHA of "a".
+      write("a", "AAA\n");
+      write("b.txt", "BBB\n");
+      const weird = "a\nb.txt";
+      write(weird, "WEIRD\n");
+
+      const [result] = computeChangedFileSHAs([file(weird)]);
+
+      expect(result!.sha).toBe(expectedSHA(weird));
+      expect(result!.sha).not.toBe(expectedSHA("a"));
+      expect(result!.sha).not.toBe(expectedSHA("b.txt"));
+    });
+  });
+
+  test("handles a large batch in one pass", () => {
+    const files: GitHubFile[] = [];
+    for (let i = 0; i < 200; i++) {
+      write(`f${i}.txt`, `contents ${i}\n`);
+      files.push(file(`f${i}.txt`));
+    }
+
+    const results = computeChangedFileSHAs(files);
+    expect(results).toHaveLength(200);
+    expect(results.every((r) => /^[0-9a-f]{40}$/.test(r.sha))).toBe(true);
+    expect(results[0]!.sha).toBe(expectedSHA("f0.txt"));
+    expect(results[199]!.sha).toBe(expectedSHA("f199.txt"));
+    // Distinct contents must produce distinct SHAs — a batch that repeated one
+    // line, or zipped incorrectly, would collapse them.
+    expect(new Set(results.map((r) => r.sha)).size).toBe(200);
+  });
+});


### PR DESCRIPTION
Fixes #1666.

`fetchGitHubData` spawned a separate synchronous `git hash-object` process for every changed file. Hashing is trivial, so process creation dominated and the cost grew linearly with PR size — paid on every tag-mode invocation against a PR, before Claude starts.

This extracts the loop into an exported `computeChangedFileSHAs` and batches it into a single `git hash-object --stdin-paths` call.

## Measured

400 files, scratch repo, macOS:

| | Time |
|---|---|
| Per-file (400 spawns) | 2385 ms |
| Batched (1 spawn) | 26 ms |

Linux runners fork faster than macOS, so the absolute numbers on GitHub-hosted runners will be lower — but the shape holds, since it is spawn count that is being removed.

I've dropped the "blocks the event loop" framing from the issue. `fetchGitHubData` is awaited with nothing running concurrently, so blocking wasn't causing observable harm; the real cost was the spawns. The batched call is still synchronous, which keeps this diff to one function. Converting to `execFile` + `await` would be an easy follow-up if you'd prefer it.

## Behaviour preserved deliberately

**Deleted files never enter the batch** — they have no working-tree content. Batch output is zipped back onto the hashable subset, not the full list, so a deleted file in the middle can't shift the SHAs of everything after it. There's a regression test for exactly that offset.

**Failure stays isolated.** git aborts the whole batch on the first unreadable path — emitting the SHAs computed before it, then exiting 128. A failed batch falls back to hashing each file individually, so one bad path degrades only its own SHA, as before. That fallback also means the behaviour reported in #979, #730 and #239 is unchanged: those cases fail the batch and land on the same per-file path that runs today.

The one cost is that a fully-failing batch now spends 1 extra spawn before falling back.

## The count check is load-bearing, not defensive

`hashObjectBatch` accepts a result only when it contains exactly one SHA per input path. I originally wrote a separate guard that skipped batching for paths containing newlines, then mutation-tested it and found the guard was redundant while the count check was doing the real work — so I removed the guard.

The case that makes it matter: `--stdin-paths` is newline-delimited, so a path like `a\nb.txt` is read as two paths. If files `a` and `b.txt` both exist, **git exits 0** and returns two SHAs for one requested path — neither belonging to the real file:

```console
$ printf 'a\nb.txt\n' | git hash-object --stdin-paths
43d5a8ed6ef6c00ff775008633f95787d088285d   # SHA of "a"
ba629238ca89489f2b350e196ca445e09d8bb834   # SHA of "b.txt"
$ git hash-object -- $'a\nb.txt'
1b71afdde058de1a5f749c4903adb6415d89c2dc   # the actual file
```

Nothing errors. Without the count check the file silently gets the SHA of `a`. There's a test for it.

## Also fixed

`--` added to the single-file call, so a path beginning with `-` isn't parsed as an option (`git hash-object "-dash.txt"` → ``error: unknown switch `d'``). The batch path is immune by construction, since paths arrive on stdin rather than as arguments.

## Tests

`test/compute-changed-file-shas.test.ts` — 18 tests against **real git** in a scratch repository rather than a mocked `child_process`. The behaviour under test *is* git's batch semantics, so asserting against a mock would only restate the implementation's own assumptions.

Covers ordering (with deliberately unsorted input), the deleted-file offset, all-deleted sets, per-file failure isolation, directories, leading-dash and spaced and nested paths, the newline collision above, and a 200-file batch asserting 200 distinct SHAs.

Mutation-tested:

| Mutation | Result |
|---|---|
| Remove the count check | 1 failed |
| Remove the per-file fallback | 5 failed |
| Zip batch output onto the full list | 1 failed |
| Drop `--` from the single-file call | 1 failed |

## Verification

- `bun test` — 938 pass, 0 fail (existing `data-fetcher.test.ts`: 94 pass, unchanged)
- `bun run typecheck` — clean
- `bun run format:check` — clean
