### PR TITLE
fix: replace process.exit(1) with throw in setupBranch() error handler

### DIFF
--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -347,6 +347,6 @@ export async function setupBranch(
     };
   } catch (error) {
     console.error("Error in branch setup:", error);
-    process.exit(1);
+    throw error;
   }
 }


### PR DESCRIPTION
The `setupBranch()` function in `src/github/operations/branch.ts` was calling `process.exit(1)` in its error handler, which prevented the top-level orchestrator in `src/entrypoints/run.ts` from executing its catch and finally blocks. This caused branch setup failures to bypass critical cleanup operations including temporary credential deletion via `workloadIdentity?.stop()`, GitHub tracking comment updates that inform users of the failure reason, and proper failure reporting via `@actions/core`. The root cause is that premature process termination prevents the orchestrator's lifecycle management from running.

The fix replaces `process.exit(1)` with `throw error;` in the catch block at line 350, allowing errors to propagate up to the orchestrator where they are properly handled, logged, and cleaned up.

Fixes #1747
