### PR TITLE
fix: isolate Claude settings per action run

### DIFF
--- a/base-action/src/index.ts
+++ b/base-action/src/index.ts
@@ -3,7 +3,10 @@
 import * as core from "@actions/core";
 import { preparePrompt } from "./prepare-prompt";
 import { runClaude } from "./run-claude";
-import { setupClaudeCodeSettings } from "./setup-claude-code-settings";
+import {
+  prependSettingsArgToClaudeArgs,
+  setupClaudeCodeSettings,
+} from "./setup-claude-code-settings";
 import { validateEnvironmentVariables } from "./validate-env";
 import { installPlugins } from "./install-plugins";
 import { setExecutionFileOutputIfPresent } from "./execution-file";
@@ -27,7 +30,7 @@ async function run() {
       process.env.INPUT_PATH_TO_CLAUDE_CODE_EXECUTABLE ||
       `${process.env.HOME}/.local/bin/claude`;
 
-    await setupClaudeCodeSettings(
+    const settingsPath = await setupClaudeCodeSettings(
       process.env.INPUT_SETTINGS,
       undefined, // homeDir
     );
@@ -45,7 +48,10 @@ async function run() {
     });
 
     const result = await runClaude(promptConfig.path, {
-      claudeArgs: process.env.INPUT_CLAUDE_ARGS,
+      claudeArgs: prependSettingsArgToClaudeArgs(
+        process.env.INPUT_CLAUDE_ARGS,
+        settingsPath,
+      ),
       allowedTools: process.env.INPUT_ALLOWED_TOOLS,
       disallowedTools: process.env.INPUT_DISALLOWED_TOOLS,
       maxTurns: process.env.INPUT_MAX_TURNS,

--- a/base-action/src/setup-claude-code-settings.ts
+++ b/base-action/src/setup-claude-code-settings.ts
@@ -1,22 +1,46 @@
-import { $ } from "bun";
-import { homedir } from "os";
-import { readFile } from "fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+async function resolveClaudeConfigDir(homeDir?: string): Promise<string> {
+  const configuredDir = process.env.CLAUDE_CONFIG_DIR?.trim();
+  if (configuredDir) {
+    process.env.CLAUDE_CONFIG_DIR = configuredDir;
+    return configuredDir;
+  }
+
+  const baseDir = process.env.RUNNER_TEMP?.trim() || homeDir || tmpdir();
+  await mkdir(baseDir, { recursive: true });
+
+  const sessionDir = await mkdtemp(join(baseDir, "claude-code-action-"));
+  process.env.CLAUDE_CONFIG_DIR = sessionDir;
+  console.log(`Using session-scoped Claude config directory: ${sessionDir}`);
+  return sessionDir;
+}
+
+export function prependSettingsArgToClaudeArgs(
+  claudeArgs: string | undefined,
+  settingsPath: string,
+): string {
+  const settingsArg = `--settings ${JSON.stringify(settingsPath)}`;
+  const trimmedArgs = claudeArgs?.trim();
+  return trimmedArgs ? `${settingsArg}\n${trimmedArgs}` : settingsArg;
+}
 
 export async function setupClaudeCodeSettings(
   settingsInput?: string,
   homeDir?: string,
-) {
-  const home = homeDir ?? homedir();
-  const settingsPath = `${home}/.claude/settings.json`;
+): Promise<string> {
+  const configDir = await resolveClaudeConfigDir(homeDir);
+  const settingsPath = join(configDir, "settings.json");
   console.log(`Setting up Claude settings at: ${settingsPath}`);
 
-  // Ensure .claude directory exists
-  console.log(`Creating .claude directory...`);
-  await $`mkdir -p ${home}/.claude`.quiet();
+  console.log(`Creating Claude config directory...`);
+  await mkdir(configDir, { recursive: true });
 
   let settings: Record<string, unknown> = {};
   try {
-    const existingSettings = await $`cat ${settingsPath}`.quiet().text();
+    const existingSettings = await readFile(settingsPath, "utf-8");
     if (existingSettings.trim()) {
       settings = JSON.parse(existingSettings);
       console.log(
@@ -63,6 +87,7 @@ export async function setupClaudeCodeSettings(
   settings.enableAllProjectMcpServers = true;
   console.log(`Updated settings with enableAllProjectMcpServers: true`);
 
-  await $`echo ${JSON.stringify(settings, null, 2)} > ${settingsPath}`.quiet();
+  await writeFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
   console.log(`Settings saved successfully`);
+  return settingsPath;
 }

--- a/base-action/test/setup-claude-code-settings.test.ts
+++ b/base-action/test/setup-claude-code-settings.test.ts
@@ -1,58 +1,102 @@
 #!/usr/bin/env bun
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { setupClaudeCodeSettings } from "../src/setup-claude-code-settings";
+import {
+  prependSettingsArgToClaudeArgs,
+  setupClaudeCodeSettings,
+} from "../src/setup-claude-code-settings";
 import { tmpdir } from "os";
 import { mkdir, writeFile, readFile, rm } from "fs/promises";
-import { join } from "path";
+import { dirname, join } from "path";
 
 const testHomeDir = join(
   tmpdir(),
   "claude-code-test-home",
   Date.now().toString(),
 );
-const settingsPath = join(testHomeDir, ".claude", "settings.json");
+const sharedHomeSettingsPath = join(testHomeDir, ".claude", "settings.json");
 const testSettingsDir = join(testHomeDir, ".claude-test");
 const testSettingsPath = join(testSettingsDir, "test-settings.json");
 
+let originalClaudeConfigDir: string | undefined;
+let originalRunnerTemp: string | undefined;
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+describe("prependSettingsArgToClaudeArgs", () => {
+  test("should create a settings arg when no claude args are provided", () => {
+    expect(
+      prependSettingsArgToClaudeArgs(undefined, "/tmp/settings.json"),
+    ).toBe('--settings "/tmp/settings.json"');
+  });
+
+  test("should prepend settings before existing claude args", () => {
+    expect(
+      prependSettingsArgToClaudeArgs(
+        '--model "claude-sonnet-4-20250514"',
+        "/tmp/settings path/settings.json",
+      ),
+    ).toBe(
+      '--settings "/tmp/settings path/settings.json"\n--model "claude-sonnet-4-20250514"',
+    );
+  });
+});
+
 describe("setupClaudeCodeSettings", () => {
   beforeEach(async () => {
-    // Create test home directory and test settings directory
+    originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    originalRunnerTemp = process.env.RUNNER_TEMP;
+    delete process.env.CLAUDE_CONFIG_DIR;
+    delete process.env.RUNNER_TEMP;
+
     await mkdir(testHomeDir, { recursive: true });
     await mkdir(testSettingsDir, { recursive: true });
   });
 
   afterEach(async () => {
-    // Clean up test home directory
     await rm(testHomeDir, { recursive: true, force: true });
+    restoreEnv("CLAUDE_CONFIG_DIR", originalClaudeConfigDir);
+    restoreEnv("RUNNER_TEMP", originalRunnerTemp);
   });
 
   test("should always set enableAllProjectMcpServers to true when no input", async () => {
-    await setupClaudeCodeSettings(undefined, testHomeDir);
+    const settingsPath = await setupClaudeCodeSettings(undefined, testHomeDir);
 
     const settingsContent = await readFile(settingsPath, "utf-8");
     const settings = JSON.parse(settingsContent);
 
+    expect(settingsPath).not.toBe(sharedHomeSettingsPath);
+    expect(process.env.CLAUDE_CONFIG_DIR).toBe(dirname(settingsPath));
     expect(settings.enableAllProjectMcpServers).toBe(true);
   });
 
-  test("should merge settings from JSON string input", async () => {
+  test("should write settings from JSON string input to session settings", async () => {
     const inputSettings = JSON.stringify({
       model: "claude-sonnet-4-20250514",
       env: { API_KEY: "test-key" },
     });
 
-    await setupClaudeCodeSettings(inputSettings, testHomeDir);
+    const settingsPath = await setupClaudeCodeSettings(
+      inputSettings,
+      testHomeDir,
+    );
 
     const settingsContent = await readFile(settingsPath, "utf-8");
     const settings = JSON.parse(settingsContent);
 
+    expect(settingsPath).not.toBe(sharedHomeSettingsPath);
     expect(settings.enableAllProjectMcpServers).toBe(true);
     expect(settings.model).toBe("claude-sonnet-4-20250514");
     expect(settings.env).toEqual({ API_KEY: "test-key" });
   });
 
-  test("should merge settings from file path input", async () => {
+  test("should write settings from file path input to session settings", async () => {
     const testSettings = {
       hooks: {
         PreToolUse: [
@@ -69,11 +113,15 @@ describe("setupClaudeCodeSettings", () => {
 
     await writeFile(testSettingsPath, JSON.stringify(testSettings, null, 2));
 
-    await setupClaudeCodeSettings(testSettingsPath, testHomeDir);
+    const settingsPath = await setupClaudeCodeSettings(
+      testSettingsPath,
+      testHomeDir,
+    );
 
     const settingsContent = await readFile(settingsPath, "utf-8");
     const settings = JSON.parse(settingsContent);
 
+    expect(settingsPath).not.toBe(sharedHomeSettingsPath);
     expect(settings.enableAllProjectMcpServers).toBe(true);
     expect(settings.hooks).toEqual(testSettings.hooks);
     expect(settings.permissions).toEqual(testSettings.permissions);
@@ -85,7 +133,10 @@ describe("setupClaudeCodeSettings", () => {
       model: "test-model",
     });
 
-    await setupClaudeCodeSettings(inputSettings, testHomeDir);
+    const settingsPath = await setupClaudeCodeSettings(
+      inputSettings,
+      testHomeDir,
+    );
 
     const settingsContent = await readFile(settingsPath, "utf-8");
     const settings = JSON.parse(settingsContent);
@@ -95,19 +146,19 @@ describe("setupClaudeCodeSettings", () => {
   });
 
   test("should throw error for invalid JSON string", async () => {
-    expect(() =>
+    await expect(
       setupClaudeCodeSettings("{ invalid json", testHomeDir),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 
   test("should throw error for non-existent file path", async () => {
-    expect(() =>
+    await expect(
       setupClaudeCodeSettings("/non/existent/file.json", testHomeDir),
-    ).toThrow();
+    ).rejects.toThrow();
   });
 
   test("should handle empty string input", async () => {
-    await setupClaudeCodeSettings("", testHomeDir);
+    const settingsPath = await setupClaudeCodeSettings("", testHomeDir);
 
     const settingsContent = await readFile(settingsPath, "utf-8");
     const settings = JSON.parse(settingsContent);
@@ -116,7 +167,10 @@ describe("setupClaudeCodeSettings", () => {
   });
 
   test("should handle whitespace-only input", async () => {
-    await setupClaudeCodeSettings("   \n\t  ", testHomeDir);
+    const settingsPath = await setupClaudeCodeSettings(
+      "   \n\t  ",
+      testHomeDir,
+    );
 
     const settingsContent = await readFile(settingsPath, "utf-8");
     const settings = JSON.parse(settingsContent);
@@ -124,27 +178,75 @@ describe("setupClaudeCodeSettings", () => {
     expect(settings.enableAllProjectMcpServers).toBe(true);
   });
 
-  test("should merge with existing settings", async () => {
-    // First, create some existing settings
-    await setupClaudeCodeSettings(
+  test("should merge with existing session settings", async () => {
+    const firstSettingsPath = await setupClaudeCodeSettings(
       JSON.stringify({ existingKey: "existingValue" }),
       testHomeDir,
     );
 
-    // Then, add new settings
-    const newSettings = JSON.stringify({
-      newKey: "newValue",
-      model: "claude-opus-4-1-20250805",
-    });
+    const secondSettingsPath = await setupClaudeCodeSettings(
+      JSON.stringify({
+        newKey: "newValue",
+        model: "claude-opus-4-1-20250805",
+      }),
+      testHomeDir,
+    );
 
-    await setupClaudeCodeSettings(newSettings, testHomeDir);
-
-    const settingsContent = await readFile(settingsPath, "utf-8");
+    const settingsContent = await readFile(secondSettingsPath, "utf-8");
     const settings = JSON.parse(settingsContent);
 
+    expect(secondSettingsPath).toBe(firstSettingsPath);
     expect(settings.enableAllProjectMcpServers).toBe(true);
     expect(settings.existingKey).toBe("existingValue");
     expect(settings.newKey).toBe("newValue");
     expect(settings.model).toBe("claude-opus-4-1-20250805");
+  });
+
+  test("should not merge settings input into shared home settings", async () => {
+    const sharedSettings = {
+      permissions: { deny: ["Write"] },
+      sharedKey: "shared-value",
+    };
+    await mkdir(dirname(sharedHomeSettingsPath), { recursive: true });
+    await writeFile(
+      sharedHomeSettingsPath,
+      JSON.stringify(sharedSettings, null, 2),
+    );
+
+    const settingsPath = await setupClaudeCodeSettings(
+      JSON.stringify({ permissions: { allow: ["Read"] } }),
+      testHomeDir,
+    );
+
+    const sharedSettingsContent = await readFile(
+      sharedHomeSettingsPath,
+      "utf-8",
+    );
+    const sessionSettingsContent = await readFile(settingsPath, "utf-8");
+    const sessionSettings = JSON.parse(sessionSettingsContent);
+
+    expect(settingsPath).not.toBe(sharedHomeSettingsPath);
+    expect(JSON.parse(sharedSettingsContent)).toEqual(sharedSettings);
+    expect(sessionSettings.permissions).toEqual({ allow: ["Read"] });
+    expect(sessionSettings.sharedKey).toBeUndefined();
+    expect(sessionSettings.enableAllProjectMcpServers).toBe(true);
+  });
+
+  test("should honor CLAUDE_CONFIG_DIR when provided", async () => {
+    const configDir = join(testHomeDir, "custom-claude-config");
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+
+    const settingsPath = await setupClaudeCodeSettings(
+      JSON.stringify({ model: "test-model" }),
+      testHomeDir,
+    );
+
+    const settingsContent = await readFile(settingsPath, "utf-8");
+    const settings = JSON.parse(settingsContent);
+
+    expect(settingsPath).toBe(join(configDir, "settings.json"));
+    expect(process.env.CLAUDE_CONFIG_DIR).toBe(configDir);
+    expect(settings.model).toBe("test-model");
+    expect(settings.enableAllProjectMcpServers).toBe(true);
   });
 });

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -39,7 +39,10 @@ import { redactSecrets } from "../github/utils/sanitizer";
 import { setupWorkloadIdentity } from "../../base-action/src/workload-identity";
 import type { WorkloadIdentityHandle } from "../../base-action/src/workload-identity";
 import { validateEnvironmentVariables } from "../../base-action/src/validate-env";
-import { setupClaudeCodeSettings } from "../../base-action/src/setup-claude-code-settings";
+import {
+  prependSettingsArgToClaudeArgs,
+  setupClaudeCodeSettings,
+} from "../../base-action/src/setup-claude-code-settings";
 import { installPlugins } from "../../base-action/src/install-plugins";
 import { preparePrompt } from "../../base-action/src/prepare-prompt";
 import { runClaude } from "../../base-action/src/run-claude";
@@ -272,7 +275,9 @@ async function run() {
       }
     }
 
-    await setupClaudeCodeSettings(process.env.INPUT_SETTINGS);
+    const settingsPath = await setupClaudeCodeSettings(
+      process.env.INPUT_SETTINGS,
+    );
 
     await installPlugins(
       process.env.INPUT_PLUGIN_MARKETPLACES,
@@ -289,7 +294,10 @@ async function run() {
     });
 
     const claudeResult: ClaudeRunResult = await runClaude(promptConfig.path, {
-      claudeArgs: prepareResult.claudeArgs,
+      claudeArgs: prependSettingsArgToClaudeArgs(
+        prepareResult.claudeArgs,
+        settingsPath,
+      ),
       appendSystemPrompt: process.env.APPEND_SYSTEM_PROMPT,
       model: process.env.ANTHROPIC_MODEL,
       pathToClaudeCodeExecutable: claudeExecutable,


### PR DESCRIPTION
## What
Fixes #1688. The action `settings` input was written into shared user-scope Claude settings and could leak across jobs on shared-HOME runners.

## Fix
Write action-generated settings into a per-run Claude config directory, honor an existing `CLAUDE_CONFIG_DIR`, and pass that file to Claude with `--settings`.

## Test
Added setup settings tests for shared HOME isolation, `CLAUDE_CONFIG_DIR`, and the generated `--settings` arg.
