### PR TITLE
Count write permission approvers when association is NONE

### DIFF
--- a/agent-approval-check/agent_approval_check.py
+++ b/agent-approval-check/agent_approval_check.py
@@ -34,7 +34,8 @@ AGENT DETECTION:
 
 APPROVAL COUNTING:
     Valid approvals come from non-agent users with write access to the
-    repository (verified via the collaborators permission API), via either:
+    repository (verified via the collaborators permission API; GitHub
+    authorAssociation is not used as a gate), via either:
     - A non-dismissed APPROVED review (staleness is controlled by GitHub's
       branch protection dismiss_stale_reviews setting)
     - A /approve <sha> comment
@@ -102,12 +103,12 @@ logger = logging.getLogger(__name__)
 CHECK_NAME = "agent-approval-check"
 REQUIRED_APPROVALS = int(os.environ.get("REQUIRED_APPROVALS") or 2)
 
-# Only approvals from users with write access to the repo count. authorAssociation
-# alone can't prove that (a MEMBER or COLLABORATOR may have read/triage only), so
-# it's used as a cheap pre-filter and the actual gate is a per-user REST
-# `GET /repos/{o}/{r}/collaborators/{login}/permission` check. A login outside
-# this set is not a collaborator at all, so the REST call is skipped.
-WRITE_ACCESS_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+# Only approvals from users with write access to the repo count. The
+# authoritative gate is a per-user REST
+# `GET /repos/{o}/{r}/collaborators/{login}/permission` check.
+# authorAssociation is logged for diagnosis but is not used as a pre-filter:
+# a repository-scoped token in a private org may report NONE for a
+# write-authorized reviewer whose org membership is not public.
 WRITE_PERMISSION_LEVELS = frozenset({"write", "push", "maintain", "admin"})
 DOCS_URL = (
     os.environ.get("DOCS_URL")
@@ -671,8 +672,11 @@ def iter_approve_commands(
         commenter = comment.get("user", {}).get("login", "")
         if not commenter:  # Skip deleted users or null authors
             continue
-        if comment.get("author_association") not in WRITE_ACCESS_ASSOCIATIONS:
-            continue
+        logger.info(
+            "Approve comment candidate %s association=%s",
+            commenter,
+            comment.get("author_association") or "(empty)",
+        )
         if is_agent_user(commenter, config):
             continue
         if is_excluded_approver(commenter, config):
@@ -946,8 +950,12 @@ def count_approvers(
     # GitHub's branch protection settings (dismiss_stale_reviews_on_push)
     # control which reviews remain active — we defer to that.
     for login, review in get_latest_review_per_user(reviews).items():
-        if review.get("author_association") not in WRITE_ACCESS_ASSOCIATIONS:
-            continue
+        logger.info(
+            "Review candidate %s association=%s state=%s",
+            login,
+            review.get("author_association") or "(empty)",
+            review.get("state"),
+        )
         if is_agent_user(login, config):
             continue
         if is_excluded_approver(login, config):

--- a/agent-approval-check/test_agent_approval_check.py
+++ b/agent-approval-check/test_agent_approval_check.py
@@ -1,0 +1,94 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "httpx",
+#   "pyyaml",
+#   "tenacity",
+# ]
+# ///
+"""Unit tests for approval counting (#1700)."""
+
+from __future__ import annotations
+
+import unittest
+
+from agent_approval_check import AgentConfig, count_approvers, iter_approve_commands
+
+
+def _config() -> AgentConfig:
+    return AgentConfig(
+        agent_emails=[],
+        agent_app_logins=["claude[bot]"],
+        excluded_approver_logins=[],
+        exempt_head_branches=[],
+    )
+
+
+def _review(login: str, association: str, state: str = "APPROVED") -> dict:
+    return {
+        "user": {"login": login},
+        "author_association": association,
+        "state": state,
+        "submitted_at": "2026-08-19T00:00:00Z",
+    }
+
+
+def _approve_comment(login: str, association: str, sha: str) -> dict:
+    return {
+        "user": {"login": login},
+        "author_association": association,
+        "body": f"/approve {sha}",
+        "id": 1,
+        "node_id": "IC_1",
+    }
+
+
+HEAD = "abcdef1234567890"
+
+
+class CountApproversAssociationTests(unittest.TestCase):
+    def test_none_association_with_write_permission_is_counted(self) -> None:
+        approvers = count_approvers(
+            HEAD,
+            [_review("alice", "NONE")],
+            [],
+            _config(),
+            lambda login: login == "alice",
+        )
+        self.assertEqual(approvers, {"alice"})
+
+    def test_member_association_without_write_permission_is_not_counted(self) -> None:
+        approvers = count_approvers(
+            HEAD,
+            [_review("bob", "MEMBER")],
+            [],
+            _config(),
+            lambda login: False,
+        )
+        self.assertEqual(approvers, set())
+
+    def test_approve_comment_none_association_with_write_permission_is_counted(
+        self,
+    ) -> None:
+        approvers = count_approvers(
+            HEAD,
+            [],
+            [_approve_comment("carol", "NONE", HEAD)],
+            _config(),
+            lambda login: login == "carol",
+        )
+        self.assertEqual(approvers, {"carol"})
+
+    def test_approve_comment_without_write_permission_is_not_counted(self) -> None:
+        commands = list(
+            iter_approve_commands(
+                [_approve_comment("dave", "COLLABORATOR", HEAD)],
+                _config(),
+                lambda login: False,
+            )
+        )
+        self.assertEqual(commands, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1700

A repository scoped token in a private org can report NONE for a reviewer who still has write access. Approval counting used authorAssociation as a prefilter and never called the collaborators permission API for those users.

This change treats the permission API as the only write access gate. Association is still logged. Unit tests cover NONE association with write permission and MEMBER association without write permission.

Test plan
1. Run python3 unittest test_agent_approval_check in the agent approval check directory
2. Confirm a write access reviewer with NONE association is counted
3. Confirm a MEMBER without write permission is not counted