### PR TITLE
docs: reference claude_args instead of the removed allowed_tools input

### DIFF
--- a/docs/capabilities-and-limitations.md
+++ b/docs/capabilities-and-limitations.md
@@ -19,7 +19,7 @@
 - **Approve PRs**: For security reasons, Claude cannot approve pull requests
 - **Post Multiple Comments**: Claude only acts by updating its initial comment
 - **Execute Commands Outside Its Context**: Claude only has access to the repository and PR/issue context it's triggered in
-- **Run Arbitrary Bash Commands**: By default, Claude cannot execute Bash commands unless explicitly allowed using the `allowed_tools` configuration
+- **Run Arbitrary Bash Commands**: By default, Claude cannot execute Bash commands unless explicitly allowed via `claude_args` with `--allowedTools`
 - **Perform Branch Operations**: Cannot merge branches, rebase, or perform other git operations beyond pushing commits
 
 ## How It Works

--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -125,9 +125,10 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     isIssueCommentEvent(context) ||
     isPullRequestReviewCommentEvent(context)
   ) {
-    const commentBody = isIssueCommentEvent(context)
-      ? context.payload.comment.body
-      : context.payload.comment.body;
+    // Both IssueCommentEvent and PullRequestReviewCommentEvent expose
+    // payload.comment.body, and the enclosing guard has already narrowed the
+    // union to those two.
+    const commentBody = context.payload.comment.body;
     // Check for exact match with word boundaries or punctuation
     const regex = new RegExp(
       `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,


### PR DESCRIPTION
Fixes #1670.

## Docs

`docs/capabilities-and-limitations.md` told users to configure tool access with the `allowed_tools` input, which v1.0 removed:

```diff
-- **Run Arbitrary Bash Commands**: … unless explicitly allowed using the `allowed_tools` configuration
+- **Run Arbitrary Bash Commands**: … unless explicitly allowed via `claude_args` with `--allowedTools`
```

`allowed_tools` appears elsewhere in `docs/` — `usage.md:106`, `configuration.md:342` — but always inside a deprecation table, which is correct and left alone. This file was the only place still phrasing it as live guidance, and it's linked from the README as "What Claude can and cannot do", so it's among the first pages a new user reads.

I checked the rest of that file for other removed v0.x inputs (`disallowed_tools`, `custom_instructions`, `direct_prompt`, `override_prompt`, `max_turns`, `claude_env`, `anthropic_model`, `fallback_model`, `mode`) — this was the only one.

## Cleanup

`src/github/validation/trigger.ts` had a ternary whose branches were identical:

```diff
-    const commentBody = isIssueCommentEvent(context)
-      ? context.payload.comment.body
-      : context.payload.comment.body;
+    const commentBody = context.payload.comment.body;
```

Both `IssueCommentEvent` and `PullRequestReviewCommentEvent` expose `payload.comment.body`, and the enclosing `if` has already narrowed the union to those two, so the access needs no discrimination. `bun run typecheck` passing is what confirms the narrowing holds without it. `isIssueCommentEvent` is still used by that guard, so the import stays.

#1670 offered to drop this half if you'd rather keep docs and source changes separate — still happy to.

## Verification

- `bun test` — 920 pass, 0 fail
- `bun run typecheck` — clean
- `bun run format:check` — clean

## Note on overlap

#1676 also touches `src/github/validation/trigger.ts`, removing the unused `checkTriggerAction` and its `@actions/core` import at the top and bottom of the file. This change is in the middle, so the two do not overlap and should merge in either order — flagging it only so it isn't a surprise.
