### PR TITLE
feat(security): align outbound comment sanitization with redactSecrets

### DIFF
--- a/src/github/utils/sanitizer.ts
+++ b/src/github/utils/sanitizer.ts
@@ -77,6 +77,17 @@ export function sanitizeContent(content: string): string {
 }
 
 /**
+ * Sanitize model-authored comment content before publishing to GitHub.
+ *
+ * Combines structural/prompt-injection sanitization (`sanitizeContent`) with
+ * multi-provider secret redaction (`redactSecrets` for GitHub tokens, Anthropic API keys,
+ * AWS keys, Slack tokens, and JWTs) as a defense-in-depth measure.
+ */
+export function sanitizeCommentBody(content: string): string {
+  return redactSecrets(sanitizeContent(content));
+}
+
+/**
  * Redact well-known credential formats (GitHub, Anthropic, AWS, Slack, JWTs)
  * from arbitrary text. Callers don't need to know which vendor a value belongs to.
  *

--- a/src/mcp/github-comment-server.ts
+++ b/src/mcp/github-comment-server.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { GITHUB_API_URL } from "../github/api/config";
 import { Octokit } from "@octokit/rest";
 import { updateClaudeComment } from "../github/operations/comments/update-claude-comment";
-import { sanitizeContent } from "../github/utils/sanitizer";
+import { sanitizeCommentBody } from "../github/utils/sanitizer";
 
 // Get repository information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -55,7 +55,7 @@ server.tool(
       const isPullRequestReviewComment =
         eventName === "pull_request_review_comment";
 
-      const sanitizedBody = sanitizeContent(body);
+      const sanitizedBody = sanitizeCommentBody(body);
 
       const result = await updateClaudeComment(octokit, {
         owner,

--- a/src/mcp/github-inline-comment-server.ts
+++ b/src/mcp/github-inline-comment-server.ts
@@ -4,7 +4,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { appendFileSync } from "fs";
 import { z } from "zod";
 import { createOctokit } from "../github/api/client";
-import { sanitizeContent } from "../github/utils/sanitizer";
+import { sanitizeCommentBody } from "../github/utils/sanitizer";
 import { removeBufferedComment } from "./inline-comment-buffer";
 
 // Get repository and PR information from environment variables
@@ -98,8 +98,8 @@ server.tool(
       const repo = REPO_NAME;
       const pull_number = parseInt(PR_NUMBER, 10);
 
-      // Sanitize the comment body to remove any potential GitHub tokens
-      const sanitizedBody = sanitizeContent(body);
+      // Sanitize the comment body and redact potential secrets
+      const sanitizedBody = sanitizeCommentBody(body);
 
       // Validate that either line or both startLine and line are provided
       if (!line && !startLine) {

--- a/test/sanitizer.test.ts
+++ b/test/sanitizer.test.ts
@@ -6,6 +6,7 @@ import {
   stripHiddenAttributes,
   normalizeHtmlEntities,
   sanitizeContent,
+  sanitizeCommentBody,
   stripHtmlComments,
   redactGitHubTokens,
   redactSecrets,
@@ -516,5 +517,58 @@ describe("stripHtmlComments (legacy)", () => {
     expect(stripHtmlComments("Hello <!-- \nexample\n -->World")).toBe(
       "Hello World",
     );
+  });
+});
+
+describe("sanitizeCommentBody", () => {
+  it("should sanitize hidden content and redact multi-provider secrets", () => {
+    const comment = `
+      <!-- Internal comment -->
+      Here is the review feedback:
+      - GitHub PAT: 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
+      - Anthropic Key: sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789_-abcdefgh
+      - AWS Key: AKIAIOSFODNN7EXAMPLE
+      - Slack Token: xoxb-1234567890-abcdefghijkl
+      - JWT: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+      - Zero-width: clean\u200Btext
+    `;
+
+    const result = sanitizeCommentBody(comment);
+
+    // Stripped hidden elements
+    expect(result).not.toContain("<!-- Internal comment -->");
+    expect(result).not.toContain("\u200B");
+    expect(result).toContain("cleantext");
+
+    // Redacted credentials
+    expect(result).not.toContain("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");
+    expect(result).not.toContain(
+      "sk-ant-api03-AbCdEfGhIjKlMnOpQrStUvWxYz0123456789_-abcdefgh",
+    );
+    expect(result).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(result).not.toContain("xoxb-1234567890-abcdefghijkl");
+    expect(result).not.toContain("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+
+    expect(result).toContain("[REDACTED_GITHUB_TOKEN]");
+    expect(result).toContain("[REDACTED_ANTHROPIC_KEY]");
+    expect(result).toContain("[REDACTED_AWS_KEY_ID]");
+    expect(result).toContain("[REDACTED_SLACK_TOKEN]");
+    expect(result).toContain("[REDACTED_JWT]");
+  });
+
+  it("should preserve valid code review suggestions and markdown formatting", () => {
+    const validComment = `### Code Review Feedback
+
+Here is a suggestion to fix the logic:
+
+\`\`\`typescript
+function calculateTotal(items: Item[]): number {
+  return items.reduce((sum, item) => sum + item.price, 0);
+}
+\`\`\`
+
+Please also check the test cases in \`test/index.test.ts\`.`;
+
+    expect(sanitizeCommentBody(validComment)).toBe(validComment);
   });
 });


### PR DESCRIPTION
### Summary
This PR harmonizes the outbound comment publishing MCP servers (`github-comment-server.ts` and `github-inline-comment-server.ts`) with existing secret redaction practices used across execution files, step summaries, and error logs (`redactSecrets`).

### Context & Rationale
Currently, error messages, turn formatting, and execution summaries use `redactSecrets()` to mask well-known credential formats (including GitHub tokens, Anthropic API keys, AWS access keys, Slack tokens, and JWTs).
However, `github-comment-server.ts` and `github-inline-comment-server.ts` only called `sanitizeContent()`, which primarily strips hidden markdown/prompt injection attributes and only masks GitHub tokens via `redactGitHubTokens()`.

While upstream environment variable isolation and subprocess scrubbing are the primary security boundaries against credential disclosure, extending comment sanitization to apply full `redactSecrets()` provides valuable defense-in-depth and ensures consistent secret hygiene across all public-facing comment sinks.

### Changes
- Introduced `sanitizeCommentBody(content: string)` in `src/github/utils/sanitizer.ts`, cleanly composing structural sanitization (`sanitizeContent`) with multi-vendor secret redaction (`redactSecrets`).
- Updated `github-comment-server.ts` (`update_claude_comment`) and `github-inline-comment-server.ts` (`create_inline_comment`) to sanitize outbound comments with `sanitizeCommentBody`.
- Added unit tests in `test/sanitizer.test.ts` covering multi-vendor credential redaction (Anthropic, AWS, Slack, JWT, GitHub) while ensuring valid markdown code blocks and review comments remain intact.
