### PR TITLE
fix(prepare): tell the agent when PR config paths were restored from base

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -28,7 +28,10 @@ import { detectMode } from "../modes/detector";
 import { prepareTagMode } from "../modes/tag";
 import { prepareAgentMode } from "../modes/agent";
 import { checkContainsTrigger } from "../github/validation/trigger";
-import { restoreConfigFromBase } from "../github/operations/restore-config";
+import {
+  restoreConfigFromBase,
+  describeRestoredPaths,
+} from "../github/operations/restore-config";
 import { validateBranchName } from "../github/operations/branch";
 import { collectActionInputsPresence } from "./collect-inputs";
 import { updateCommentLink } from "./update-comment-link";
@@ -272,6 +275,20 @@ async function run() {
       }
       if (restoreBase) {
         restoredConfigPaths = restoreConfigFromBase(restoreBase);
+        // Tell the agent this happened. restoreConfigFromBase() only logs to
+        // the raw Action run log, which the agent never sees — without this,
+        // its own Bash/Read tool calls observe deleted/modified paths
+        // relative to HEAD with no explanation available anywhere in its
+        // context. See #1738.
+        const restoreNotice = describeRestoredPaths(restoredConfigPaths);
+        if (restoreNotice) {
+          process.env.APPEND_SYSTEM_PROMPT = [
+            process.env.APPEND_SYSTEM_PROMPT,
+            restoreNotice,
+          ]
+            .filter(Boolean)
+            .join("\n\n");
+        }
       }
     }
 

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -266,6 +266,36 @@ function ensureClaudePrExcludedFromGit(): void {
  *   rather than the PR. Callers that stage files must exclude these, or they
  *   will commit the revert back onto the PR author's branch.
  */
+/**
+ * Builds an agent-facing notice describing which paths were just reverted to
+ * the base branch, so the CLI's system prompt can carry it.
+ *
+ * restoreConfigFromBase() runs before the CLI starts and never informs the
+ * agent it happened: it only logs to the raw Action run log and returns the
+ * path list to the (separate) auto-commit exclusion logic in
+ * branch-cleanup.ts. Without this notice, the agent's own Bash/Read tool
+ * calls observe deleted/modified paths relative to HEAD with no explanation
+ * available anywhere in its context — indistinguishable, from inside the
+ * session, from filesystem corruption. See #1738.
+ *
+ * @param restoredPaths - Return value of restoreConfigFromBase(); empty when
+ *   it did not run (not a PR context) or restored nothing.
+ * @returns Empty string when there is nothing to report.
+ */
+export function describeRestoredPaths(restoredPaths: string[]): string {
+  if (restoredPaths.length === 0) {
+    return "";
+  }
+  return (
+    `Note: this is a pull request, so ${restoredPaths.join(", ")} were replaced with their versions ` +
+    "from the base branch before you started (PR-authored versions are untrusted config/hooks). " +
+    "If \`git status\`/\`git diff\` show these paths as modified or deleted relative to HEAD, or a " +
+    "listing is missing files a PR commit added under them, that is this intentional revert — not a " +
+    "checkout or filesystem problem. The PR-authored versions are preserved, unexecuted, under " +
+    "\`.claude-pr/\` for reference. Every other path reflects the actual PR HEAD."
+  );
+}
+
 export function restoreConfigFromBase(baseBranch: string): string[] {
   console.log(
     `Restoring ${SENSITIVE_PATHS.join(", ")} from origin/${baseBranch} (PR head is untrusted)`,

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -12,7 +12,10 @@ import {
   writeFileSync,
 } from "fs";
 import { dirname, isAbsolute, join } from "path";
-import { restoreConfigFromBase } from "../src/github/operations/restore-config";
+import {
+  restoreConfigFromBase,
+  describeRestoredPaths,
+} from "../src/github/operations/restore-config";
 
 const CLAUDE_PR_EXCLUDE_PATTERN = "/.claude-pr/";
 
@@ -529,4 +532,23 @@ describe("restoreConfigFromBase", () => {
     const gitPath = git(["rev-parse", "--git-path", "info/exclude"]).trim();
     return isAbsolute(gitPath) ? gitPath : join(repoDir, gitPath);
   }
+});
+
+describe("describeRestoredPaths", () => {
+  test("returns empty string when nothing was restored", () => {
+    expect(describeRestoredPaths([])).toBe("");
+  });
+
+  test("names every restored path", () => {
+    const notice = describeRestoredPaths([".claude", "CLAUDE.md"]);
+    expect(notice).toContain(".claude, CLAUDE.md");
+  });
+
+  test("explains git status/diff noise and points to .claude-pr/", () => {
+    const notice = describeRestoredPaths([".claude"]);
+    expect(notice).toContain("git status");
+    expect(notice).toContain("git diff");
+    expect(notice).toContain(".claude-pr/");
+    expect(notice).toContain("not a checkout or filesystem problem");
+  });
 });


### PR DESCRIPTION
Related to [#1738](https://github.com/anthropics/claude-code-action/issues/1738) — this does not address the issue's root cause. It fixes a separate, real gap that surfaced while investigating it.

restoreConfigFromBase() intentionally deletes and restores .claude/, .mcp.json, CLAUDE.md, and related configuration files to their base-branch versions before the CLI starts. PR-authored versions of these files are untrusted, so this behavior is necessary for RCE prevention.

However, the restore is currently invisible to the agent. It is logged to the raw run log, but that information is never included in the CLI's context. As a result, the agent's Bash/Read calls can see files missing, while git status and git diff show uncommitted deletions relative to HEAD. From inside the session, this is indistinguishable from an unexpected checkout or workspace issue.

This PR addresses that blind spot by:

Adding describeRestoredPaths() as a pure, unit-tested function.
Injecting its notice into APPEND_SYSTEM_PROMPT whenever a restore actually occurs.
Preserving any existing value already set by the workflow.

Not related to #1738's actual cause

A follow-up from the reporter on #1738 confirms this PR does not touch their root cause. Their reproduction shows a repo-wide mismatch — every file that differs between base and head shows base's content, and every file only added on head is missing entirely, cross-checked directly against the actual base tree. restoreConfigFromBase() cannot produce that: it's documented to touch only the fixed SENSITIVE_PATHS list and explicitly leaves the rest of the tree at PR head, so this isn't a partial explanation of their case — it's a different, unrelated gap.

I posted a separate comment on #1738 with what I ruled out in this repo's own git-handling code and a suggested bisection (checking whether the mismatch is present immediately after actions/checkout, before this action even runs) to help narrow down the actual cause.

This PR stands on its own: the SENSITIVE_PATHS revert is real, intentional, and currently invisible to the agent regardless of what's causing #1738.

Tests

Added 3 cases to test/restore-config.test.ts covering:

Empty input.
Restored path names being included in the notice.
git status/git diff output and the .claude-pr/ pointer being present.

The full test suite, typecheck, and formatting all pass locally.