### PR TITLE
fix(base-action): validate max_turns to prevent NaN reaching the SDK

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -25,6 +25,24 @@ const ACCUMULATING_FLAGS = new Set([
 // Delimiter used to join accumulated flag values
 const ACCUMULATE_DELIMITER = "\x00";
 
+/**
+ * Parse a maxTurns value into a number, failing loudly on values that would
+ * otherwise silently disable the turn limit. parseInt() returns NaN for
+ * non-numeric input (e.g. a typo in the workflow file), and the SDK serializes
+ * NaN to null in JSON, so the limit would be silently dropped. Rejecting NaN
+ * and negative values here surfaces the mistake instead of running unbounded.
+ */
+function parseMaxTurns(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    throw new Error(
+      `Invalid max_turns value: "${value}". Must be a non-negative integer.`,
+    );
+  }
+  return parsed;
+}
+
 // shell-quote treats ()|&;<> as control operators and splits adjacent text
 // around them into separate tokens (returned as `{op}` objects, which we then
 // dropped). For CLI args these must be literal characters — e.g. unquoted
@@ -315,11 +333,9 @@ export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   const sdkOptions: SdkOptions = {
     // Direct options from ClaudeOptions inputs
     model: options.model || modelFromClaudeArgs,
-    maxTurns: options.maxTurns
-      ? parseInt(options.maxTurns, 10)
-      : maxTurnsFromClaudeArgs
-        ? parseInt(maxTurnsFromClaudeArgs, 10)
-        : undefined,
+    maxTurns: parseMaxTurns(
+      options.maxTurns || maxTurnsFromClaudeArgs,
+    ),
     allowedTools:
       mergedAllowedTools.length > 0 ? mergedAllowedTools : undefined,
     disallowedTools:

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -544,6 +544,46 @@ describe("parseSdkOptions", () => {
       expect(result.sdkOptions.maxTurns).toBe(25);
       expect(result.sdkOptions.extraArgs?.["max-turns"]).toBeUndefined();
     });
+
+    test("should reject non-numeric max-turns in claudeArgs instead of passing NaN", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--max-turns abc",
+      };
+
+      expect(() => parseSdkOptions(options)).toThrow(
+        'Invalid max_turns value: "abc". Must be a non-negative integer.',
+      );
+    });
+
+    test("should reject non-numeric maxTurns input instead of passing NaN", () => {
+      const options: ClaudeOptions = {
+        maxTurns: "abc",
+      };
+
+      expect(() => parseSdkOptions(options)).toThrow(
+        'Invalid max_turns value: "abc". Must be a non-negative integer.',
+      );
+    });
+
+    test("should reject negative max-turns in claudeArgs", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--max-turns -5",
+      };
+
+      expect(() => parseSdkOptions(options)).toThrow(
+        'Invalid max_turns value: "-5". Must be a non-negative integer.',
+      );
+    });
+
+    test("should allow zero max-turns (no limit)", () => {
+      const options: ClaudeOptions = {
+        claudeArgs: "--max-turns 0",
+      };
+
+      const result = parseSdkOptions(options);
+
+      expect(result.sdkOptions.maxTurns).toBe(0);
+    });
   });
 
   describe("environment variables passthrough", () => {


### PR DESCRIPTION
`parseInt()` returns `NaN` for non-numeric values (e.g. a typo in `max_turns` or `--max-turns` in `claude_args`), and the SDK serializes `NaN` to `null` in JSON, so the turn limit is silently dropped and the run proceeds unbounded. This also defeats the post-run check in `run-claude-sdk.ts` (`num_turns > maxTurns` is false for `NaN`).

Invalid values now throw a clear error instead of silently disabling the limit.

- Validates both the `max_turns` input and `--max-turns` from `claude_args`
- Rejects non-numeric and negative values; zero, decimals, and existing precedence behavior are unchanged
- 4 new tests, 168 total pass, `tsc --noEmit` clean