### PR TITLE
fix: clean checkout includeIf credentials

### DIFF
--- a/src/github/operations/git-config.ts
+++ b/src/github/operations/git-config.ts
@@ -60,12 +60,12 @@ export async function configureGitAuth(
  * actions/checkout < v6 stored the header directly in the repo-local config,
  * where `git config --unset-all` removes it. Since v6.0.0 (backported to
  * v5.0.1 and v4.3.1) the header is written to a separate file under
- * RUNNER_TEMP that the repo config pulls in via `include.path`; `--unset-all`
- * on the local config cannot touch an include-provided value, so the removal
- * was a silent no-op and the checkout credential (typically the workflow
- * GITHUB_TOKEN) stayed usable by git for the rest of the job. Clear the
- * header from the local config AND from every included file so it can no
- * longer authenticate while Claude runs.
+ * RUNNER_TEMP that the repo config pulls in via `include.path` or
+ * `includeIf.gitdir:*.path`; `--unset-all` on the local config cannot touch an
+ * include-provided value, so the removal was a silent no-op and the checkout
+ * credential (typically the workflow GITHUB_TOKEN) stayed usable by git for
+ * the rest of the job. Clear the header from every config file that contributes
+ * an active value so it can no longer authenticate while Claude runs.
  */
 export async function replaceCheckoutCredentials(
   githubToken: string,
@@ -78,26 +78,28 @@ export async function replaceCheckoutCredentials(
   const extraheaderKey = `http.${GITHUB_SERVER_URL}/.extraheader`;
   let removedHeader = false;
   try {
-    await $`git config --unset-all ${extraheaderKey}`;
-    removedHeader = true;
-  } catch {
-    // No extraheader in the local config (expected on the v6+ include layout).
-  }
-  try {
-    const includePaths =
-      await $`git config --local --get-all include.path`.text();
-    for (const includePath of includePaths.split("\n")) {
-      const path = includePath.trim();
-      if (!path) continue;
+    const configOrigins =
+      await $`git config --local --includes --null --show-origin --get-all ${extraheaderKey}`.text();
+    const originFields = configOrigins.split("\0");
+    const configPaths = new Set<string>();
+    for (let index = 0; index + 1 < originFields.length; index += 2) {
+      const origin = originFields[index];
+      if (origin.startsWith("file:")) {
+        configPaths.add(origin.slice("file:".length));
+      }
+    }
+
+    for (const path of configPaths) {
       try {
         await $`git config --file ${path} --unset-all ${extraheaderKey}`;
         removedHeader = true;
       } catch {
-        // This include does not define the header; leave it untouched.
+        // The value may have been removed concurrently; continue with the
+        // remaining config origins.
       }
     }
   } catch {
-    // No include.path entries in the local config.
+    // No active checkout extraheader in the local config or its includes.
   }
   console.log(
     removedHeader

--- a/test/git-config.test.ts
+++ b/test/git-config.test.ts
@@ -50,6 +50,22 @@ function gitConfigGetAll(key: string): string {
   }
 }
 
+function gitConfigGetAllWithIncludes(key: string): string {
+  try {
+    return runGit(["config", "--local", "--includes", "--get-all", key]);
+  } catch {
+    return "";
+  }
+}
+
+function gitConfigFileGetAll(path: string, key: string): string {
+  try {
+    return runGit(["config", "--file", path, "--get-all", key]);
+  } catch {
+    return "";
+  }
+}
+
 function remoteUrl(): string {
   return runGit(["remote", "get-url", "origin"]);
 }
@@ -148,6 +164,62 @@ describe("git-config", () => {
       expect(gitConfigGetAll("credential.helper")).toBe(helperPath);
       expect(statSync(helperPath).mode & 0o777).toBe(0o700);
       expect(process.env.GH_TOKEN).toBe("helper-token");
+    });
+
+    test("removes the checkout extraheader from an ordinary include", async () => {
+      git(["config", "--local", "--unset-all", EXTRAHEADER_KEY]);
+      const credentialConfig = join(tempDir, "checkout credentials");
+      runGit([
+        "config",
+        "--file",
+        credentialConfig,
+        "--add",
+        EXTRAHEADER_KEY,
+        "AUTHORIZATION: basic included",
+      ]);
+      git(["config", "--local", "--add", "include.path", credentialConfig]);
+
+      expect(gitConfigGetAllWithIncludes(EXTRAHEADER_KEY)).toContain(
+        "AUTHORIZATION",
+      );
+
+      await replaceCheckoutCredentials(
+        "test-token",
+        createMockAutomationContext(),
+      );
+
+      expect(gitConfigFileGetAll(credentialConfig, EXTRAHEADER_KEY)).toBe("");
+      expect(gitConfigGetAllWithIncludes(EXTRAHEADER_KEY)).toBe("");
+      expect(gitConfigGetAll("include.path")).toBe(credentialConfig);
+    });
+
+    test("removes the checkout extraheader from a checkout v7 includeIf", async () => {
+      git(["config", "--local", "--unset-all", EXTRAHEADER_KEY]);
+      const credentialConfig = join(tempDir, "checkout v7 credentials");
+      runGit([
+        "config",
+        "--file",
+        credentialConfig,
+        "--add",
+        EXTRAHEADER_KEY,
+        "AUTHORIZATION: basic conditional",
+      ]);
+      const gitDir = runGit(["rev-parse", "--absolute-git-dir"], repoDir);
+      const includeKey = `includeIf.gitdir:${gitDir}.path`;
+      git(["config", "--local", "--add", includeKey, credentialConfig]);
+
+      expect(gitConfigGetAllWithIncludes(EXTRAHEADER_KEY)).toContain(
+        "AUTHORIZATION",
+      );
+
+      await replaceCheckoutCredentials(
+        "test-token",
+        createMockAutomationContext(),
+      );
+
+      expect(gitConfigFileGetAll(credentialConfig, EXTRAHEADER_KEY)).toBe("");
+      expect(gitConfigGetAllWithIncludes(EXTRAHEADER_KEY)).toBe("");
+      expect(gitConfigGetAll(includeKey)).toBe(credentialConfig);
     });
 
     test("succeeds when there is no checkout extraheader to remove", async () => {


### PR DESCRIPTION
## Summary

- discover active checkout authorization headers from their Git config origins
- remove headers contributed through both `include.path` and checkout v7 `includeIf.gitdir` files
- preserve the include entries while replacing the effective Git credential
- add regression coverage for ordinary and conditional include layouts, including config paths with spaces

## Why

`actions/checkout@v7` persists its credential through `includeIf.gitdir:*`, so scanning only `include.path` leaves the workflow `GITHUB_TOKEN` active. Git can then prefer that header over the action token, suppressing downstream workflow events for agent pushes.

## Verification

- `bun test test/git-config.test.ts` (6 passed)
- `bun build src/github/operations/git-config.ts --target bun`
- `git diff --check`

Closes #1721.