### PR TITLE
fix: bound download_job_log against a stalled log fetch

### DIFF
--- a/src/mcp/github-actions-server.ts
+++ b/src/mcp/github-actions-server.ts
@@ -17,11 +17,18 @@ const PR_NUMBER = process.env.PR_NUMBER;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const RUNNER_TEMP = process.env.RUNNER_TEMP || "/tmp";
 
-if (!REPO_OWNER || !REPO_NAME || !PR_NUMBER || !GITHUB_TOKEN) {
-  console.error(
-    "[GitHub CI Server] Error: REPO_OWNER, REPO_NAME, PR_NUMBER, and GITHUB_TOKEN environment variables are required",
-  );
-  process.exit(1);
+// Job logs are fetched by ID from GitHub-hosted storage; bound the request so a
+// stalled fetch can't hang this MCP call forever. Mirrors the timeout added to
+// fetchImage() in src/github/utils/image-downloader.ts (#1625).
+const DOWNLOAD_JOB_LOG_TIMEOUT_MS = 30_000;
+
+if (import.meta.main) {
+  if (!REPO_OWNER || !REPO_NAME || !PR_NUMBER || !GITHUB_TOKEN) {
+    console.error(
+      "[GitHub CI Server] Error: REPO_OWNER, REPO_NAME, PR_NUMBER, and GITHUB_TOKEN environment variables are required",
+    );
+    process.exit(1);
+  }
 }
 
 const server = new McpServer({
@@ -205,6 +212,40 @@ server.tool(
   },
 );
 
+export async function downloadJobLog(
+  client: Octokit,
+  params: { owner: string; repo: string; job_id: number },
+  runnerTemp: string,
+  timeoutMs: number = DOWNLOAD_JOB_LOG_TIMEOUT_MS,
+): Promise<{ path: string; size_bytes: number }> {
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await client.actions.downloadJobLogsForWorkflowRun({
+      owner: params.owner,
+      repo: params.repo,
+      job_id: params.job_id,
+      request: { signal: controller.signal },
+    });
+
+    const logsText = response.data as unknown as string;
+
+    const logsDir = `${runnerTemp}/github-ci-logs`;
+    await mkdir(logsDir, { recursive: true });
+
+    const logPath = `${logsDir}/job-${params.job_id}.log`;
+    await writeFile(logPath, logsText, "utf-8");
+
+    return {
+      path: logPath,
+      size_bytes: Buffer.byteLength(logsText, "utf-8"),
+    };
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
 server.tool(
   "download_job_log",
   "Download job logs to disk",
@@ -218,24 +259,11 @@ server.tool(
         baseUrl: GITHUB_API_URL,
       });
 
-      const response = await client.actions.downloadJobLogsForWorkflowRun({
-        owner: REPO_OWNER!,
-        repo: REPO_NAME!,
-        job_id,
-      });
-
-      const logsText = response.data as unknown as string;
-
-      const logsDir = `${RUNNER_TEMP}/github-ci-logs`;
-      await mkdir(logsDir, { recursive: true });
-
-      const logPath = `${logsDir}/job-${job_id}.log`;
-      await writeFile(logPath, logsText, "utf-8");
-
-      const result = {
-        path: logPath,
-        size_bytes: Buffer.byteLength(logsText, "utf-8"),
-      };
+      const result = await downloadJobLog(
+        client,
+        { owner: REPO_OWNER!, repo: REPO_NAME!, job_id },
+        RUNNER_TEMP,
+      );
 
       return {
         content: [
@@ -277,6 +305,8 @@ async function runServer() {
   }
 }
 
-runServer().catch(() => {
-  process.exit(1);
-});
+if (import.meta.main) {
+  runServer().catch(() => {
+    process.exit(1);
+  });
+}

--- a/test/github-actions-server.test.ts
+++ b/test/github-actions-server.test.ts
@@ -1,0 +1,94 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { readFile, rm } from "fs/promises";
+import os from "os";
+import path from "path";
+import { downloadJobLog } from "../src/mcp/github-actions-server";
+import type { Octokit } from "@octokit/rest";
+
+describe("downloadJobLog", () => {
+  const tmpDirs: string[] = [];
+
+  const makeRunnerTemp = () => {
+    const dir = path.join(
+      os.tmpdir(),
+      `download-job-log-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    tmpDirs.push(dir);
+    return dir;
+  };
+
+  afterEach(async () => {
+    while (tmpDirs.length) {
+      const dir = tmpDirs.pop()!;
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  const createStallingClient = (): {
+    client: Octokit;
+    getSignal: () => AbortSignal | undefined;
+  } => {
+    let signal: AbortSignal | undefined;
+    const client = {
+      actions: {
+        downloadJobLogsForWorkflowRun: (params: {
+          request?: { signal?: AbortSignal };
+        }) => {
+          signal = params.request?.signal;
+          return new Promise((_resolve, reject) => {
+            signal?.addEventListener("abort", () => {
+              reject(new Error("This operation was aborted"));
+            });
+            // Otherwise never settles, simulating a stalled fetch.
+          });
+        },
+      },
+    } as unknown as Octokit;
+    return { client, getSignal: () => signal };
+  };
+
+  test("rejects with a timeout instead of hanging when the download stalls", async () => {
+    const { client, getSignal } = createStallingClient();
+    const runnerTemp = makeRunnerTemp();
+
+    await expect(
+      downloadJobLog(
+        client,
+        { owner: "owner", repo: "repo", job_id: 123 },
+        runnerTemp,
+        5,
+      ),
+    ).rejects.toThrow();
+
+    expect(getSignal()?.aborted).toBe(true);
+  });
+
+  test("writes the log to disk and clears the timeout when the download succeeds", async () => {
+    const runnerTemp = makeRunnerTemp();
+    const client = {
+      actions: {
+        downloadJobLogsForWorkflowRun: async (params: {
+          request?: { signal?: AbortSignal };
+        }) => {
+          expect(params.request?.signal?.aborted).toBe(false);
+          return { data: "log line 1\nlog line 2\n" };
+        },
+      },
+    } as unknown as Octokit;
+
+    const result = await downloadJobLog(
+      client,
+      { owner: "owner", repo: "repo", job_id: 456 },
+      runnerTemp,
+      30_000,
+    );
+
+    expect(result.path).toBe(`${runnerTemp}/github-ci-logs/job-456.log`);
+    expect(result.size_bytes).toBe(
+      Buffer.byteLength("log line 1\nlog line 2\n", "utf-8"),
+    );
+
+    const written = await readFile(result.path, "utf-8");
+    expect(written).toBe("log line 1\nlog line 2\n");
+  });
+});


### PR DESCRIPTION
`fetchImage()` in `src/github/utils/image-downloader.ts:292-321` bounds every image fetch with a timeout-driven `AbortController` (added in #1625). `download_job_log` in `src/mcp/github-actions-server.ts:221-225` fetches a GitHub-hosted resource the same way and never got the same treatment:

```ts
const response = await client.actions.downloadJobLogsForWorkflowRun({
  owner: REPO_OWNER!, repo: REPO_NAME!, job_id,
});
```

No timeout, no `AbortController`. `@octokit/rest@21` runs on Node's native `fetch`, which has no default timeout, and Octokit only cancels a request when the caller passes `request: { signal }`. If the log-blob fetch stalls, that `await` never resolves and never rejects. I confirmed `github-actions-server.ts` has no `AbortController`/`signal`/`setTimeout` anywhere in the file before this change, and confirmed `request: { signal }` is the documented Octokit option for cancelling a request (`RequestRequestOptions` in `@octokit/types`).

Both calls are the same shape: an MCP tool fetches a resource referenced by an ID from untrusted PR/CI content and writes it to a temp dir for Claude to read. Only one of them got bounded.

**Why this matters in practice:** `download_job_log` is one of the fixed, always-enabled `tagModeTools` (`src/modes/tag/index.ts:142`), so it's live on every tag-mode run. A normal "fix the failing CI" run calls `get_ci_status` -> `get_workflow_run_details` -> `download_job_log`. If that fetch stalls, the MCP call hangs with nothing to recover it. These runs are headless, so nothing interrupts it — the job only ends when the Actions job-level `timeout-minutes` kills it from the outside, burning the entire job budget with the tracking comment stuck at "Claude Code is working...".

## The fix

Mirrors `fetchImage()`: an `AbortController` aborts the request after a timeout, passed to Octokit via `request: { signal }`. I extracted the download+write logic into an exported `downloadJobLog()` function with an injectable `timeoutMs` (defaulting to a named `DOWNLOAD_JOB_LOG_TIMEOUT_MS = 30_000`, mirroring the sibling's `DEFAULT_IMAGE_DOWNLOAD_TIMEOUT_MS` convention) so the timeout path is directly unit-testable without spinning up the MCP transport.

Scope: this PR only adds the missing timeout. The log response is also buffered into memory with no size cap before being written to disk — that's a separate concern and I'm leaving it alone here; happy to open a follow-up if it's wanted.

## Testability side effect

`github-actions-server.ts` previously did its `REPO_OWNER`/`REPO_NAME`/`PR_NUMBER`/`GITHUB_TOKEN` env check and called `runServer()` unconditionally at module load, which would kill the process (or try to connect a stdio transport) just from importing the file in a test. I guarded both with `if (import.meta.main)`, the same pattern already used in `src/entrypoints/run.ts`, `prepare.ts`, `format-turns.ts`, `update-comment-link.ts`, and `cleanup-ssh-signing.ts`. No behavior change when the file is run as the actual MCP server entrypoint.

## Testing

Added `test/github-actions-server.test.ts` with an injected Octokit client whose `downloadJobLogsForWorkflowRun` never resolves unless its `AbortSignal` fires, plus a happy-path test that writes a real temp file and checks its contents.

RED (fix reverted, stalling call left unbounded):
```
$ timeout 15 bun test test/github-actions-server.test.ts
bun test v1.4.0 (1381054db)

test/github-actions-server.test.ts:
[GitHub CI Server] MCP Server instance created
$ echo $?
124
```
Killed by the 15s wrapper — the unbounded call hangs forever, reproducing the actual bug.

GREEN (fix restored):
```
$ bun test test/github-actions-server.test.ts
bun test v1.4.0 (1381054db)

test/github-actions-server.test.ts:
[GitHub CI Server] MCP Server instance created

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [49.00ms]
```

Full suite and typecheck:
```
$ bun run typecheck
$ tsc --noEmit
(clean, no output)

$ bun test
 947 pass
 9 fail
 2194 expect() calls
Ran 956 tests across 56 files. [6.66s]
```
The 9 failures are all in `test/github-graphql-url.test.ts` (`Bun.spawnSync` -> `ENOEXEC` against a locally broken `bun` binary shim on my machine) and reproduce identically on a clean `git stash` of `main` with no changes applied — unrelated to this PR.

## Dedupe check

Checked all 269 currently open PRs' changed files for `github-actions-server` and `image-downloader`:
- Zero open PRs touch `src/mcp/github-actions-server.ts`.
- #1624, #1661, #1685 touch `src/github/utils/image-downloader.ts` (directory-collision and size-limit fixes on the image path) — confirmed via full `gh pr diff` on each that none of them extends to `github-actions-server.ts`.
- Searched open PR titles/bodies for `download_job_log`/`downloadJobLog`/`github-actions-server` — no matches for this fix.

No duplicate exists for this specific fix.
