### PR TITLE
fix: percent-encode parentheses in compare link branch names

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -20,6 +20,7 @@ import {
 import type { ParsedGitHubContext } from "../github/context";
 import type { CommonFields, PreparedContext, EventData } from "./types";
 import { GITHUB_SERVER_URL } from "../github/api/config";
+import { encodeBranchNameForUrl } from "../github/operations/comments/common";
 import { extractUserRequest } from "../utils/extract-user-request";
 export type { CommonFields, PreparedContext } from "./types";
 
@@ -602,7 +603,7 @@ ${
   eventData.claudeBranch
     ? `
 When done with changes, provide a PR link:
-[Create a PR](${GITHUB_SERVER_URL}/${context.repository}/compare/${eventData.baseBranch}...${eventData.claudeBranch}?quick_pull=1&title=<url-encoded-title>&body=<url-encoded-body>)
+[Create a PR](${GITHUB_SERVER_URL}/${context.repository}/compare/${encodeBranchNameForUrl(eventData.baseBranch ?? "")}...${encodeBranchNameForUrl(eventData.claudeBranch ?? "")}?quick_pull=1&title=<url-encoded-title>&body=<url-encoded-body>)
 Use THREE dots (...) between branches. URL-encode all parameters.`
     : ""
 }

--- a/src/github/operations/comments/common.ts
+++ b/src/github/operations/comments/common.ts
@@ -14,7 +14,17 @@ export function createJobRunLink(
 
 /** Encode Git-ref path segments without turning `/` into `%2F`. */
 export function encodeBranchNameForUrl(branchName: string): string {
-  return branchName.split("/").map(encodeURIComponent).join("/");
+  // encodeURIComponent deliberately leaves `(` and `)` unescaped, but both
+  // terminate a markdown link destination early (#1710 made them legal in
+  // branch names), so they are escaped explicitly here.
+  return branchName
+    .split("/")
+    .map((segment) =>
+      encodeURIComponent(segment)
+        .replace(/\(/g, "%28")
+        .replace(/\)/g, "%29"),
+    )
+    .join("/");
 }
 
 export function createBranchLink(

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -235,6 +235,40 @@ describe("generatePrompt", () => {
     );
   });
 
+  test("encodes branch names with special characters in the compare link", async () => {
+    const envVars: PreparedContext = {
+      repository: "owner/repo",
+      claudeCommentId: "12345",
+      triggerPhrase: "@claude",
+      eventData: {
+        eventName: "issues",
+        eventAction: "assigned",
+        isPR: false,
+        issueNumber: "1001",
+        baseBranch: "main",
+        claudeBranch: "claude/feat(parser)-handle-empty-input",
+        assigneeTrigger: "claude-bot",
+      },
+    };
+
+    // The pre-built compare link lives in the simple-prompt template.
+    process.env.USE_SIMPLE_PROMPT = "true";
+    try {
+      const prompt = await generatePrompt(envVars, mockGitHubData, false, "tag");
+
+      const line = prompt.split("\n").filter((l) => l.includes("compare/main...")).join("\n---\n");
+      expect(line).toBeDefined();
+      // Parentheses must be percent-encoded so they cannot terminate the
+      // markdown link early; path slashes stay literal.
+      expect(line).toContain(
+        "compare/main...claude/feat%28parser%29-handle-empty-input?",
+      );
+      expect(line).not.toContain("feat(parser)-handle-empty-input?");
+    } finally {
+      delete process.env.USE_SIMPLE_PROMPT;
+    }
+  });
+
   test("should generate prompt for issue labeled event", async () => {
     const envVars: PreparedContext = {
       repository: "owner/repo",


### PR DESCRIPTION
## What

`encodeBranchNameForUrl` relied on `encodeURIComponent`, which deliberately leaves parentheses unescaped. The pre-built compare link in `create-prompt` also interpolated branch names without going through the helper at all.

## Why

#1710 made parentheses legal in branch names, and #1713 added this helper to encode branch names in links, but the combination still breaks: a branch like `claude/feat(parser)-handle-empty-input` renders as a markdown link whose destination terminates at the first `)`, truncating the query string and pointing users at a dead URL.

## Change

- Escape `(` and `)` explicitly in `encodeBranchNameForUrl` after `encodeURIComponent`, so all five existing call sites become parenthesis-safe.
- Route the compare link in `create-prompt` through the helper (it was interpolating raw values).
- Regression test builds the prompt for a parenthesised branch and asserts the percent-encoded form.

## Verification

```
$ bun test test/create-prompt.test.ts
51 pass, 0 fail          # includes the new regression test

# with only the helper change reverted:
1 fail                   # raw parens reappear in the link
```