### PR TITLE
feat: package repo as a Claude Code plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "claude-code-action",
+  "version": "1.0.0",
+  "description": "Bundles the GitHub MCP servers that power the Claude Code GitHub Action: PR/issue comment updates, inline review comments, commit-signed file operations, and CI status inspection.",
+  "author": {
+    "name": "Anthropic",
+    "url": "https://github.com/anthropics/claude-code-action"
+  },
+  "homepage": "https://github.com/anthropics/claude-code-action",
+  "repository": "https://github.com/anthropics/claude-code-action",
+  "license": "MIT",
+  "keywords": ["github", "mcp", "pull-request", "code-review", "ci"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 
 **/.claude/settings.local.json
+
+.claude/worktrees/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,96 @@
+{
+  "mcpServers": {
+    "github_comment": {
+      "type": "stdio",
+      "command": "bun",
+      "args": [
+        "--no-env-file",
+        "--config=${CLAUDE_PLUGIN_ROOT}/bunfig.toml",
+        "run",
+        "${CLAUDE_PLUGIN_ROOT}/src/mcp/github-comment-server.ts"
+      ],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+        "REPO_OWNER": "${REPO_OWNER}",
+        "REPO_NAME": "${REPO_NAME}",
+        "CLAUDE_COMMENT_ID": "${CLAUDE_COMMENT_ID:-}",
+        "GITHUB_EVENT_NAME": "${GITHUB_EVENT_NAME:-}",
+        "GITHUB_API_URL": "${GITHUB_API_URL:-https://api.github.com}"
+      }
+    },
+    "github_inline_comment": {
+      "type": "stdio",
+      "command": "bun",
+      "args": [
+        "--no-env-file",
+        "--config=${CLAUDE_PLUGIN_ROOT}/bunfig.toml",
+        "run",
+        "${CLAUDE_PLUGIN_ROOT}/src/mcp/github-inline-comment-server.ts"
+      ],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+        "REPO_OWNER": "${REPO_OWNER}",
+        "REPO_NAME": "${REPO_NAME}",
+        "PR_NUMBER": "${PR_NUMBER}",
+        "CLASSIFY_INLINE_COMMENTS": "${CLASSIFY_INLINE_COMMENTS:-false}",
+        "GITHUB_API_URL": "${GITHUB_API_URL:-https://api.github.com}"
+      }
+    },
+    "github_file_ops": {
+      "type": "stdio",
+      "command": "bun",
+      "args": [
+        "--no-env-file",
+        "--config=${CLAUDE_PLUGIN_ROOT}/bunfig.toml",
+        "run",
+        "${CLAUDE_PLUGIN_ROOT}/src/mcp/github-file-ops-server.ts"
+      ],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+        "REPO_OWNER": "${REPO_OWNER}",
+        "REPO_NAME": "${REPO_NAME}",
+        "BRANCH_NAME": "${BRANCH_NAME}",
+        "BASE_BRANCH": "${BASE_BRANCH:-main}",
+        "REPO_DIR": "${REPO_DIR}",
+        "IS_PR": "${IS_PR:-false}",
+        "GITHUB_EVENT_NAME": "${GITHUB_EVENT_NAME:-}",
+        "GITHUB_API_URL": "${GITHUB_API_URL:-https://api.github.com}"
+      }
+    },
+    "github_ci": {
+      "type": "stdio",
+      "command": "bun",
+      "args": [
+        "--no-env-file",
+        "--config=${CLAUDE_PLUGIN_ROOT}/bunfig.toml",
+        "run",
+        "${CLAUDE_PLUGIN_ROOT}/src/mcp/github-actions-server.ts"
+      ],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}",
+        "REPO_OWNER": "${REPO_OWNER}",
+        "REPO_NAME": "${REPO_NAME}",
+        "PR_NUMBER": "${PR_NUMBER}",
+        "RUNNER_TEMP": "${RUNNER_TEMP:-/tmp}"
+      }
+    },
+    "github": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "-e",
+        "GITHUB_HOST",
+        "ghcr.io/github/github-mcp-server:sha-23fa0dd"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}",
+        "GITHUB_HOST": "${GITHUB_SERVER_URL:-https://github.com}"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Each solution includes complete working examples, configuration details, and exp
 - [Custom Automations](./docs/custom-automations.md) - Examples of automated workflows and custom prompts
 - [Configuration](./docs/configuration.md) - MCP servers, permissions, environment variables, and advanced settings
 - [Experimental Features](./docs/experimental.md) - Execution modes and network restrictions
+- [Claude Code Plugin](./docs/claude-code-plugin.md) - Installing this repo as a plugin to use its MCP servers locally
 - [Cloud Providers](./docs/cloud-providers.md) - AWS Bedrock, Google Vertex AI, and Microsoft Foundry setup
 - [Capabilities & Limitations](./docs/capabilities-and-limitations.md) - What Claude can and cannot do
 - [Security](./docs/security.md) - Access control, permissions, and commit signing

--- a/docs/claude-code-plugin.md
+++ b/docs/claude-code-plugin.md
@@ -1,0 +1,100 @@
+# Using this repo as a Claude Code plugin
+
+Alongside its role as a GitHub Action, this repository is installable as a
+Claude Code plugin. The plugin bundles the MCP servers the action configures so
+you can drive them from an interactive Claude Code session instead of only from
+inside a workflow run.
+
+- Manifest: [`.claude-plugin/plugin.json`](../.claude-plugin/plugin.json)
+- Server config: [`.mcp.json`](../.mcp.json)
+
+## Bundled servers
+
+| Server                  | Source                                      | Tools                                                           |
+| ----------------------- | ------------------------------------------- | --------------------------------------------------------------- |
+| `github_comment`        | `src/mcp/github-comment-server.ts`          | `update_claude_comment`                                         |
+| `github_inline_comment` | `src/mcp/github-inline-comment-server.ts`   | `create_inline_comment`                                         |
+| `github_file_ops`       | `src/mcp/github-file-ops-server.ts`         | `commit_files`, `delete_files`                                  |
+| `github_ci`             | `src/mcp/github-actions-server.ts`          | `get_ci_status`, `get_workflow_run_details`, `download_job_log` |
+| `github`                | `ghcr.io/github/github-mcp-server` (Docker) | Upstream GitHub toolset                                         |
+
+The first four are this repo's own code, spawned as stdio processes with `bun`
+using the same flags the action uses (`--no-env-file` plus `--config` pinned to
+this repo's `bunfig.toml`) so runtime config resolves from the plugin directory
+rather than your current working directory.
+
+The fifth, `github`, is GitHub's own upstream server. It runs as a Docker
+container pinned to the same digest the action pins — `sha-23fa0dd`,
+[v0.17.1](https://github.com/github/github-mcp-server/releases/tag/v0.17.1).
+Bump it here and in `prepareMcpConfig` together, or the plugin and the action
+will drift.
+
+## Requirements
+
+- `bun` on `PATH`.
+- Dependencies installed in the plugin directory (`bun install`).
+- A GitHub token with access to the target repository.
+- A running Docker daemon, but only for the `github` server. The other four do
+  not need it.
+
+## Environment variables
+
+Values are read from your shell at server start. Variables with a default are
+optional.
+
+### Required by the four `bun` servers
+
+| Variable       | Purpose                              |
+| -------------- | ------------------------------------ |
+| `GITHUB_TOKEN` | Token used for all GitHub API calls. |
+| `REPO_OWNER`   | Owner of the target repository.      |
+| `REPO_NAME`    | Name of the target repository.       |
+
+### Per server
+
+| Variable                       | Servers                           | Default                          |
+| ------------------------------ | --------------------------------- | -------------------------------- |
+| `GITHUB_API_URL`               | comment, inline_comment, file_ops | `https://api.github.com`         |
+| `GITHUB_EVENT_NAME`            | comment, file_ops                 | empty                            |
+| `CLAUDE_COMMENT_ID`            | comment                           | empty                            |
+| `PR_NUMBER`                    | inline_comment, ci                | _required_                       |
+| `CLASSIFY_INLINE_COMMENTS`     | inline_comment                    | `false`                          |
+| `BRANCH_NAME`                  | file_ops                          | _required_                       |
+| `BASE_BRANCH`                  | file_ops                          | `main`                           |
+| `REPO_DIR`                     | file_ops                          | _required_ — local checkout path |
+| `IS_PR`                        | file_ops                          | `false`                          |
+| `RUNNER_TEMP`                  | ci                                | `/tmp`                           |
+| `GITHUB_PERSONAL_ACCESS_TOKEN` | github                            | _required_                       |
+| `GITHUB_SERVER_URL`            | github                            | `https://github.com`             |
+
+The `github` server reads its own `GITHUB_PERSONAL_ACCESS_TOKEN` rather than
+`GITHUB_TOKEN`. The action passes the same value to both; locally you can do the
+same, or scope a separate token to it.
+
+For GitHub Enterprise, set `GITHUB_API_URL` to your instance's API endpoint and
+`GITHUB_SERVER_URL` to its web host.
+
+## Caveats
+
+The four `bun` servers were written for the Actions runtime, and that shows:
+
+- `github_comment` edits a specific tracking comment. Without a valid
+  `CLAUDE_COMMENT_ID` it has nothing to update.
+- `github_inline_comment` and `github_ci` only make sense against a real pull
+  request, so `PR_NUMBER` must point at one.
+- `github_file_ops` commits through the GitHub API (the commit-signing path),
+  not through local git. It writes to `BRANCH_NAME` on the remote.
+
+The `github` server is the exception. It is a general-purpose GitHub toolset
+with no Actions-specific assumptions, so it behaves normally in a local session.
+
+## Verifying the install
+
+Run `/mcp` in an interactive session to confirm the servers connected and to see
+the exact tool names as they are exposed to you. Inside the action the tools are
+namespaced `mcp__github_comment__*`, `mcp__github_inline_comment__*`,
+`mcp__github_file_ops__*`, `mcp__github_ci__*`, and `mcp__github__*`; when
+loaded as a plugin the prefix is plugin-scoped, so read the names off `/mcp`
+rather than assuming.
+
+Use `claude --debug` to inspect connection and tool-discovery failures.


### PR DESCRIPTION
## Summary

Makes this repository installable as a Claude Code plugin, so the MCP servers the action already configures can be used from an interactive Claude Code session rather than only inside a workflow run.

No runtime code changes — this is additive configuration plus docs.

## What's added

- **`.claude-plugin/plugin.json`** — plugin manifest.
- **`.mcp.json`** — five stdio servers mirroring `prepareMcpConfig`:
  - the four `bun` servers in `src/mcp/` (`github_comment`, `github_inline_comment`, `github_file_ops`, `github_ci`), launched with the same flags `bunServerArgs` uses (`--no-env-file`, `--config` pinned to `bunfig.toml`) so runtime config resolves from the plugin directory
  - GitHub's upstream `github` server, pinned to the same `ghcr.io/github/github-mcp-server:sha-23fa0dd` digest `install-mcp-server.ts` pins
- **`docs/claude-code-plugin.md`** — tool inventory per server, full env-var reference, and the local-session caveats.
- **`.gitignore`** — ignore `.claude/worktrees/`.

## Notes

- Env vars use `${VAR:-default}` where the code has a default, so an unset optional var can't leak a literal `${VAR}` into a server process.
- The four `bun` servers were written for the Actions runtime and depend on injected repo/PR context (`CLAUDE_COMMENT_ID`, `PR_NUMBER`, `BRANCH_NAME`, …). The docs are explicit about which ones need what and where the limits are locally, rather than implying they all work standalone.
- The digest is now pinned in two places (`.mcp.json` and `prepareMcpConfig`); the docs call out that they need bumping together.

## Testing

- `bun run typecheck` — clean.
- `prettier --check` — clean on all changed files.
- `bun test` — 887 pass / 44 fail, **identical to the same run on `main` without this commit** (verified by testing `upstream/main` detached). The 44 failures are pre-existing Windows-environment failures, unrelated to this change. On Linux CI this should be green.
