### PR TITLE
fix(settings): improve settings input validation and error diagnostics

### DIFF
--- a/base-action/src/setup-claude-code-settings.ts
+++ b/base-action/src/setup-claude-code-settings.ts
@@ -2,6 +2,84 @@ import { $ } from "bun";
 import { homedir } from "os";
 import { readFile } from "fs/promises";
 
+/**
+ * Validates and parses the settings input string.
+ * Supports:
+ *  1. Inline JSON strings (must parse to a JSON object dictionary)
+ *  2. File paths pointing to a JSON configuration file
+ */
+export async function parseSettingsInput(
+  rawInput: string,
+): Promise<Record<string, unknown>> {
+  const trimmed = rawInput.trim();
+  if (!trimmed) {
+    return {};
+  }
+
+  // If input starts with '{' or '[', it is intended as inline JSON syntax
+  const isLikelyInlineJson = trimmed.startsWith("{") || trimmed.startsWith("[");
+
+  if (isLikelyInlineJson) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to parse inline settings JSON: ${msg}`);
+    }
+
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw new Error(
+        `Invalid settings format: expected a JSON object dictionary, received ${Array.isArray(parsed) ? "array" : typeof parsed}`,
+      );
+    }
+
+    return parsed as Record<string, unknown>;
+  }
+
+  // Otherwise, treat as a configuration file path
+  console.log(`Treating settings input as file path: ${trimmed}`);
+  let fileContent: string;
+  try {
+    fileContent = await readFile(trimmed, "utf-8");
+  } catch (fileErr) {
+    const code = (fileErr as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT") {
+      throw new Error(
+        `Settings input is neither valid inline JSON nor an existing file path: '${trimmed}'`,
+      );
+    }
+    const msg = fileErr instanceof Error ? fileErr.message : String(fileErr);
+    throw new Error(`Failed to read settings file '${trimmed}': ${msg}`);
+  }
+
+  let parsedFromFile: unknown;
+  try {
+    parsedFromFile = JSON.parse(fileContent);
+  } catch (jsonErr) {
+    const msg = jsonErr instanceof Error ? jsonErr.message : String(jsonErr);
+    throw new Error(
+      `Failed to parse settings JSON from file '${trimmed}': ${msg}`,
+    );
+  }
+
+  if (
+    typeof parsedFromFile !== "object" ||
+    parsedFromFile === null ||
+    Array.isArray(parsedFromFile)
+  ) {
+    throw new Error(
+      `Invalid settings file format in '${trimmed}': expected a JSON object dictionary, received ${Array.isArray(parsedFromFile) ? "array" : typeof parsedFromFile}`,
+    );
+  }
+
+  return parsedFromFile as Record<string, unknown>;
+}
+
 export async function setupClaudeCodeSettings(
   settingsInput?: string,
   homeDir?: string,
@@ -33,26 +111,8 @@ export async function setupClaudeCodeSettings(
   // Handle settings input (either file path or JSON string)
   if (settingsInput && settingsInput.trim()) {
     console.log(`Processing settings input...`);
-    let inputSettings: Record<string, unknown> = {};
-
-    try {
-      // First try to parse as JSON
-      inputSettings = JSON.parse(settingsInput);
-      console.log(`Parsed settings input as JSON`);
-    } catch (e) {
-      // If not JSON, treat as file path
-      console.log(
-        `Settings input is not JSON, treating as file path: ${settingsInput}`,
-      );
-      try {
-        const fileContent = await readFile(settingsInput, "utf-8");
-        inputSettings = JSON.parse(fileContent);
-        console.log(`Successfully read and parsed settings from file`);
-      } catch (fileError) {
-        console.error(`Failed to read or parse settings file: ${fileError}`);
-        throw new Error(`Failed to process settings input: ${fileError}`);
-      }
-    }
+    const inputSettings = await parseSettingsInput(settingsInput);
+    console.log(`Successfully processed input settings`);
 
     // Merge input settings with existing settings
     settings = { ...settings, ...inputSettings };

--- a/base-action/test/setup-claude-code-settings.test.ts
+++ b/base-action/test/setup-claude-code-settings.test.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env bun
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { setupClaudeCodeSettings } from "../src/setup-claude-code-settings";
+import {
+  setupClaudeCodeSettings,
+  parseSettingsInput,
+} from "../src/setup-claude-code-settings";
 import { tmpdir } from "os";
 import { mkdir, writeFile, readFile, rm } from "fs/promises";
 import { join } from "path";
@@ -95,15 +98,15 @@ describe("setupClaudeCodeSettings", () => {
   });
 
   test("should throw error for invalid JSON string", async () => {
-    expect(() =>
+    expect(
       setupClaudeCodeSettings("{ invalid json", testHomeDir),
-    ).toThrow();
+    ).rejects.toThrow(/Failed to parse inline settings JSON/);
   });
 
   test("should throw error for non-existent file path", async () => {
-    expect(() =>
+    expect(
       setupClaudeCodeSettings("/non/existent/file.json", testHomeDir),
-    ).toThrow();
+    ).rejects.toThrow(/neither valid inline JSON nor an existing file path/);
   });
 
   test("should handle empty string input", async () => {
@@ -146,5 +149,39 @@ describe("setupClaudeCodeSettings", () => {
     expect(settings.existingKey).toBe("existingValue");
     expect(settings.newKey).toBe("newValue");
     expect(settings.model).toBe("claude-opus-4-1-20250805");
+  });
+});
+
+describe("parseSettingsInput", () => {
+  test("should return empty object for empty or whitespace input", async () => {
+    expect(await parseSettingsInput("")).toEqual({});
+    expect(await parseSettingsInput("   ")).toEqual({});
+  });
+
+  test("should parse valid inline JSON object", async () => {
+    const res = await parseSettingsInput('{"model": "test-model"}');
+    expect(res).toEqual({ model: "test-model" });
+  });
+
+  test("should reject inline JSON that is an array", async () => {
+    await expect(parseSettingsInput("[1, 2, 3]")).rejects.toThrow(
+      /Invalid settings format: expected a JSON object dictionary/,
+    );
+  });
+
+  test("should reject file containing invalid JSON", async () => {
+    const invalidFile = join(testSettingsDir, "invalid.json");
+    await writeFile(invalidFile, "not valid json content");
+    await expect(parseSettingsInput(invalidFile)).rejects.toThrow(
+      /Failed to parse settings JSON from file/,
+    );
+  });
+
+  test("should reject file containing non-object JSON", async () => {
+    const nonObjFile = join(testSettingsDir, "array.json");
+    await writeFile(nonObjFile, JSON.stringify([1, 2, 3]));
+    await expect(parseSettingsInput(nonObjFile)).rejects.toThrow(
+      /Invalid settings file format/,
+    );
   });
 });


### PR DESCRIPTION
## Summary
This PR improves input parsing, error handling, and diagnostic reporting in \setupClaudeCodeSettings\ (\ase-action/src/setup-claude-code-settings.ts\).

### Problems Addressed
1. **Misleading Error Reporting on Malformed JSON**:
   Previously, if a workflow author supplied an inline JSON string that contained a syntax error (such as a missing bracket, quote, or trailing comma), \JSON.parse\ failed and the loader immediately fell back to treating the entire string as a filesystem path. When \eadFile\ failed, an obscure \ENOENT: no such file or directory, open '{...'\ error was raised instead of reporting the actual JSON syntax error.
2. **Missing Dictionary Object Type Guard**:
   \JSON.parse\ can successfully parse non-object primitives or arrays (e.g. \[1, 2, 3]\ or \123\), which were then shallowly merged via \{ ...settings, ...inputSettings }\ without validating that \inputSettings\ is a valid object dictionary.
3. **Defensive Input Handling**:
   Introduced clean separation between inline JSON strings (detected via syntax prefix) and configuration file paths, providing precise diagnostic messages for:
   - Inline JSON syntax errors
   - Missing configuration files
   - Malformed JSON in configuration files
   - Non-dictionary configuration formats

### Changes
- Extracted and exported \parseSettingsInput\ helper function in \ase-action/src/setup-claude-code-settings.ts\.
- Added precise diagnostic error messages for inline JSON syntax errors and missing/invalid file paths.
- Added type validation to enforce that parsed settings evaluate to a non-null, non-array object dictionary.
- Expanded test coverage in \ase-action/test/setup-claude-code-settings.test.ts\ to verify inline JSON errors, file parsing errors, and non-object inputs.

### Verification
- Verified all existing and new unit tests for \setupClaudeCodeSettings\ and \parseSettingsInput\.
- Formatted with Prettier.