### PR TITLE
fix: allow creating new files in nested non-existent directories

### DIFF
--- a/src/mcp/path-validation.ts
+++ b/src/mcp/path-validation.ts
@@ -30,26 +30,37 @@ export async function validatePathWithinRepo(
   try {
     resolvedPath = await realpath(initialPath);
   } catch {
-    // File doesn't exist yet - fall back to checking the parent directory
-    // This handles the case where we're creating a new file
-    const parentDir = resolve(initialPath, "..");
-    try {
-      const resolvedParent = await realpath(parentDir);
+    // File doesn't exist yet - walk up to find the closest existing ancestor directory
+    // This handles the case where we're creating a new file in existing or nested non-existent directories
+    let currentDir = resolve(initialPath, "..");
+    while (true) {
+      let resolvedAncestor: string | null = null;
+      try {
+        resolvedAncestor = await realpath(currentDir);
+      } catch {
+        // Ancestor directory does not exist yet; move up to parent
+        const parentDir = resolve(currentDir, "..");
+        if (parentDir === currentDir) {
+          // Reached filesystem root without finding an existing ancestor
+          break;
+        }
+        currentDir = parentDir;
+        continue;
+      }
+
       if (
-        resolvedParent !== resolvedRoot &&
-        !resolvedParent.startsWith(resolvedRoot + sep)
+        resolvedAncestor !== resolvedRoot &&
+        !resolvedAncestor.startsWith(resolvedRoot + sep)
       ) {
         throw new Error(
           `Path '${filePath}' resolves outside the repository root`,
         );
       }
-      // Parent is valid, return the initial path since file doesn't exist yet
+      // Ancestor is valid and within repo root; return initialPath since file doesn't exist yet
       return initialPath;
-    } catch {
-      throw new Error(
-        `Path '${filePath}' resolves outside the repository root`,
-      );
     }
+
+    throw new Error(`Path '${filePath}' resolves outside the repository root`);
   }
 
   // Path must be within repo root (or be the root itself)

--- a/test/github-file-ops-path-validation.test.ts
+++ b/test/github-file-ops-path-validation.test.ts
@@ -75,6 +75,24 @@ describe("validatePathWithinRepo", () => {
       // (can't realpath a file that doesn't exist yet)
       expect(result).toBe(resolve(repoRoot, "src/newfile.js"));
     });
+
+    it("should handle new files in nested non-existent directories under existing directory", async () => {
+      const result = await validatePathWithinRepo(
+        "src/components/button/index.tsx",
+        repoRoot,
+      );
+      expect(result).toBe(resolve(repoRoot, "src/components/button/index.tsx"));
+    });
+
+    it("should handle new files in deeply nested non-existent directories from repo root", async () => {
+      const result = await validatePathWithinRepo(
+        "deeply/nested/non/existent/dir/file.txt",
+        repoRoot,
+      );
+      expect(result).toBe(
+        resolve(repoRoot, "deeply/nested/non/existent/dir/file.txt"),
+      );
+    });
   });
 
   describe("path traversal attacks", () => {
@@ -111,6 +129,15 @@ describe("validatePathWithinRepo", () => {
     it("should reject absolute paths to sibling directories", async () => {
       await expect(
         validatePathWithinRepo(resolve(outsideDir, "secret.txt"), repoRoot),
+      ).rejects.toThrow(/resolves outside the repository root/);
+    });
+
+    it("should reject non-existent files in nested paths outside the repo", async () => {
+      await expect(
+        validatePathWithinRepo(
+          "../outside/nonexistent/nested/file.txt",
+          repoRoot,
+        ),
       ).rejects.toThrow(/resolves outside the repository root/);
     });
   });
@@ -168,6 +195,39 @@ describe("validatePathWithinRepo", () => {
         await expect(
           validatePathWithinRepo("escape-dir/secret.txt", repoRoot),
         ).rejects.toThrow(/resolves outside the repository root/);
+      } finally {
+        await rm(symlinkPath, { force: true });
+      }
+    });
+
+    it("should reject non-existent files in nested directories through escaping symlinks", async () => {
+      const symlinkPath = resolve(repoRoot, "escape-dir");
+      await symlink(outsideDir, symlinkPath);
+
+      try {
+        await expect(
+          validatePathWithinRepo(
+            "escape-dir/nested/nonexistent/file.txt",
+            repoRoot,
+          ),
+        ).rejects.toThrow(/resolves outside the repository root/);
+      } finally {
+        await rm(symlinkPath, { force: true });
+      }
+    });
+
+    it("should accept non-existent files in nested directories through valid internal directory symlinks", async () => {
+      const symlinkPath = resolve(repoRoot, "src-link");
+      await symlink(resolve(repoRoot, "src"), symlinkPath);
+
+      try {
+        const result = await validatePathWithinRepo(
+          "src-link/nested/nonexistent/file.txt",
+          repoRoot,
+        );
+        expect(result).toBe(
+          resolve(repoRoot, "src-link/nested/nonexistent/file.txt"),
+        );
       } finally {
         await rm(symlinkPath, { force: true });
       }


### PR DESCRIPTION
## Problem
When validating paths for new files that have not yet been created, `validatePathWithinRepo` fell back to calling `realpath(parentDir)` on the immediate parent directory.

If a new file is being created inside nested directories that do not yet exist (for example `src/components/button/index.tsx` where neither `components/` nor `button/` has been created yet), `realpath(parentDir)` threw `ENOENT`, which was caught and caused the function to incorrectly reject the valid path with `Path '...' resolves outside the repository root`.

## Solution
Update `validatePathWithinRepo` to walk up the directory tree to find the closest existing ancestor directory:
- Recursively inspect parent directories until an existing ancestor directory is found.
- Verify that the resolved ancestor directory resides within `resolvedRoot`.
- Return `initialPath` for the non-existent target path once the ancestor is validated.

## Testing
- Added unit tests for new files in nested non-existent directories under existing directories (`src/components/button/index.tsx`).
- Added unit tests for new files in deeply nested non-existent directories from repo root (`deeply/nested/non/existent/dir/file.txt`).
- Verified path traversal attacks (`../outside/...`) and escaping symlinks continue to be correctly rejected for non-existent nested paths.
- Verified valid internal symlinks to directories continue to accept nested new files.
- All path validation unit tests pass (`27 pass, 0 fail`).
- All format and TypeScript checks pass (`bun run format:check`, `bun run typecheck`).
