### PR TITLE
fix: configure git auth before setupBranch in tag mode

### DIFF
--- a/src/modes/tag/index.ts
+++ b/src/modes/tag/index.ts
@@ -63,10 +63,7 @@ export async function prepareTagMode({
     excludeCommentsByActor: context.inputs.excludeCommentsByActor,
   });
 
-  // Setup branch
-  const branchInfo = await setupBranch(octokit, githubData, context);
-
-  // Configure git authentication
+  // Configure git authentication before setupBranch to ensure credentials are available
   // SSH signing takes precedence if provided
   const useSshSigning = !!context.inputs.sshSigningKey;
   const useApiCommitSigning = context.inputs.useCommitSigning && !useSshSigning;
@@ -110,6 +107,9 @@ export async function prepareTagMode({
       throw error;
     }
   }
+
+  // Setup branch
+  const branchInfo = await setupBranch(octokit, githubData, context);
 
   // Create prompt file
   await createPrompt(


### PR DESCRIPTION
In tag mode, `setupBranch()` was called before `configureGitAuth()`, causing git fetch to fail on private repositories when using `actions/checkout` with `persist-credentials: false`. The fetch would fail with "Command failed: git fetch origin" because no credentials were configured yet, leaving a permanently pending comment on the PR.

This reorders `src/modes/tag/index.ts` to configure git authentication (lines 66-108) before calling `setupBranch()` (line 111). The git auth block now runs immediately after `fetchGitHubData()`, ensuring credentials are available for the subsequent fetch operation in `setupBranch()`.

Agent mode was unaffected because it never calls `setupBranch()`, reading branch state from environment variables instead.

Fixes #1711