### PR TITLE
fix: teach claude_args --allowedTools in the signed prompt

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -856,7 +856,7 @@ What You CANNOT Do:
 - Submit formal GitHub PR reviews
 - Approve pull requests (for security reasons)
 - Post multiple comments (you only update your initial comment)
-- Execute commands outside the repository context${useCommitSigning ? "\n- Run arbitrary Bash commands (unless explicitly allowed via allowed_tools configuration)" : ""}
+- Execute commands outside the repository context${useCommitSigning ? "\n- Run arbitrary Bash commands (unless explicitly allowed via claude_args with --allowedTools)" : ""}
 - Perform branch operations (cannot merge branches, rebase, or perform other git operations beyond creating and pushing commits)
 - Modify files in the .github/workflows directory (GitHub App permissions do not allow workflow modifications)
 

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -824,6 +824,35 @@ describe("generatePrompt", () => {
 
     // Should not have git command instructions
     expect(prompt).not.toContain("Use git commands via the Bash tool");
+
+    // Bash is off unless the user passes --allowedTools through claude_args.
+    // allowed_tools was removed in v1.0 and must not appear as live guidance.
+    expect(prompt).toContain(
+      "Run arbitrary Bash commands (unless explicitly allowed via claude_args with --allowedTools)",
+    );
+    expect(prompt).not.toContain("allowed_tools configuration");
+  });
+
+  test("does not mention allowed_tools when commit signing is off", async () => {
+    const envVars: PreparedContext = {
+      repository: "owner/repo",
+      claudeCommentId: "12345",
+      triggerPhrase: "@claude",
+      eventData: {
+        eventName: "issue_comment",
+        commentId: "67890",
+        isPR: true,
+        prNumber: "123",
+        commentBody: "@claude fix the bug",
+      },
+    };
+
+    const prompt = await generatePrompt(envVars, mockGitHubData, false, "tag");
+
+    expect(prompt).not.toContain("allowed_tools");
+    expect(prompt).not.toContain(
+      "Run arbitrary Bash commands (unless explicitly allowed",
+    );
   });
 
   describe("simplified prompt (USE_SIMPLE_PROMPT)", () => {


### PR DESCRIPTION
## Summary

When commit signing is on, the tag-mode prompt told the model that Bash is off unless allowed via `allowed_tools`. That input was removed in v1.0. The same prompt already tells the model to mention `--allowedTools` later in the analysis section.

This updates the CANNOT line to `claude_args` with `--allowedTools`, matching the current configuration surface.

Related to #1670. The docs change for that issue is already in #1678; this is the leftover model-facing sentence, not a second docs PR.

## Test plan

- [x] `bun test test/create-prompt.test.ts` (50 pass, run three times)
- [x] `bun run typecheck`
- [x] Signed prompt contains `claude_args with --allowedTools` and does not contain `allowed_tools`
- [x] Unsigned prompt does not add the Bash restriction line

From [RESILIENCE Agentic Solutions](https://we-are-resilience.com).

Made with [Cursor](https://cursor.com)