### PR TITLE
fix: preserve repeated plugin-dir arguments

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -20,6 +20,7 @@ const ACCUMULATING_FLAGS = new Set([
   "disallowed-tools",
   "mcp-config",
   "add-dir",
+  "plugin-dir",
 ]);
 
 // Delimiter used to join accumulated flag values

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -280,7 +280,19 @@ describe("parseSdkOptions", () => {
       expect(result.sdkOptions.disallowedTools).toEqual(["Bash", "Write"]);
     });
   });
+  describe("plugin-dir accumulation", () => {
+    test("should preserve repeated --plugin-dir flags", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--plugin-dir ./plugin-a --plugin-dir ./plugin-b",
+      };
 
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.extraArgs?.["plugin-dir"]).toBe(
+        "./plugin-a\x00./plugin-b",
+      );
+    });
+  });
   describe("mcp-config merging", () => {
     test("should pass through single mcp-config in extraArgs", () => {
       const options: ClaudeOptions = {


### PR DESCRIPTION
## Summary

- add `plugin-dir` to `ACCUMULATING_FLAGS`
- preserve repeated `--plugin-dir` values instead of keeping only the final value
- add a focused regression test covering multiple plugin directories

Fixes #1728.

## Testing

- Focused parser suite: 42 passed, 0 failed
- TypeScript typecheck passed
- Prettier check passed
- Full Windows run: 916 passed; remaining failures occurred outside the focused parser suite