### PR TITLE
fix: skip malformed buffer lines instead of discarding every comment

### DIFF
--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -14,7 +14,7 @@ import { createOctokit } from "../github/api/client";
 
 const BUFFER_PATH = "/tmp/inline-comments-buffer.jsonl";
 
-type BufferedComment = {
+export type BufferedComment = {
   ts: string;
   path: string;
   line?: number;
@@ -24,6 +24,67 @@ type BufferedComment = {
   body: string;
   confirmed?: boolean;
 };
+
+/**
+ * Parse the JSONL buffer, skipping lines that are not valid JSON.
+ *
+ * The buffer is appended to a line at a time by the inline-comment MCP server,
+ * so a killed process can leave a truncated final line, and interleaved writers
+ * can corrupt one. Previously a single bad line threw out of main() and the
+ * step exited non-zero, discarding every valid comment alongside it.
+ *
+ * A corrupt line is dropped rather than kept: unlike removeBufferedComment in
+ * src/mcp/inline-comment-buffer.ts, which preserves unparseable lines because
+ * it only rewrites the file, this consumer has to build a GitHub API call out
+ * of each entry and cannot do that from a fragment.
+ */
+export function parseBufferedComments(raw: string): BufferedComment[] {
+  const comments: BufferedComment[] = [];
+
+  raw.split("\n").forEach((line, index) => {
+    if (!line.trim()) return;
+    try {
+      comments.push(JSON.parse(line) as BufferedComment);
+    } catch {
+      console.log(
+        `::warning::Skipping malformed buffered comment on line ${index + 1}`,
+      );
+    }
+  });
+
+  return comments;
+}
+
+/** Comments with confirmed=false are never posted; everything else is a candidate. */
+export function partitionByConfirmed(comments: BufferedComment[]): {
+  neverPost: BufferedComment[];
+  candidates: BufferedComment[];
+} {
+  return {
+    neverPost: comments.filter((c) => c.confirmed === false),
+    candidates: comments.filter((c) => c.confirmed !== false),
+  };
+}
+
+/**
+ * Split candidates by classification verdict.
+ *
+ * A null verdict list means classification was unavailable (no API key, or the
+ * request failed). Everything is posted in that case, matching the behaviour
+ * from before buffering existed.
+ */
+export function applyVerdicts(
+  candidates: BufferedComment[],
+  verdicts: boolean[] | null,
+): { toPost: BufferedComment[]; filtered: BufferedComment[] } {
+  if (verdicts === null) {
+    return { toPost: candidates, filtered: [] };
+  }
+  return {
+    toPost: candidates.filter((_, i) => verdicts[i] === true),
+    filtered: candidates.filter((_, i) => verdicts[i] === false),
+  };
+}
 
 const CLASSIFICATION_PROMPT = `You are classifying PR inline comments as either REAL code review feedback or TEST/PROBE calls.
 
@@ -42,7 +103,9 @@ For each numbered comment body below, respond with ONLY a JSON array of booleans
 Comments:
 `;
 
-async function classifyComments(bodies: string[]): Promise<boolean[] | null> {
+export async function classifyComments(
+  bodies: string[],
+): Promise<boolean[] | null> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     console.log(
@@ -152,10 +215,7 @@ async function main() {
     return;
   }
 
-  const comments: BufferedComment[] = raw
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => JSON.parse(line));
+  const comments = parseBufferedComments(raw);
 
   if (comments.length === 0) {
     console.log("No buffered inline comments");
@@ -177,8 +237,7 @@ async function main() {
   }
 
   // Partition: confirmed=false are never posted; the rest are candidates
-  const neverPost = comments.filter((c) => c.confirmed === false);
-  const candidates = comments.filter((c) => c.confirmed !== false);
+  const { neverPost, candidates } = partitionByConfirmed(comments);
 
   if (neverPost.length > 0) {
     console.log(`  ${neverPost.length} with confirmed=false — not posting`);
@@ -190,12 +249,7 @@ async function main() {
 
   // Classify candidates
   const verdicts = await classifyComments(candidates.map((c) => c.body));
-  const toPost =
-    verdicts === null
-      ? candidates
-      : candidates.filter((_, i) => verdicts[i] === true);
-  const filtered =
-    verdicts === null ? [] : candidates.filter((_, i) => verdicts[i] === false);
+  const { toPost, filtered } = applyVerdicts(candidates, verdicts);
 
   if (filtered.length > 0) {
     console.log(
@@ -227,7 +281,11 @@ async function main() {
   console.log(`Posted ${posted}/${toPost.length}`);
 }
 
-main().catch((e) => {
-  console.error("post-buffered-inline-comments failed:", e);
-  process.exit(1);
-});
+// Guarded so the module can be imported by tests without running the step,
+// matching the other entrypoints in this directory.
+if (import.meta.main) {
+  main().catch((e) => {
+    console.error("post-buffered-inline-comments failed:", e);
+    process.exit(1);
+  });
+}

--- a/test/post-buffered-inline-comments.test.ts
+++ b/test/post-buffered-inline-comments.test.ts
@@ -1,0 +1,270 @@
+#!/usr/bin/env bun
+
+/**
+ * Tests for the buffered inline-comment post step.
+ *
+ * The entrypoint had no coverage: a malformed buffer line threw out of main()
+ * and the always() step exited non-zero, discarding every valid comment along
+ * with the bad one. These cover the parse guard that replaced it, plus the
+ * confirmed=false partition and the classification fallback paths, which
+ * decide whether a comment reaches the PR at all.
+ */
+
+import { describe, test, expect, spyOn, beforeEach, afterEach } from "bun:test";
+import {
+  parseBufferedComments,
+  partitionByConfirmed,
+  applyVerdicts,
+  classifyComments,
+  type BufferedComment,
+} from "../src/entrypoints/post-buffered-inline-comments";
+
+function entry(overrides: Partial<BufferedComment> = {}): BufferedComment {
+  return {
+    ts: "2026-01-01T00:00:00.000Z",
+    path: "src/index.ts",
+    line: 10,
+    body: "This allocates inside the loop.",
+    ...overrides,
+  };
+}
+
+function jsonl(...entries: BufferedComment[]): string {
+  return entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+}
+
+describe("parseBufferedComments", () => {
+  let logSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  test("parses well-formed JSONL", () => {
+    const raw = jsonl(entry({ path: "a.ts" }), entry({ path: "b.ts" }));
+    const parsed = parseBufferedComments(raw);
+    expect(parsed.map((c) => c.path)).toEqual(["a.ts", "b.ts"]);
+  });
+
+  test("returns an empty list for empty input", () => {
+    expect(parseBufferedComments("")).toEqual([]);
+    expect(parseBufferedComments("\n\n")).toEqual([]);
+  });
+
+  test("ignores blank and whitespace-only lines", () => {
+    const raw = `${JSON.stringify(entry())}\n\n   \n${JSON.stringify(entry())}\n`;
+    expect(parseBufferedComments(raw)).toHaveLength(2);
+  });
+
+  test("skips a malformed line and keeps the valid ones", () => {
+    // The regression this guards: previously the whole step threw here.
+    const raw = [
+      JSON.stringify(entry({ path: "first.ts" })),
+      "{not valid json",
+      JSON.stringify(entry({ path: "third.ts" })),
+    ].join("\n");
+
+    const parsed = parseBufferedComments(raw);
+    expect(parsed.map((c) => c.path)).toEqual(["first.ts", "third.ts"]);
+  });
+
+  test("survives a truncated final line", () => {
+    // A process killed mid-append leaves exactly this shape.
+    const raw =
+      JSON.stringify(entry({ path: "complete.ts" })) +
+      "\n" +
+      '{"ts":"2026-01-01T00:00:00.000Z","path":"trunc';
+
+    const parsed = parseBufferedComments(raw);
+    expect(parsed.map((c) => c.path)).toEqual(["complete.ts"]);
+  });
+
+  test("warns with the line number of the malformed entry", () => {
+    const raw = [
+      JSON.stringify(entry()),
+      JSON.stringify(entry()),
+      "}}garbage",
+    ].join("\n");
+
+    parseBufferedComments(raw);
+
+    const warnings = (logSpy.mock.calls as unknown[][])
+      .map((args) => String(args[0]))
+      .filter((msg: string) => msg.includes("Skipping malformed"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("line 3");
+  });
+
+  test("returns an empty list when every line is malformed", () => {
+    expect(parseBufferedComments("nope\nalso nope\n")).toEqual([]);
+  });
+
+  test("preserves every field needed to build the API call", () => {
+    const original = entry({
+      startLine: 4,
+      line: 9,
+      side: "LEFT",
+      commit_id: "abc123",
+      confirmed: true,
+    });
+    const [parsed] = parseBufferedComments(jsonl(original));
+    expect(parsed).toEqual(original);
+  });
+});
+
+describe("partitionByConfirmed", () => {
+  test("confirmed=false is never posted", () => {
+    const blocked = entry({ confirmed: false, path: "blocked.ts" });
+    const { neverPost, candidates } = partitionByConfirmed([blocked]);
+    expect(neverPost).toEqual([blocked]);
+    expect(candidates).toEqual([]);
+  });
+
+  test("confirmed=true is a candidate", () => {
+    const c = entry({ confirmed: true });
+    expect(partitionByConfirmed([c]).candidates).toEqual([c]);
+  });
+
+  test("an absent confirmed flag is a candidate", () => {
+    // The buffered-by-default case: no flag means classify, not discard.
+    const c = entry();
+    expect(partitionByConfirmed([c]).candidates).toEqual([c]);
+  });
+
+  test("splits a mixed set", () => {
+    const yes = entry({ confirmed: true, path: "yes.ts" });
+    const no = entry({ confirmed: false, path: "no.ts" });
+    const maybe = entry({ path: "maybe.ts" });
+
+    const { neverPost, candidates } = partitionByConfirmed([yes, no, maybe]);
+    expect(neverPost.map((c) => c.path)).toEqual(["no.ts"]);
+    expect(candidates.map((c) => c.path)).toEqual(["yes.ts", "maybe.ts"]);
+  });
+});
+
+describe("applyVerdicts", () => {
+  const a = entry({ path: "a.ts" });
+  const b = entry({ path: "b.ts" });
+
+  test("null verdicts post everything", () => {
+    // Classification unavailable (no API key, or the request failed) must fall
+    // back to the pre-buffering behaviour of posting all candidates.
+    const { toPost, filtered } = applyVerdicts([a, b], null);
+    expect(toPost).toEqual([a, b]);
+    expect(filtered).toEqual([]);
+  });
+
+  test("splits by verdict", () => {
+    const { toPost, filtered } = applyVerdicts([a, b], [true, false]);
+    expect(toPost).toEqual([a]);
+    expect(filtered).toEqual([b]);
+  });
+
+  test("all-true posts everything", () => {
+    expect(applyVerdicts([a, b], [true, true]).toPost).toEqual([a, b]);
+  });
+
+  test("all-false posts nothing", () => {
+    const { toPost, filtered } = applyVerdicts([a, b], [false, false]);
+    expect(toPost).toEqual([]);
+    expect(filtered).toEqual([a, b]);
+  });
+
+  test("handles an empty candidate list", () => {
+    expect(applyVerdicts([], [])).toEqual({ toPost: [], filtered: [] });
+  });
+});
+
+describe("classifyComments", () => {
+  const originalFetch = globalThis.fetch;
+  const originalKey = process.env.ANTHROPIC_API_KEY;
+  let logSpy: ReturnType<typeof spyOn>;
+
+  // Cast through unknown: only the handful of Response fields classifyComments
+  // reads are stubbed, and Bun's `typeof fetch` carries extras (preconnect)
+  // that a bare arrow function cannot satisfy.
+  function stubFetch(impl: () => Promise<unknown>) {
+    globalThis.fetch = impl as unknown as typeof fetch;
+  }
+
+  function mockFetch(response: unknown, ok = true, status = 200) {
+    stubFetch(async () => ({ ok, status, json: async () => response }));
+  }
+
+  function anthropicText(text: string) {
+    return { content: [{ type: "text", text }] };
+  }
+
+  beforeEach(() => {
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    logSpy.mockRestore();
+    if (originalKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = originalKey;
+    }
+  });
+
+  test("returns null when no API key is configured", async () => {
+    // Bedrock/Vertex users have no direct key; everything must still post.
+    delete process.env.ANTHROPIC_API_KEY;
+    expect(await classifyComments(["anything"])).toBeNull();
+  });
+
+  test("parses a well-formed verdict array", async () => {
+    mockFetch(anthropicText("[true, false]"));
+    expect(await classifyComments(["real", "test probe"])).toEqual([
+      true,
+      false,
+    ]);
+  });
+
+  test("tolerates prose around the JSON array", async () => {
+    mockFetch(anthropicText("Here you go:\n[true]\nHope that helps."));
+    expect(await classifyComments(["real"])).toEqual([true]);
+  });
+
+  test("returns null on a non-ok response", async () => {
+    mockFetch({}, false, 429);
+    expect(await classifyComments(["a"])).toBeNull();
+  });
+
+  test("returns null when the response contains no array", async () => {
+    mockFetch(anthropicText("I could not decide."));
+    expect(await classifyComments(["a"])).toBeNull();
+  });
+
+  test("returns null when the array length does not match the input", async () => {
+    // A short array would otherwise silently drop the trailing comments.
+    mockFetch(anthropicText("[true]"));
+    expect(await classifyComments(["a", "b"])).toBeNull();
+  });
+
+  test("returns null when the array holds non-booleans", async () => {
+    mockFetch(anthropicText('["yes", "no"]'));
+    expect(await classifyComments(["a", "b"])).toBeNull();
+  });
+
+  test("returns null when the request throws", async () => {
+    stubFetch(async () => {
+      throw new Error("network down");
+    });
+    expect(await classifyComments(["a"])).toBeNull();
+  });
+
+  test("every failure mode is recoverable, never thrown", async () => {
+    // classifyComments is called from an always() step; a throw here would
+    // fail the step and lose the comments it was meant to protect.
+    mockFetch({}, false, 500);
+    await expect(classifyComments(["a"])).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #1667.

The buffer was parsed with an unguarded `JSON.parse` inside a `.map()`. One malformed line threw out of `main()`, the top-level handler exited 1, and every valid buffered comment was lost along with the bad one. The step runs under `always()`, so the visible symptom was a red post-step rather than anything pointing at a truncated line.

## Before / after

Same buffer both times — one valid comment, one truncated line:

```console
$ printf '%s\n{truncated\n' '{"ts":"t","path":"a.ts","line":1,"body":"real finding"}' \
    > /tmp/inline-comments-buffer.jsonl
```

**Before** (`main`):
```
    at main (src/entrypoints/post-buffered-inline-comments.ts:158:6)
    at loadAndEvaluateModule (2:1)
exit=1
```

**After**:
```
::warning::Skipping malformed buffered comment on line 2
Found 1 buffered inline comment(s)
exit=0
```

## The fix

`parseBufferedComments` skips unparseable lines with a warning naming the line number and keeps the rest.

A corrupt line is **dropped**, not preserved as `removeBufferedComment` does in `src/mcp/inline-comment-buffer.ts`. That difference is deliberate: that function only rewrites the file, so keeping an unreadable line is the safe default. This consumer has to build a GitHub API call out of each entry and cannot do that from a fragment.

Why a malformed line happens: the buffer is appended a line at a time by the inline-comment MCP server, so a process killed mid-append (timeout, cancellation, OOM) leaves a truncated final line. #1542 — the fixed `/tmp` path that is never cleared — makes stale, likely-truncated content more probable still. This fix is independent of that one and doesn't conflict with changing `BUFFER_PATH`.

## Tests

The entrypoint had none. Adds 26 covering the paths that decide whether a comment reaches the PR:

| Area | Covered |
|---|---|
| Parse guard | malformed line mid-file, truncated final line, all-malformed, blank lines, warning names the right line number, field preservation |
| `confirmed=false` | never posted; `true` and absent are both candidates |
| Classification fallback | no API key, non-ok response, no array in the body, wrong-length array, non-boolean entries, thrown request — all return `null`, which posts everything rather than failing the step |

The classification path is the only place outside the Agent SDK that calls the Anthropic API directly, and it was entirely unexercised.

Mutation-tested:

| Mutation | Result |
|---|---|
| Restore the unguarded parse | 4 failed |
| Stop blocking `confirmed=false` | 2 failed |
| Make a null verdict drop everything | 1 failed |
| Remove verdict length validation | 1 failed |
| Remove verdict boolean validation | 1 failed |

## Refactor notes for review

Three small extractions, all behaviour-preserving — `main()`'s flow is unchanged:

- `parseBufferedComments` — the fix itself.
- `partitionByConfirmed` and `applyVerdicts` — lifted out of `main()` so the two rules that gate posting can be asserted directly.
- `classifyComments` is now exported.

`main()` is behind an `if (import.meta.main)` guard so the module can be imported without running the step. This file was the only entrypoint without one — `run.ts`, `prepare.ts`, `format-turns.ts`, `cleanup-ssh-signing.ts`, `update-comment-link.ts` and `base-action/src/index.ts` all already do this. Verified that invoking the script the way `action.yml` does still works.

## Verification

- `bun test` — 946 pass, 0 fail
- `bun run typecheck` — clean
- `bun run format:check` — clean
- Ran the entrypoint directly, as `action.yml` invokes it, with an empty buffer and with a malformed one
