### PR TITLE
fix: configure git auth before tag-mode branch setup

### DIFF
--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -62,10 +62,11 @@ export async function prepareTagMode({
     excludeCommentsByActor: context.inputs.excludeCommentsByActor,
   });
 
-  // Setup branch
-  const branchInfo = await setupBranch(octokit, githubData, context);
-
-  // Configure git authentication
+  // Configure git authentication before setupBranch, which performs an
+  // unauthenticated `git fetch` on several paths (open same-repo PR, fork PR,
+  // new branch from an issue/closed PR). If the workflow checked out with
+  // actions/checkout's `persist-credentials: false`, that fetch has no
+  // credential to use unless auth is configured first.
   // SSH signing takes precedence if provided
   const useSshSigning = !!context.inputs.sshSigningKey;
   const useApiCommitSigning = context.inputs.useCommitSigning && !useSshSigning;
@@ -99,6 +100,9 @@ export async function prepareTagMode({
       throw error;
     }
   }
+
+  // Setup branch
+  const branchInfo = await setupBranch(octokit, githubData, context);
 
   // Create prompt file
   await createPrompt(

--- a/test/modes/tag.test.ts
+++ b/test/modes/tag.test.ts
@@ -1,8 +1,89 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import type { Mock } from "bun:test";
 import { prepareTagMode } from "../../src/modes/tag";
+import { mockIssueCommentContext } from "../mockContext";
+import * as actorValidation from "../../src/github/validation/actor";
+import * as createInitialComment from "../../src/github/operations/comments/create-initial";
+import * as fetcher from "../../src/github/data/fetcher";
+import * as branchOps from "../../src/github/operations/branch";
+import * as gitConfig from "../../src/github/operations/git-config";
+import * as createPromptModule from "../../src/create-prompt";
 
 describe("Tag Mode", () => {
   test("prepareTagMode is exported as a function", () => {
     expect(typeof prepareTagMode).toBe("function");
+  });
+
+  describe("git auth ordering", () => {
+    const callOrder: string[] = [];
+    const restores: Mock<any>[] = [];
+
+    beforeEach(() => {
+      callOrder.length = 0;
+      delete process.env.CLAUDE_ARGS;
+
+      restores.push(
+        spyOn(actorValidation, "checkHumanActor").mockImplementation(
+          async () => {},
+        ) as unknown as Mock<any>,
+      );
+      restores.push(
+        spyOn(createInitialComment, "createInitialComment").mockImplementation(
+          async () => ({ id: 42 }) as any,
+        ) as unknown as Mock<any>,
+      );
+      restores.push(
+        spyOn(fetcher, "fetchGitHubData").mockImplementation(async () => ({
+          contextData: {
+            title: "Test issue",
+            body: "",
+            labels: { nodes: [] },
+          } as any,
+          comments: [],
+          changedFiles: [],
+          changedFilesWithSHA: [],
+          reviewData: null,
+          imageUrlMap: new Map(),
+        })) as unknown as Mock<any>,
+      );
+      restores.push(
+        spyOn(gitConfig, "configureGitAuth").mockImplementation(async () => {
+          callOrder.push("configureGitAuth");
+        }) as unknown as Mock<any>,
+      );
+      restores.push(
+        spyOn(branchOps, "setupBranch").mockImplementation(async () => {
+          callOrder.push("setupBranch");
+          return {
+            baseBranch: "main",
+            claudeBranch: "claude/issue-1",
+            currentBranch: "claude/issue-1",
+          };
+        }) as unknown as Mock<any>,
+      );
+      restores.push(
+        spyOn(createPromptModule, "createPrompt").mockImplementation(
+          async () => {},
+        ) as unknown as Mock<any>,
+      );
+    });
+
+    afterEach(() => {
+      for (const restore of restores) {
+        restore.mockRestore();
+      }
+      restores.length = 0;
+      delete process.env.CLAUDE_ARGS;
+    });
+
+    test("configures git authentication before setupBranch performs its fetch", async () => {
+      await prepareTagMode({
+        context: mockIssueCommentContext,
+        octokit: {} as any,
+        githubToken: "test-token",
+      });
+
+      expect(callOrder).toEqual(["configureGitAuth", "setupBranch"]);
+    });
   });
 });


### PR DESCRIPTION
Fixes #1711.

## Bug

In tag mode (`src/modes/tag/index.ts`), `setupBranch()` was called before `configureGitAuth()` / `setupSshSigning()`. `setupBranch()` (`src/github/operations/branch.ts`) runs `git fetch` on several paths — checking out an open same-repo PR branch, fetching a fork PR via `refs/pull/N/head`, or resolving the source branch for a new branch off an issue/closed PR — all via `execGit`, which is `execFileSync("git", ..., { stdio: "inherit" })` and throws on a non-zero exit.

The only thing in this code path that puts a usable credential on `origin` is `configureGitAuth` (`src/github/operations/git-config.ts`), and it ran after `setupBranch`.

Concretely: private repo, `actions/checkout@v7` with `persist-credentials: false` (a documented hardening step), `claude-code-action@v1` in tag mode, someone comments `@claude ...`. The tracking comment ("Claude Code is working…") gets posted, then `setupBranch`'s fetch runs with no credential and throws.

That failure is worse than an ordinary red run. In `src/entrypoints/run.ts`, `commentId` is declared `undefined` and only gets assigned from `prepareResult.commentId` after `prepareTagMode` returns successfully. Since the throw happens inside `prepareTagMode` (mid-call), that assignment is never reached. The `finally` block only patches the tracking comment when `commentId` is truthy, so it's skipped. Net effect: the run fails, but the "Claude Code is working…" comment it already posted is never updated and just sits there. Every `@claude` mention in that repo does this.

## Fix

Move the git-auth setup (`configureGitAuth` / `setupSshSigning`) ahead of the `setupBranch()` call in `prepareTagMode`. I checked `configureGitAuth` for any dependency on branch state first — it only needs `githubToken`, `context`, and the bot user (login/id from inputs), none of which come from `setupBranch`, so the reorder has no side effects on the auth setup itself.

This PR only touches that ordering. It does not change how `run.ts` tracks `commentId` — making a failed run's tracking comment resolve to an error state is a separate, valid fix but a different concern from preventing this particular failure, so I left it out. Happy to file that separately if it's wanted.

## Note on prior art

While checking for competing PRs I found #1340 ("fix: configure git auth before tag branch setup"), open since May, doing the same reorder against #1236 (the issue #1711 is labeled a duplicate of). It's had no review or comment in three months. I'm not trying to step on it — if a maintainer prefers to pick that one up instead, that's fine by me. I'm filing this one because #1711 is the currently open, actively described issue, and I wanted the fix to come with a passing regression test against current `main`.

## Testing

- Added `test/modes/tag.test.ts` — regression test spying on `configureGitAuth` and `setupBranch` and asserting call order.
- Confirmed the test fails against unpatched `main` (`["setupBranch", "configureGitAuth"]` vs expected `["configureGitAuth", "setupBranch"]`), passes after the fix, and reverting the source change makes it fail again with the same output — so the test actually exercises the ordering, not something incidental.
- `bun test` — 805 pass, 0 fail, 1761 expect() calls, across 44 files.
- `bun run typecheck` — clean.
- `npx prettier --check src/modes/tag/index.ts test/modes/tag.test.ts` — clean.
