### PR TITLE
chore: remove orphaned dead code from v1.0 entrypoint consolidation

### DIFF
--- a/a.patch
+++ b/a.patch
@@ -1,0 +1,193 @@
+diff --git a/src/entrypoints/prepare.ts b/src/entrypoints/prepare.ts
+deleted file mode 100644
+index 553bdb6..0000000
+--- a/src/entrypoints/prepare.ts
++++ /dev/null
+@@ -1,103 +0,0 @@
+-#!/usr/bin/env bun
+-
+-/**
+- * Prepare the Claude action by checking trigger conditions, verifying human actor,
+- * and creating the initial tracking comment
+- */
+-
+-import * as core from "@actions/core";
+-import { setupGitHubToken } from "../github/token";
+-import { checkWritePermissions } from "../github/validation/permissions";
+-import { createOctokit } from "../github/api/client";
+-import {
+-  parseGitHubContext,
+-  isEntityContext,
+-  isWorkflowRunEvent,
+-} from "../github/context";
+-import { detectMode } from "../modes/detector";
+-import { prepareTagMode } from "../modes/tag";
+-import { prepareAgentMode } from "../modes/agent";
+-import { checkContainsTrigger } from "../github/validation/trigger";
+-import { collectActionInputsPresence } from "./collect-inputs";
+-
+-async function run() {
+-  try {
+-    collectActionInputsPresence();
+-
+-    // Parse GitHub context first to enable mode detection
+-    const context = parseGitHubContext();
+-
+-    // Auto-detect mode based on context
+-    const modeName = detectMode(context);
+-    console.log(
+-      `Auto-detected mode: ${modeName} for event: ${context.eventName}`,
+-    );
+-
+-    // Setup GitHub token
+-    const githubToken = await setupGitHubToken();
+-    const octokit = createOctokit(githubToken);
+-
+-    // Step 3: Check write permissions (entity contexts and workflow_run)
+-    if (isEntityContext(context) || isWorkflowRunEvent(context)) {
+-      // Check if github_token was provided as input (not from app)
+-      const githubTokenProvided = !!process.env.OVERRIDE_GITHUB_TOKEN;
+-      const hasWritePermissions = await checkWritePermissions(
+-        octokit.rest,
+-        context,
+-        context.inputs.allowedNonWriteUsers,
+-        githubTokenProvided,
+-      );
+-      if (!hasWritePermissions) {
+-        throw new Error(
+-          "Actor does not have write permissions to the repository",
+-        );
+-      }
+-    }
+-
+-    // Check trigger conditions
+-    const containsTrigger =
+-      modeName === "tag"
+-        ? isEntityContext(context) && checkContainsTrigger(context)
+-        : !!context.inputs?.prompt;
+-
+-    // Debug logging
+-    console.log(`Mode: ${modeName}`);
+-    console.log(`Context prompt: ${context.inputs?.prompt || "NO PROMPT"}`);
+-    console.log(`Trigger result: ${containsTrigger}`);
+-
+-    // Set output for action.yml to check
+-    core.setOutput("contains_trigger", containsTrigger.toString());
+-
+-    if (!containsTrigger) {
+-      console.log("No trigger found, skipping remaining steps");
+-      // Still set github_token output even when skipping
+-      core.setOutput("github_token", githubToken);
+-      return;
+-    }
+-
+-    // Run prepare
+-    console.log(
+-      `Preparing with mode: ${modeName} for event: ${context.eventName}`,
+-    );
+-    if (modeName === "tag") {
+-      await prepareTagMode({ context, octokit, githubToken });
+-    } else {
+-      await prepareAgentMode({ context, octokit, githubToken });
+-    }
+-
+-    // MCP config is handled by individual modes (tag/agent) and included in their claude_args output
+-
+-    // Expose the GitHub token (Claude App token) as an output
+-    core.setOutput("github_token", githubToken);
+-  } catch (error) {
+-    const errorMessage = error instanceof Error ? error.message : String(error);
+-    core.setFailed(`Prepare step failed with error: ${errorMessage}`);
+-    // Also output the clean error message for the action to capture
+-    core.setOutput("prepare_error", errorMessage);
+-    process.exit(1);
+-  }
+-}
+-
+-if (import.meta.main) {
+-  run();
+-}
+diff --git a/src/github/operations/comments/update-with-branch.ts b/src/github/operations/comments/update-with-branch.ts
+deleted file mode 100644
+index 838b154..0000000
+--- a/src/github/operations/comments/update-with-branch.ts
++++ /dev/null
+@@ -1,57 +0,0 @@
+-#!/usr/bin/env bun
+-
+-/**
+- * Update the initial tracking comment with branch link
+- * This happens after the branch is created for issues
+- */
+-
+-import {
+-  createJobRunLink,
+-  createBranchLink,
+-  createCommentBody,
+-} from "./common";
+-import { type Octokits } from "../../api/client";
+-import {
+-  isPullRequestReviewCommentEvent,
+-  type ParsedGitHubContext,
+-} from "../../context";
+-import { updateClaudeComment } from "./update-claude-comment";
+-
+-export async function updateTrackingComment(
+-  octokit: Octokits,
+-  context: ParsedGitHubContext,
+-  commentId: number,
+-  branch?: string,
+-) {
+-  const { owner, repo } = context.repository;
+-
+-  const jobRunLink = createJobRunLink(owner, repo, context.runId);
+-
+-  // Add branch link for issues (not PRs)
+-  let branchLink = "";
+-  if (branch && !context.isPR) {
+-    branchLink = createBranchLink(owner, repo, branch);
+-  }
+-
+-  const updatedBody = createCommentBody(jobRunLink, branchLink);
+-
+-  // Update the existing comment with the branch link
+-  try {
+-    const isPRReviewComment = isPullRequestReviewCommentEvent(context);
+-
+-    await updateClaudeComment(octokit.rest, {
+-      owner,
+-      repo,
+-      commentId,
+-      body: updatedBody,
+-      isPullRequestReviewComment: isPRReviewComment,
+-    });
+-
+-    console.log(
+-      `✅ Updated ${isPRReviewComment ? "PR review" : "issue"} comment ${commentId} with branch link`,
+-    );
+-  } catch (error) {
+-    console.error("Error updating comment with branch link:", error);
+-    throw error;
+-  }
+-}
+diff --git a/src/github/validation/trigger.ts b/src/github/validation/trigger.ts
+index 41c9e32..8e05f1d 100644
+--- a/src/github/validation/trigger.ts
++++ b/src/github/validation/trigger.ts
+@@ -1,6 +1,5 @@
+ #!/usr/bin/env bun
+ 
+-import * as core from "@actions/core";
+ import {
+   isIssuesEvent,
+   isIssuesAssignedEvent,
+@@ -147,9 +146,3 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
+ export function escapeRegExp(string: string) {
+   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+ }
+-
+-export async function checkTriggerAction(context: ParsedGitHubContext) {
+-  const containsTrigger = checkContainsTrigger(context);
+-  core.setOutput("contains_trigger", containsTrigger.toString());
+-  return containsTrigger;
+-}


### PR DESCRIPTION
Closes #1668.

## What this does

Removes the three confirmed-dead pieces of code from the v1.0 `run.ts` consolidation:

1. **`src/entrypoints/prepare.ts`** (103 lines) — orphaned duplicate of the prepare phase. `action.yml` only ever invokes `run.ts`, `cleanup-ssh-signing.ts`, and `post-buffered-inline-comments.ts`; nothing imports this file.
2. **`updateTrackingComment`** (`src/github/operations/comments/update-with-branch.ts`) — the file's only export, no callers. Superseded by `updateCommentLink` via `checkAndCommitOrDeleteBranch`.
3. **`checkTriggerAction`** (`src/github/validation/trigger.ts`) — thin wrapper around `checkContainsTrigger` that also set a `contains_trigger` output nobody declares in `action.yml`. Removed the now-unused `@actions/core` import along with it; `ParsedGitHubContext` stays, since `checkContainsTrigger` still needs it.

## On the confirmation question in the issue

The issue asks for confirmation that `prepare.ts` is genuinely dead before opening a PR. I re-ran the same checks independently against current `main`:

```
$ grep -rn "entrypoints/prepare" --include="*.ts" --include="*.yml" src action.yml test base-action
(no output)
```

Same for `updateTrackingComment` and `checkTriggerAction` — each symbol's only match is its own definition. I also confirmed `action.yml` never declares a `contains_trigger` output, and checked `test/prepare-context.test.ts` isn't related (it tests `prepareContext` from `src/create-prompt`, unconnected to the deleted `prepare.ts` entrypoint — naming coincidence).

## Item 4 — left untouched

Per the issue, the `ALLOWED_TOOLS`/`DISALLOWED_TOOLS` dead env var exports in `src/create-prompt/index.ts` are intentionally **not** touched here. The existing code comment says they're kept so an H1 report's referenced file stays in sync with the live fix — that's a maintainer call, not mine.

## Testing

I don't have a working `bun` toolchain in the environment I used to prepare this, so I wasn't able to run `bun test` / `bun run typecheck` / `bun run format:check` myself. The change is a pure deletion (no logic touched in surviving code besides the one import), but please treat CI as the real verification here rather than my word for it.