### PR TITLE
fix: restore package-manager config (.pnpmfile.cjs/.npmrc/.yarnrc.yml) from base to close install-time RCE

### DIFF
--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -31,11 +31,11 @@ import { fetchDepthArgs } from "./fetch-depth";
 //                       install scripts.
 //
 // Deliberately excluded from the CLI's broader auto-edit blocklist:
-// .git/ — not tracked by git; PR commits cannot place files there.
-// Restoring it would also undo the PR checkout entirely.
-// .gitconfig — git reads ~/.gitconfig and .git/config, never cwd/.gitconfig.
-// .bashrc etc. — shells source these from $HOME; checkout cannot reach $HOME.
-// .vscode/.idea— IDE config; nothing in the CLI's startup path reads them.
+//   .git/        — not tracked by git; PR commits cannot place files there.
+//                  Restoring it would also undo the PR checkout entirely.
+//   .gitconfig   — git reads ~/.gitconfig and .git/config, never cwd/.gitconfig.
+//   .bashrc etc. — shells source these from $HOME; checkout cannot reach $HOME.
+//   .vscode/.idea— IDE config; nothing in the CLI's startup path reads them.
 export const SENSITIVE_PATHS = [
   ".claude",
   ".mcp.json",

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -27,8 +27,13 @@ import { fetchDepthArgs } from "./fetch-depth";
 //                       `--ignore-scripts`.
 //       .yarnrc.yml   — `yarnPath` / `plugins` point to JS that Yarn loads and
 //                       executes on any command, including install.
+//       .yarnrc       — Yarn Classic's `yarn-path` points to JS that Yarn 1
+//                       runs as its binary on any command, including install —
+//                       the pre-Berry equivalent of `.yarnrc.yml`.
 //       .npmrc        — can redirect the registry (supply-chain) and re-enable
 //                       install scripts.
+//       bunfig.toml   — `preload` runs JS on `bun run`/`bun test`, and
+//                       `[install].registry` can redirect the registry.
 //
 // Deliberately excluded from the CLI's broader auto-edit blocklist:
 //   .git/        — not tracked by git; PR commits cannot place files there.
@@ -48,6 +53,8 @@ export const SENSITIVE_PATHS = [
   ".pnpmfile.cjs",
   ".npmrc",
   ".yarnrc.yml",
+  ".yarnrc",
+  "bunfig.toml",
 ];
 
 const CLAUDE_PR_EXCLUDE_PATTERN = "/.claude-pr/";

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -15,14 +15,27 @@ import {
 import { dirname, join, posix, relative, sep } from "path";
 import { fetchDepthArgs } from "./fetch-depth";
 
-// Paths that are both PR-controllable and read from cwd at CLI startup.
+// Paths that are PR-controllable AND auto-loaded or auto-executed from cwd
+// before any meaningful review — either by the CLI at startup, or by tooling
+// the action/agent routinely invokes while working on a task:
+//   - CLI startup reads: .claude/, .mcp.json, .claude.json, CLAUDE.md, ...
+//   - git operations the action performs: .husky (hooks run on commit),
+//     .gitmodules (read on fetch)
+//   - package-manager config executed on `install` (a routine agent step):
+//       .pnpmfile.cjs — top-level JS that pnpm runs on install; it is config,
+//                       not a lifecycle script, so it executes even under
+//                       `--ignore-scripts`.
+//       .yarnrc.yml   — `yarnPath` / `plugins` point to JS that Yarn loads and
+//                       executes on any command, including install.
+//       .npmrc        — can redirect the registry (supply-chain) and re-enable
+//                       install scripts.
 //
 // Deliberately excluded from the CLI's broader auto-edit blocklist:
-//   .git/        — not tracked by git; PR commits cannot place files there.
-//                  Restoring it would also undo the PR checkout entirely.
-//   .gitconfig   — git reads ~/.gitconfig and .git/config, never cwd/.gitconfig.
-//   .bashrc etc. — shells source these from $HOME; checkout cannot reach $HOME.
-//   .vscode/.idea— IDE config; nothing in the CLI's startup path reads them.
+// .git/ — not tracked by git; PR commits cannot place files there.
+// Restoring it would also undo the PR checkout entirely.
+// .gitconfig — git reads ~/.gitconfig and .git/config, never cwd/.gitconfig.
+// .bashrc etc. — shells source these from $HOME; checkout cannot reach $HOME.
+// .vscode/.idea— IDE config; nothing in the CLI's startup path reads them.
 export const SENSITIVE_PATHS = [
   ".claude",
   ".mcp.json",
@@ -32,6 +45,9 @@ export const SENSITIVE_PATHS = [
   "CLAUDE.md",
   "CLAUDE.local.md",
   ".husky",
+  ".pnpmfile.cjs",
+  ".npmrc",
+  ".yarnrc.yml",
 ];
 
 const CLAUDE_PR_EXCLUDE_PATTERN = "/.claude-pr/";

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -425,6 +425,46 @@ describe("restoreConfigFromBase", () => {
     ).toEqual([".claude/settings.json", "CLAUDE.md"]);
   });
 
+  test("removes a PR-added .pnpmfile.cjs and preserves it for review", () => {
+    // A fork PR plants a .pnpmfile.cjs. pnpm executes its top-level code on
+    // `pnpm install` — even with --ignore-scripts — so a routine install run
+    // by the agent would execute it. It does not exist on base.
+    writeRepoFile(
+      ".pnpmfile.cjs",
+      "require('fs').writeFileSync('/tmp/pwned', 'x');\nmodule.exports = {};\n",
+    );
+    git(["add", ".pnpmfile.cjs"]);
+    git(["commit", "-m", "pr adds pnpmfile"]);
+
+    restoreConfigFromBase("main");
+
+    // Gone from the tree the agent operates on...
+    expect(existsRepoFile(".pnpmfile.cjs")).toBe(false);
+    // ...but still inspectable in the read-only review snapshot.
+    expect(readRepoFile(".claude-pr/.pnpmfile.cjs")).toContain("/tmp/pwned");
+  });
+
+  test("restores a PR-modified .npmrc to the base version", () => {
+    git(["checkout", "main"]);
+    writeRepoFile(".npmrc", "registry=https://registry.npmjs.org/\n");
+    git(["add", ".npmrc"]);
+    git(["commit", "-m", "base adds npmrc"]);
+    git(["push", "origin", "main"]);
+    git(["checkout", "pr"]);
+    writeRepoFile(".npmrc", "registry=https://evil.example.com/\n");
+    git(["add", ".npmrc"]);
+    git(["commit", "-m", "pr repoints registry"]);
+
+    restoreConfigFromBase("main");
+
+    expect(readRepoFile(".npmrc")).toBe(
+      "registry=https://registry.npmjs.org/\n",
+    );
+    expect(readRepoFile(".claude-pr/.npmrc")).toBe(
+      "registry=https://evil.example.com/\n",
+    );
+  });
+
   function git(args: string[]): string {
     return execFileSync("git", args, {
       cwd: repoDir,

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -465,6 +465,38 @@ describe("restoreConfigFromBase", () => {
     );
   });
 
+  test("removes a PR-added .yarnrc and preserves it for review", () => {
+    // A fork PR plants a Yarn Classic .yarnrc whose `yarn-path` points at
+    // PR-controlled JS; Yarn 1 runs that file as its binary on any yarn command
+    // (install included) — the pre-Berry equivalent of .yarnrc.yml. Not on base.
+    writeRepoFile(".yarnrc", 'yarn-path "./.yarn/pr.cjs"\n');
+    git(["add", ".yarnrc"]);
+    git(["commit", "-m", "pr adds yarnrc"]);
+
+    restoreConfigFromBase("main");
+
+    // Gone from the tree the agent operates on...
+    expect(existsRepoFile(".yarnrc")).toBe(false);
+    // ...but still inspectable in the read-only review snapshot.
+    expect(readRepoFile(".claude-pr/.yarnrc")).toContain("yarn-path");
+  });
+
+  test("removes a PR-added bunfig.toml and preserves it for review", () => {
+    // A fork PR plants a bunfig.toml whose `preload` runs PR-controlled JS on
+    // `bun run`/`bun test`; the action routinely invokes bun, so this would
+    // execute. It does not exist on base.
+    writeRepoFile("bunfig.toml", 'preload = ["./.pr-preload.ts"]\n');
+    git(["add", "bunfig.toml"]);
+    git(["commit", "-m", "pr adds bunfig"]);
+
+    restoreConfigFromBase("main");
+
+    // Gone from the tree the agent operates on...
+    expect(existsRepoFile("bunfig.toml")).toBe(false);
+    // ...but still inspectable in the read-only review snapshot.
+    expect(readRepoFile(".claude-pr/bunfig.toml")).toContain("preload");
+  });
+
   function git(args: string[]): string {
     return execFileSync("git", args, {
       cwd: repoDir,


### PR DESCRIPTION
## Summary

`restoreConfigFromBase` reverts PR-controlled config that gets auto-loaded or
auto-executed from `cwd` back to the reviewed base version, so a fork PR can't
run code before/while the agent works. The list already covers `.husky`
(git hooks that run on the routine `git commit` the agent performs) and
`.gitmodules` (read on fetch), but it omits the package-manager equivalents.

This adds `.pnpmfile.cjs`, `.npmrc`, and `.yarnrc.yml` — the same three files
Claude Code itself already recognizes as sensitive config.

## Why these are the same class as `.husky`

Installing dependencies is a routine, expected agent step in JS repos ("set up
the project", "run the tests", "add a dep"). A fork PR that plants one of these
gets code execution the moment that install runs:

- **`.pnpmfile.cjs`** — pnpm loads and runs its top-level JS on install/resolve.
  It's *config*, not a lifecycle script, so it executes **even under
  `--ignore-scripts`**. "ignore-scripts makes install safe" does not hold for
  this file. Reproduced on pnpm 11.21.0 / Node 24.19.0 — in an empty directory
  containing only:

  ```jsonc
  // package.json
  {"name":"t","version":"1.0.0"}
  ```
  ```js
  // .pnpmfile.cjs
  require('fs').writeFileSync('pnpmfile-ran','1'); module.exports = {};
  ```
  ```console
  $ pnpm install --ignore-scripts --offline
  Already up to date

  Done in 638ms using pnpm v11.21.0
  $ ls pnpmfile-ran
  pnpmfile-ran
  ```

  The marker file is created, so the pnpmfile ran. Renaming `.pnpmfile.cjs` away
  and re-running leaves no marker, confirming that file is the source. The
  fixture has no dependencies at all, so this is the pnpmfile itself executing,
  not a package lifecycle script.
- **`.yarnrc.yml`** — `yarnPath` / `plugins` point to JS that Yarn loads and
  executes on any command, install included.
- **`.npmrc`** — can redirect the registry (supply-chain) and re-enable install
  scripts.

This is the same pattern that justified `.husky`: a PR-planted file that runs
arbitrary code when the agent performs an ordinary operation (`git commit` →
`pnpm install`).

## Scope / honesty

This is **defense-in-depth for the fork-PR vector**, not a claim of a new
zero-click auto-trigger — nothing here runs at CLI startup on its own. It closes
the gap where a maintainer relies on the model to notice a disguised
`.pnpmfile.cjs` before running `install`; model judgment is probabilistic and
model-dependent, so a deterministic revert-to-base is the right backstop. The
tradeoff is identical to the existing entries: the PR-authored version is still
snapshotted to `.claude-pr/` for review agents to inspect (never executed), and
only PR-head *changes* are reverted — a legitimate base `.npmrc`/`.yarnrc.yml`
is preserved.

## Changes

- Add `.pnpmfile.cjs`, `.npmrc`, `.yarnrc.yml` to `SENSITIVE_PATHS`.
- Expand the block comment so the list's rationale stays accurate (covers files
  executed by tooling the agent routinely runs, not only CLI-startup reads).
- Tests: a PR-added `.pnpmfile.cjs` is removed from the working tree but kept in
  `.claude-pr/` for review; a PR-modified `.npmrc` is restored to base.

## Testing

- Added two unit tests in `test/restore-config.test.ts` covering the new paths (a PR-added `.pnpmfile.cjs` is removed and snapshotted to `.claude-pr/`; a PR-modified `.npmrc` is restored to base).
- `bun run typecheck` passes locally.
- Note: the full `bun test` suite has pre-existing symlink/autocrlf failures on Windows unrelated to this change (they reproduce on `main` too); the new tests are written in the same style as the existing ones and rely on CI (Linux) as the real signal.

Happy to trim to just `.pnpmfile.cjs` (the clearest-cut case) if you'd prefer
the most minimal change.

