### PR TITLE
fix buffered inline comment delivery failures

### DIFF
--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -10,11 +10,12 @@
  * calls posted immediately.
  */
 import { readFileSync } from "fs";
+import * as core from "@actions/core";
 import { createOctokit } from "../github/api/client";
 
 const BUFFER_PATH = "/tmp/inline-comments-buffer.jsonl";
 
-type BufferedComment = {
+export type BufferedComment = {
   ts: string;
   path: string;
   line?: number;
@@ -41,6 +42,42 @@ For each numbered comment body below, respond with ONLY a JSON array of booleans
 
 Comments:
 `;
+
+export function formatErrorDetails(e: unknown): string {
+  try {
+    if (e && typeof e === "object") {
+      const err = e as {
+        message?: string;
+        status?: number;
+        response?: { status?: number; data?: unknown };
+      };
+      const status = err.response?.status ?? err.status;
+      const data = err.response?.data;
+      const msg = err.message || String(e);
+      let details = msg;
+      if (status !== undefined) {
+        details += ` (status ${status})`;
+      }
+      if (data !== undefined) {
+        let dataStr: string;
+        if (typeof data === "string") {
+          dataStr = data;
+        } else {
+          try {
+            dataStr = JSON.stringify(data);
+          } catch {
+            dataStr = String(data);
+          }
+        }
+        details += `: ${dataStr}`;
+      }
+      return details;
+    }
+    return e instanceof Error ? e.message : String(e);
+  } catch {
+    return String(e);
+  }
+}
 
 async function classifyComments(bodies: string[]): Promise<boolean[] | null> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
@@ -108,7 +145,7 @@ async function classifyComments(bodies: string[]): Promise<boolean[] | null> {
   }
 }
 
-async function postComment(
+export async function postComment(
   octokit: ReturnType<typeof createOctokit>["rest"],
   owner: string,
   repo: string,
@@ -136,11 +173,54 @@ async function postComment(
     await octokit.rest.pulls.createReviewComment(params);
     return true;
   } catch (e) {
-    console.log(
-      `  failed ${c.path}:${c.line}: ${e instanceof Error ? e.message : String(e)}`,
-    );
+    const errorDetails = formatErrorDetails(e);
+    core.error(`Failed to post ${c.path}:${c.line}: ${errorDetails}`);
+    console.log(`  dropped comment body: ${JSON.stringify(c.body)}`);
     return false;
   }
+}
+
+type PostCommentsResult = {
+  posted: number;
+  failed: number;
+  total: number;
+};
+
+export async function postComments(
+  octokit: ReturnType<typeof createOctokit>["rest"],
+  owner: string,
+  repo: string,
+  pull_number: number,
+  headSha: string,
+  comments: BufferedComment[],
+): Promise<PostCommentsResult> {
+  if (comments.length === 0) {
+    return { posted: 0, failed: 0, total: 0 };
+  }
+
+  let posted = 0;
+  let failed = 0;
+
+  for (const c of comments) {
+    if (await postComment(octokit, owner, repo, pull_number, headSha, c)) {
+      console.log(`  posted ${c.path}:${c.line}`);
+      posted++;
+    } else {
+      failed++;
+    }
+  }
+
+  console.log(`Posted ${posted}/${comments.length}`);
+
+  if (failed > 0) {
+    const summary = `Failed to post ${failed}/${comments.length} inline comment(s)`;
+    core.error(summary);
+    if (posted === 0) {
+      throw new Error(summary);
+    }
+  }
+
+  return { posted, failed, total: comments.length };
 }
 
 async function main() {
@@ -217,17 +297,12 @@ async function main() {
   const headSha = pr.data.head.sha;
 
   console.log(`Posting ${toPost.length} classified-as-real comment(s)`);
-  let posted = 0;
-  for (const c of toPost) {
-    if (await postComment(octokit, owner, repo, pull_number, headSha, c)) {
-      console.log(`  posted ${c.path}:${c.line}`);
-      posted++;
-    }
-  }
-  console.log(`Posted ${posted}/${toPost.length}`);
+  await postComments(octokit, owner, repo, pull_number, headSha, toPost);
 }
 
-main().catch((e) => {
-  console.error("post-buffered-inline-comments failed:", e);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((e) => {
+    console.error("post-buffered-inline-comments failed:", e);
+    process.exit(1);
+  });
+}

--- a/test/post-buffered-inline-comments.test.ts
+++ b/test/post-buffered-inline-comments.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test";
+import * as core from "@actions/core";
+import {
+  postComments,
+  postComment,
+  formatErrorDetails,
+  type BufferedComment,
+} from "../src/entrypoints/post-buffered-inline-comments";
+import type { createOctokit } from "../src/github/api/client";
+
+describe("post-buffered-inline-comments", () => {
+  let coreErrorSpy: ReturnType<typeof spyOn>;
+  let consoleLogSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    coreErrorSpy = spyOn(core, "error").mockImplementation(() => {});
+    consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    coreErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  function createMockOctokit(
+    createReviewCommentFn: (params: unknown) => Promise<unknown>,
+  ): ReturnType<typeof createOctokit>["rest"] {
+    return {
+      rest: {
+        pulls: {
+          createReviewComment: createReviewCommentFn,
+        },
+      },
+    } as unknown as ReturnType<typeof createOctokit>["rest"];
+  }
+
+  const commentA: BufferedComment = {
+    ts: "2026-08-16T00:00:00.000Z",
+    path: "src/index.ts",
+    line: 10,
+    body: "Fix variable naming",
+  };
+
+  const commentB: BufferedComment = {
+    ts: "2026-08-16T00:00:01.000Z",
+    path: "src/utils.ts",
+    line: 25,
+    body: "Add null check here",
+  };
+
+  it("handles all-success: posts every comment, returns count, emits no error annotations", async () => {
+    const attempted: unknown[] = [];
+    const octokit = createMockOctokit(async (params) => {
+      attempted.push(params);
+      return { data: { id: 101 } };
+    });
+
+    const result = await postComments(
+      octokit,
+      "test-owner",
+      "test-repo",
+      42,
+      "head-sha-123",
+      [commentA, commentB],
+    );
+
+    expect(result).toEqual({ posted: 2, failed: 0, total: 2 });
+    expect(attempted).toHaveLength(2);
+    expect(coreErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("handles partial failure: attempts all comments, reports failed/total summary, and does not fail process", async () => {
+    const attempted: unknown[] = [];
+    const octokit = createMockOctokit(async (params) => {
+      attempted.push(params);
+      const p = params as { path: string };
+      if (p.path === "src/index.ts") {
+        throw new Error("HTTP 500: Server Error");
+      }
+      return { data: { id: 102 } };
+    });
+
+    const result = await postComments(
+      octokit,
+      "test-owner",
+      "test-repo",
+      42,
+      "head-sha-123",
+      [commentA, commentB],
+    );
+
+    expect(result).toEqual({ posted: 1, failed: 1, total: 2 });
+    expect(attempted).toHaveLength(2);
+
+    const errorCalls = (coreErrorSpy.mock.calls as unknown[][]).map((c) =>
+      String(c[0]),
+    );
+    expect(errorCalls).toHaveLength(2);
+
+    // First call is diagnostic for failed commentA
+    expect(errorCalls[0]).toBe(
+      "Failed to post src/index.ts:10: HTTP 500: Server Error",
+    );
+
+    // Second call is summary
+    expect(errorCalls[1]).toBe("Failed to post 1/2 inline comment(s)");
+
+    // Logs contain dropped comment body
+    const logCalls = (consoleLogSpy.mock.calls as unknown[][]).map((c) =>
+      String(c[0]),
+    );
+    expect(
+      logCalls.some(
+        (line) =>
+          line.includes("dropped comment body:") &&
+          line.includes(JSON.stringify(commentA.body)),
+      ),
+    ).toBe(true);
+  });
+
+  it("handles total failure: attempts all comments, emits diagnostics and summary, and throws non-zero error", async () => {
+    const attempted: unknown[] = [];
+    const octokit = createMockOctokit(async (params) => {
+      attempted.push(params);
+      throw new Error("Delivery rejected");
+    });
+
+    await expect(
+      postComments(octokit, "test-owner", "test-repo", 42, "head-sha-123", [
+        commentA,
+        commentB,
+      ]),
+    ).rejects.toThrow("Failed to post 2/2 inline comment(s)");
+
+    expect(attempted).toHaveLength(2);
+
+    const errorCalls = (coreErrorSpy.mock.calls as unknown[][]).map((c) =>
+      String(c[0]),
+    );
+    expect(errorCalls).toHaveLength(3);
+
+    expect(errorCalls[0]).toBe(
+      "Failed to post src/index.ts:10: Delivery rejected",
+    );
+    expect(errorCalls[1]).toBe(
+      "Failed to post src/utils.ts:25: Delivery rejected",
+    );
+    expect(errorCalls[2]).toBe("Failed to post 2/2 inline comment(s)");
+  });
+
+  it("extracts and preserves GitHub/Octokit 422 diagnostic details", async () => {
+    const error422 = {
+      message: "Validation Failed",
+      status: 422,
+      response: {
+        status: 422,
+        data: {
+          message: "Validation Failed",
+          errors: [
+            {
+              resource: "PullRequestReviewThread",
+              field: "path",
+              code: "invalid",
+            },
+          ],
+        },
+      },
+    };
+
+    const details = formatErrorDetails(error422);
+    expect(details).toContain("Validation Failed");
+    expect(details).toContain("422");
+    expect(details).toContain("PullRequestReviewThread");
+    expect(details).toContain("invalid");
+
+    const octokit = createMockOctokit(async () => {
+      throw error422;
+    });
+
+    const success = await postComment(
+      octokit,
+      "test-owner",
+      "test-repo",
+      42,
+      "head-sha-123",
+      commentA,
+    );
+
+    expect(success).toBe(false);
+
+    const errorCalls = (coreErrorSpy.mock.calls as unknown[][]).map((c) =>
+      String(c[0]),
+    );
+    expect(errorCalls).toHaveLength(1);
+    expect(errorCalls[0]).toContain("src/index.ts:10");
+    expect(errorCalls[0]).toContain("Validation Failed");
+    expect(errorCalls[0]).toContain("422");
+    expect(errorCalls[0]).toContain("PullRequestReviewThread");
+    expect(errorCalls[0]).toContain("invalid");
+  });
+
+  it("preserves multiline comment body in logs safely on a single log line", async () => {
+    const multilineComment: BufferedComment = {
+      ts: "2026-08-16T00:00:00.000Z",
+      path: "src/danger.ts",
+      line: 99,
+      body: "Line 1: Problem found\n::warning::Injected command\nLine 3: Suggested fix",
+    };
+
+    const octokit = createMockOctokit(async () => {
+      throw new Error("Unprocessable Entity");
+    });
+
+    const success = await postComment(
+      octokit,
+      "test-owner",
+      "test-repo",
+      42,
+      "head-sha-123",
+      multilineComment,
+    );
+
+    expect(success).toBe(false);
+
+    const errorCalls = (coreErrorSpy.mock.calls as unknown[][]).map((c) =>
+      String(c[0]),
+    );
+    expect(errorCalls).toHaveLength(1);
+    expect(errorCalls[0]).toBe(
+      "Failed to post src/danger.ts:99: Unprocessable Entity",
+    );
+
+    const logCalls = (consoleLogSpy.mock.calls as unknown[][]).map((c) =>
+      String(c[0]),
+    );
+    const droppedBodyLog = logCalls.find((line) =>
+      line.includes("dropped comment body:"),
+    );
+    expect(droppedBodyLog).toBeDefined();
+    expect(droppedBodyLog).toContain(JSON.stringify(multilineComment.body));
+    expect(droppedBodyLog).not.toContain("\n");
+  });
+
+  it("handles unserializable response.data (e.g. circular object) without throwing", async () => {
+    const circularData: Record<string, unknown> = {
+      message: "Unserializable payload",
+    };
+    circularData.self = circularData;
+
+    const circularError = {
+      message: "Circular Error",
+      response: {
+        status: 500,
+        data: circularData,
+      },
+    };
+
+    const octokit = createMockOctokit(async () => {
+      throw circularError;
+    });
+
+    // postComment returns false rather than throwing
+    const success = await postComment(
+      octokit,
+      "test-owner",
+      "test-repo",
+      42,
+      "head-sha-123",
+      commentA,
+    );
+
+    expect(success).toBe(false);
+
+    // a useful core.error annotation is emitted
+    const errorCalls = (coreErrorSpy.mock.calls as unknown[][]).map((c) =>
+      String(c[0]),
+    );
+    expect(errorCalls).toHaveLength(1);
+    expect(errorCalls[0]).toContain("src/index.ts:10");
+    expect(errorCalls[0]).toContain("Circular Error");
+    expect(errorCalls[0]).toContain("500");
+
+    // the failure remains recoverable by the normal batch logic (postComments continues to next comment)
+    const attempted: unknown[] = [];
+    const batchOctokit = createMockOctokit(async (params) => {
+      attempted.push(params);
+      const p = params as { path: string };
+      if (p.path === "src/index.ts") {
+        throw circularError;
+      }
+      return { data: { id: 200 } };
+    });
+
+    const result = await postComments(
+      batchOctokit,
+      "test-owner",
+      "test-repo",
+      42,
+      "head-sha-123",
+      [commentA, commentB],
+    );
+
+    expect(result).toEqual({ posted: 1, failed: 1, total: 2 });
+    expect(attempted).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Fixes #1679.

Buffered inline comment delivery failures were logged but otherwise ignored, so a review could report `Posted 0/N` and still succeed.

This change makes failed posts visible with GitHub Actions error annotations and preserves dropped comment bodies in the logs. Partial delivery remains non-fatal so successfully posted findings are still usable, while a complete `0/N` delivery failure exits non-zero after all comments have been attempted.

Tests cover successful delivery, partial and total failures, GitHub 422 diagnostics, multiline comment logging, and unserializable API error data.

Validation:
- `bun test test/post-buffered-inline-comments.test.ts`
- `bun test`
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`