### PR TITLE
fix: bound subprocess isolation dependency installation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -227,24 +227,10 @@ runs:
       # Best-effort: skips on non-Linux or when sudo/apt unavailable (self-hosted runners).
       if: ${{ inputs.allowed_non_write_users != '' && runner.os == 'Linux' }}
       continue-on-error: true
+      timeout-minutes: 4
       shell: bash
       run: |
-        if [ "${CLAUDE_CODE_SUBPROCESS_ENV_SCRUB:-}" = "0" ]; then
-          echo "Subprocess isolation opted out via CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0"
-          exit 0
-        fi
-        if command -v apt-get >/dev/null && command -v sudo >/dev/null; then
-          for i in 1 2 3; do
-            sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends bubblewrap socat && break
-            echo "apt-get attempt $i failed, retrying..."
-            sleep 5
-          done
-        fi
-        # Ubuntu 24.04+ restricts unprivileged user namespaces via AppArmor.
-        # The sysctl doesn't exist on older kernels — that's fine.
-        if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && command -v sudo >/dev/null; then
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-        fi
+        "${GITHUB_ACTION_PATH}/scripts/install-subprocess-isolation-dependencies.sh"
 
     - name: Pin bun binary for post-steps
       if: ${{ inputs.allowed_non_write_users != '' }}

--- a/scripts/install-subprocess-isolation-dependencies.sh
+++ b/scripts/install-subprocess-isolation-dependencies.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Best-effort installation for subprocess isolation. Keep each network command
+# bounded so a stalled apt mirror cannot consume the caller's entire timeout.
+
+if [ "${CLAUDE_CODE_SUBPROCESS_ENV_SCRUB:-}" = "0" ]; then
+  echo "Subprocess isolation opted out via CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=0"
+  exit 0
+fi
+
+if command -v apt-get >/dev/null && command -v sudo >/dev/null; then
+  if command -v timeout >/dev/null; then
+    for i in 1 2 3; do
+      if timeout 60 sudo apt-get update -qq && \
+        timeout 120 sudo apt-get install -y --no-install-recommends bubblewrap socat; then
+        break
+      fi
+      echo "apt-get attempt $i failed or timed out, retrying..."
+      sleep 5
+    done
+  else
+    echo "Skipping subprocess isolation dependency installation: timeout is unavailable"
+  fi
+fi
+
+# Ubuntu 24.04+ restricts unprivileged user namespaces via AppArmor.
+# The sysctl doesn't exist on older kernels — that's fine.
+if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ] && command -v sudo >/dev/null; then
+  sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+fi

--- a/test/action-metadata.test.ts
+++ b/test/action-metadata.test.ts
@@ -12,4 +12,15 @@ describe("action metadata", () => {
       /^  conclusion:\n    description: .+\n    value: \$\{\{ steps\.run\.outputs\.conclusion \}\}$/m,
     );
   });
+
+  test("bounds subprocess isolation dependency installation", () => {
+    const metadata = readFileSync(
+      new URL("../action.yml", import.meta.url),
+      "utf8",
+    );
+
+    expect(metadata).toMatch(
+      /- name: Install subprocess isolation dependencies[\s\S]*?continue-on-error: true\n      timeout-minutes: 4[\s\S]*?install-subprocess-isolation-dependencies\.sh/,
+    );
+  });
 });

--- a/test/install-subprocess-isolation-dependencies.test.ts
+++ b/test/install-subprocess-isolation-dependencies.test.ts
@@ -1,0 +1,87 @@
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const installer = new URL(
+  "../scripts/install-subprocess-isolation-dependencies.sh",
+  import.meta.url,
+).pathname;
+
+function writeExecutable(path: string, contents: string) {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}
+
+describe("subprocess isolation dependency installer", () => {
+  test("retries a timed-out apt command without hanging", () => {
+    const directory = mkdtempSync(join(tmpdir(), "isolation-install-"));
+    const log = join(directory, "timeout.log");
+
+    writeExecutable(
+      join(directory, "sudo"),
+      `#!/usr/bin/env bash\nexec "$@"\n`,
+    );
+    writeExecutable(
+      join(directory, "apt-get"),
+      `#!/usr/bin/env bash\nsleep 1\n`,
+    );
+    writeExecutable(
+      join(directory, "timeout"),
+      `#!/usr/bin/env bash\necho "$*" >> "${log}"\nexit 124\n`,
+    );
+    writeExecutable(join(directory, "sleep"), `#!/usr/bin/env bash\nexit 0\n`);
+
+    const result = Bun.spawnSync(["bash", installer], {
+      env: {
+        ...process.env,
+        PATH: `${directory}:${process.env.PATH}`,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(log, "utf8").trim().split("\n")).toEqual([
+      "60 sudo apt-get update -qq",
+      "60 sudo apt-get update -qq",
+      "60 sudo apt-get update -qq",
+    ]);
+    expect(result.stdout.toString()).toContain(
+      "apt-get attempt 3 failed or timed out, retrying...",
+    );
+  });
+
+  test("installs packages after a successful update", () => {
+    const directory = mkdtempSync(join(tmpdir(), "isolation-install-"));
+    const log = join(directory, "apt.log");
+
+    writeExecutable(
+      join(directory, "sudo"),
+      `#!/usr/bin/env bash\nexec "$@"\n`,
+    );
+    writeExecutable(
+      join(directory, "apt-get"),
+      `#!/usr/bin/env bash\necho "$*" >> "${log}"\n`,
+    );
+    writeExecutable(
+      join(directory, "timeout"),
+      `#!/usr/bin/env bash\nshift\nexec "$@"\n`,
+    );
+
+    const result = Bun.spawnSync(["bash", installer], {
+      env: {
+        ...process.env,
+        PATH: `${directory}:${process.env.PATH}`,
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(log, "utf8").trim().split("\n")).toEqual([
+      "update -qq",
+      "install -y --no-install-recommends bubblewrap socat",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- bound each `apt-get` network operation with GNU `timeout`
- cap the best-effort composite step at four minutes so Claude can still run
- extract the installer into a focused script and cover timeout/retry and success paths

Closes #1694.

## Validation

- `bun test` — 934 passed, 0 failed
- `bun run typecheck`
- `bun run format:check`
- focused installer and metadata tests — 4 passed, 0 failed
- `bash -n scripts/install-subprocess-isolation-dependencies.sh`
- `git diff --check`
