### PR TITLE
fix(docs): update removed allowed_tools reference and simplify dead ternary

### DIFF
--- a/docs/capabilities-and-limitations.md
+++ b/docs/capabilities-and-limitations.md
@@ -19,7 +19,7 @@
 - **Approve PRs**: For security reasons, Claude cannot approve pull requests
 - **Post Multiple Comments**: Claude only acts by updating its initial comment
 - **Execute Commands Outside Its Context**: Claude only has access to the repository and PR/issue context it's triggered in
-- **Run Arbitrary Bash Commands**: By default, Claude cannot execute Bash commands unless explicitly allowed using the `allowed_tools` configuration
+- **Run Arbitrary Bash Commands**: By default, Claude cannot execute Bash commands unless explicitly allowed via `claude_args` with `--allowedTools`
 - **Perform Branch Operations**: Cannot merge branches, rebase, or perform other git operations beyond pushing commits
 
 ## How It Works

--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -125,9 +125,7 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     isIssueCommentEvent(context) ||
     isPullRequestReviewCommentEvent(context)
   ) {
-    const commentBody = isIssueCommentEvent(context)
-      ? context.payload.comment.body
-      : context.payload.comment.body;
+    const commentBody = context.payload.comment.body;
     // Check for exact match with word boundaries or punctuation
     const regex = new RegExp(
       `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,


### PR DESCRIPTION
## Summary

Fixes #1670

- **`docs/capabilities-and-limitations.md`**: Replace the removed `allowed_tools` input reference with the current `claude_args` with `--allowedTools` guidance. This was the only remaining place where `allowed_tools` was presented as live instruction (other docs correctly mark it as deprecated).

- **`src/github/validation/trigger.ts`** (L128-130): Collapse identical ternary branches into a single assignment. Both `IssueCommentEvent` and `PullRequestReviewCommentEvent` expose `payload.comment.body`, so the discriminated-union narrowing was redundant — no behavior change.

## Test plan

- [x] Verified no other occurrences of `allowed_tools` presented as current guidance
- [x] Confirmed both event types expose `payload.comment.body` (discriminated union already narrowed by enclosing `if`)
- [x] No functional change — docs-only + dead code simplification