### PR TITLE
fix: strip unused ALL_INPUTS environment variable from Claude subprocess env

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -289,6 +289,10 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   delete env.ACTIONS_ID_TOKEN_REQUEST_URL;
   delete env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
 
+  // Remove ALL_INPUTS as it is only needed during initial setup to determine
+  // input presence (collectActionInputsPresence) and contains serialized workflow inputs.
+  delete env.ALL_INPUTS;
+
   // Build system prompt option - default to claude_code preset
   let systemPrompt: SdkOptions["systemPrompt"];
   if (options.systemPrompt) {

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -620,5 +620,22 @@ describe("parseSdkOptions", () => {
         process.env = originalEnv;
       }
     });
+
+    test("should strip ALL_INPUTS from env", () => {
+      const originalEnv = { ...process.env };
+      process.env.ALL_INPUTS = JSON.stringify({
+        anthropic_api_key: "sk-ant-test-key",
+        github_token: "ghp_test_token",
+      });
+
+      try {
+        const options: ClaudeOptions = {};
+        const result = parseSdkOptions(options);
+
+        expect(result.sdkOptions.env?.ALL_INPUTS).toBeUndefined();
+      } finally {
+        process.env = originalEnv;
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

This PR ensures the `ALL_INPUTS` environment variable is stripped when preparing the environment dictionary passed to the Claude Code SDK subprocess in `base-action/src/parse-sdk-options.ts`.

## Rationale & Context

- In `action.yml`, `ALL_INPUTS: ${{ toJson(inputs) }}` is exported to capture the full workflow inputs JSON.
- `ALL_INPUTS` is only consumed during initial action setup by `collectActionInputsPresence()` to compute input presence flags.
- The downstream Claude CLI/SDK subprocess does not require or consume `ALL_INPUTS`.
- As a defense-in-depth security hardening measure, removing `ALL_INPUTS` from `env` alongside existing OIDC token variable cleanups (`ACTIONS_ID_TOKEN_REQUEST_*`) prevents unnecessary aggregation of workflow inputs in the subprocess execution environment, adhering to the principle of least privilege.

## Changes

- Stripped `ALL_INPUTS` in `base-action/src/parse-sdk-options.ts` during SDK environment construction.
- Added a unit test in `base-action/test/parse-sdk-options.test.ts` to verify `ALL_INPUTS` is stripped from `sdkOptions.env`.

## Verification

- Ran typecheck via `npm run typecheck` in `base-action` (0 errors).
- Formatted via Prettier.
