### PR TITLE
chore: add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Keep the working tree LF on every platform: Prettier defaults to
+# endOfLine "lf" and several tests match LF-terminated content.
+* text=auto eol=lf


### PR DESCRIPTION
On Windows, git's default `core.autocrlf=true` checks out CRLF, and the contributor commands in CONTRIBUTING.md then fail on a clean clone.

**Before** (fresh clone of `main` at `3f854a8`, measured 2026-08-21, Windows 11, stock git config):

```
$ bun run format:check
[warn] Code style issues found in 191 files. Run Prettier with --write to fix.
error: script "format:check" exited with code 1
```

`bun test`: 882 pass, 49 fail.

**After** (same commit, with this file):

```
$ bun run format:check
Checking formatting...
All matched files use Prettier code style!
```

`bun test`: 885 pass, 46 fail.

Prettier defaults to `endOfLine: "lf"` and `.prettierrc` is `{}`, which accounts for the 191 files. Three tests fail only under CRLF and pass with this change:

- `action metadata > should expose the conclusion output from the run step`
- `base action README > should document every input declared in the action metadata`
- `integration tests > formats real conversation data correctly`

Each matches LF-terminated content, for example the `/^  conclusion:\n...$/m` assertion at `test/action-metadata.test.ts:11`. The remaining 46 failures are pre-existing Windows issues (path separators, POSIX permission bits, symlink privilege) and are untouched by this change.

A few things I checked before opening this:

- All tracked blobs are already LF, so there is no renormalization. `git add --renormalize .` stages zero changes, and the diff is one new file.
- `* text=auto` on its own does not fix this. It governs normalization on commit, not checkout, so the working tree stays CRLF. `eol=lf` is the minimal line that works.
- Every CI job runs on `ubuntu-latest`, where this is a no-op. Checkouts with and without the file are byte-identical under `core.autocrlf=false`.
- The repo tracks no binary files and no `.bat`, `.cmd`, or `.ps1` files, so nothing needs CRLF preserved.
- This does not reach `claude-code-base-action`. `sync-base-action.yml` triggers on `base-action/**` and copies only that directory, so a root file is neither triggered nor mirrored. Glad to add `base-action/.gitattributes` as well if you want the mirror covered, but I have left it out to keep this to one change.

AI assistance: I used Claude Code for this investigation. What I verified myself on my own Windows 11 machine, rather than taking on trust: the before and after `format:check` exit codes and the 191 file count, the three CRLF-only test failures, that `* text=auto` alone still leaves `action.yml` with 459 CR bytes in the working tree while `* text=auto eol=lf` leaves 0, and that every tracked blob is already stored LF.

