### PR TITLE
fix(sanitizer): normalize HTML entities before stripping hidden attributes

### DIFF
--- a/src/github/utils/sanitizer.ts
+++ b/src/github/utils/sanitizer.ts
@@ -70,8 +70,8 @@ export function sanitizeContent(content: string): string {
   content = stripInvisibleCharacters(content);
   content = stripMarkdownImageAltText(content);
   content = stripMarkdownLinkTitles(content);
-  content = stripHiddenAttributes(content);
   content = normalizeHtmlEntities(content);
+  content = stripHiddenAttributes(content);
   content = redactGitHubTokens(content);
   return content;
 }

--- a/test/sanitizer.test.ts
+++ b/test/sanitizer.test.ts
@@ -273,6 +273,55 @@ describe("sanitizeContent", () => {
     expect(sanitized).not.toContain('title="');
     expect(sanitized).toContain("<div>Test</div>");
   });
+
+  it("should strip hidden attributes with entity-encoded attribute names", () => {
+    const encodedAttributes = `
+      <img &#97;lt="hidden instructions" src="pic.jpg">
+      <img &#x61;lt="hex alt" src="pic2.jpg">
+      <div &#116;itle="hidden title">Content 1</div>
+      <div &#x74;itle="hex title">Content 2</div>
+      <a &#97;ria-label="hidden label" href="#">Link 1</a>
+      <a &#x61;ria-label="hex aria label" href="#">Link 2</a>
+      <div &#100;ata-custom="hidden data">Data 1</div>
+      <div &#x64;ata-custom="hex data" d&#97;t&#97;-nested="val">Data 2</div>
+      <input &#112;laceholder="hidden placeholder" type="text">
+      <input &#x70;laceholder="hex placeholder" type="password">
+      <img &#97;lt='single quoted' &#116;itle=unquoted src="pic3.jpg" class="photo">
+    `;
+
+    const sanitized = sanitizeContent(encodedAttributes);
+
+    expect(sanitized).not.toContain("hidden instructions");
+    expect(sanitized).not.toContain("hex alt");
+    expect(sanitized).not.toContain("hidden title");
+    expect(sanitized).not.toContain("hex title");
+    expect(sanitized).not.toContain("hidden label");
+    expect(sanitized).not.toContain("hex aria label");
+    expect(sanitized).not.toContain("hidden data");
+    expect(sanitized).not.toContain("hex data");
+    expect(sanitized).not.toContain("hidden placeholder");
+    expect(sanitized).not.toContain("hex placeholder");
+    expect(sanitized).not.toContain("single quoted");
+    expect(sanitized).not.toContain("unquoted");
+    expect(sanitized).not.toContain("alt=");
+    expect(sanitized).not.toContain("title=");
+    expect(sanitized).not.toContain("aria-label=");
+    expect(sanitized).not.toContain("data-custom=");
+    expect(sanitized).not.toContain("data-nested=");
+    expect(sanitized).not.toContain("placeholder=");
+
+    expect(sanitized).toContain('<img src="pic.jpg">');
+    expect(sanitized).toContain('<img src="pic2.jpg">');
+    expect(sanitized).toContain("<div>Content 1</div>");
+    expect(sanitized).toContain("<div>Content 2</div>");
+    expect(sanitized).toContain('<a href="#">Link 1</a>');
+    expect(sanitized).toContain('<a href="#">Link 2</a>');
+    expect(sanitized).toContain("<div>Data 1</div>");
+    expect(sanitized).toContain("<div>Data 2</div>");
+    expect(sanitized).toContain('<input type="text">');
+    expect(sanitized).toContain('<input type="password">');
+    expect(sanitized).toContain('<img src="pic3.jpg" class="photo">');
+  });
 });
 
 describe("redactGitHubTokens", () => {


### PR DESCRIPTION
### Summary

Adjusts the execution order in `sanitizeContent` so that `normalizeHtmlEntities` runs before `stripHiddenAttributes`.

### Motivation & Context

In `src/github/utils/sanitizer.ts`:
- `stripHiddenAttributes` uses regex patterns (such as `\salt\s*=`, `\stitle\s*=`, `\saria-label\s*=`, `\sdata-`, `\splaceholder\s*=`) to remove hidden HTML attributes from inbound content.
- Previously, `stripHiddenAttributes` was invoked before `normalizeHtmlEntities`. When input content contained HTML entity-encoded attribute names (e.g. `&#97;lt="description"` or `&#116;itle="tooltip"`), `stripHiddenAttributes` would not match the encoded attribute names. Subsequently, `normalizeHtmlEntities` decoded the entities into plain attribute names (`alt="..."`, `title="..."`), leaving those attributes present in the output.
- Running `normalizeHtmlEntities` prior to `stripHiddenAttributes` ensures all decimal and hexadecimal character entities are normalized to canonical form first, allowing subsequent attribute matching and stripping to operate accurately.

### Changes

1. **`src/github/utils/sanitizer.ts`**: Reordered `sanitizeContent` pipeline to call `normalizeHtmlEntities(content)` before `stripHiddenAttributes(content)`.
2. **`test/sanitizer.test.ts`**: Added unit tests verifying that entity-encoded attribute names (decimal, hex, and mixed) across `alt`, `title`, `aria-label`, `data-*`, and `placeholder` attributes are properly stripped.

### Verification

- `bun test test/sanitizer.test.ts test/integration-sanitization.test.ts`: 60/60 tests pass.
- `bun run typecheck` (`tsc --noEmit`): Clean with zero errors.
- Code style verified with Prettier.
