### PR TITLE
fix: expose session_id output when the run throws

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -230,6 +230,15 @@ export async function runClaudeWithSdk(
   );
   if (initMessage && "session_id" in initMessage && initMessage.session_id) {
     result.sessionId = initMessage.session_id as string;
+    // Publish the output here rather than leaving it to the caller. Every path
+    // below this point can throw (is_error, maxTurns, the --json-schema check),
+    // and a throw skips the caller's setOutput block entirely — so the session
+    // id was logged but never exposed on exactly the runs where it is most
+    // useful for debugging. execution_file already survives the error path via
+    // setExecutionFileOutputIfPresent(); this gives session_id the same
+    // guarantee. Callers still set it on success; the value is identical.
+    // See issue #1720.
+    core.setOutput("session_id", result.sessionId);
     core.info(`Set session_id: ${result.sessionId}`);
   }
 

--- a/base-action/test/run-claude-sdk.test.ts
+++ b/base-action/test/run-claude-sdk.test.ts
@@ -284,4 +284,179 @@ describe("runClaudeWithSdk", () => {
       coreErrorSpy.mockRestore();
     }
   });
+
+  describe("session_id output", () => {
+    // Regression for #1720: the session id was recorded on the result object and
+    // logged, but every throw below that point skipped the caller's setOutput
+    // block, so steps.<id>.outputs.session_id came back empty on exactly the
+    // runs a user needs it to debug.
+    async function runWithMessages(
+      messages: unknown[],
+      options: { hasJsonSchema: boolean },
+    ) {
+      const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+        () => {},
+      );
+      const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+      const core = await import("@actions/core");
+      const coreErrorSpy = spyOn(core, "error").mockImplementation(() => {});
+      const coreInfoSpy = spyOn(core, "info").mockImplementation(() => {});
+      const coreSetFailedSpy = spyOn(core, "setFailed").mockImplementation(
+        () => {},
+      );
+      const setOutputSpy = spyOn(core, "setOutput").mockImplementation(
+        () => {},
+      );
+
+      tempDir = await mkdtemp(join(tmpdir(), "claude-sdk-"));
+      process.env.RUNNER_TEMP = tempDir;
+
+      const promptPath = join(tempDir, "prompt.txt");
+      await writeFile(promptPath, "test prompt");
+
+      mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+        query: async function* () {
+          for (const message of messages) {
+            yield message;
+          }
+        },
+      }));
+
+      const { runClaudeWithSdk } = await import("../src/run-claude-sdk");
+      const call = runClaudeWithSdk(promptPath, {
+        sdkOptions: {},
+        showFullOutput: false,
+        hasJsonSchema: options.hasJsonSchema,
+      });
+
+      return {
+        call,
+        setOutputSpy,
+        restore: () => {
+          consoleErrorSpy.mockRestore();
+          consoleLogSpy.mockRestore();
+          coreErrorSpy.mockRestore();
+          coreInfoSpy.mockRestore();
+          coreSetFailedSpy.mockRestore();
+          setOutputSpy.mockRestore();
+        },
+      };
+    }
+
+    const initMessage = {
+      type: "system",
+      subtype: "init",
+      session_id: "session-abc",
+      model: "claude-sonnet-5",
+    };
+
+    test("sets session_id when --json-schema is set but structured_output is missing", async () => {
+      // The #1720 shape: the session ran and succeeded, but no structured
+      // output came back, so the run throws before the caller sets outputs.
+      const { call, setOutputSpy, restore } = await runWithMessages(
+        [
+          initMessage,
+          {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            duration_ms: 332000,
+            num_turns: 24,
+            total_cost_usd: 0.42,
+            permission_denials: [],
+          },
+        ],
+        { hasJsonSchema: true },
+      );
+
+      try {
+        await expect(call).rejects.toThrow(
+          "--json-schema was provided but Claude did not return structured_output",
+        );
+        expect(setOutputSpy).toHaveBeenCalledWith("session_id", "session-abc");
+      } finally {
+        restore();
+      }
+    });
+
+    test("sets session_id when the result reports is_error", async () => {
+      const { call, setOutputSpy, restore } = await runWithMessages(
+        [
+          initMessage,
+          {
+            type: "result",
+            subtype: "success",
+            is_error: true,
+            duration_ms: 220,
+            num_turns: 1,
+            total_cost_usd: 0,
+            permission_denials: [],
+          },
+        ],
+        { hasJsonSchema: false },
+      );
+
+      try {
+        await expect(call).rejects.toThrow("result is_error:true");
+        expect(setOutputSpy).toHaveBeenCalledWith("session_id", "session-abc");
+      } finally {
+        restore();
+      }
+    });
+
+    test("still sets session_id on a successful run", async () => {
+      const { call, setOutputSpy, restore } = await runWithMessages(
+        [
+          initMessage,
+          {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            duration_ms: 1200,
+            num_turns: 2,
+            total_cost_usd: 0.01,
+            permission_denials: [],
+          },
+        ],
+        { hasJsonSchema: false },
+      );
+
+      try {
+        const result = await call;
+        expect(result.conclusion).toBe("success");
+        expect(result.sessionId).toBe("session-abc");
+        expect(setOutputSpy).toHaveBeenCalledWith("session_id", "session-abc");
+      } finally {
+        restore();
+      }
+    });
+
+    test("does not set session_id when the init message carries none", async () => {
+      const { call, setOutputSpy, restore } = await runWithMessages(
+        [
+          { type: "system", subtype: "init", model: "claude-sonnet-5" },
+          {
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            duration_ms: 1200,
+            num_turns: 2,
+            total_cost_usd: 0.01,
+            permission_denials: [],
+          },
+        ],
+        { hasJsonSchema: false },
+      );
+
+      try {
+        await call;
+        expect(setOutputSpy).not.toHaveBeenCalledWith(
+          "session_id",
+          expect.anything(),
+        );
+      } finally {
+        restore();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Publishes the `session_id` output where it is discovered, so it survives the failure paths that currently throw past it.

The session id is read from the `system.init` message and logged at `base-action/src/run-claude-sdk.ts:233`, but it is only published as an output by the callers — `base-action/src/index.ts:67` and `src/entrypoints/run.ts:310` — *after* `runClaude` returns. Every failure path below the extraction throws rather than returns:

- the `is_error` check
- the `maxTurns` check
- the `--json-schema` structured-output check (line 274)

A throw skips the caller's `setOutput` block entirely and lands in a catch that rescues only `execution_file`, via `setExecutionFileOutputIfPresent()`. So `steps.<id>.outputs.session_id` comes back empty on exactly the runs where a user needs the session id to debug.

`execution_file` already has this guarantee; this gives `session_id` the same one. Callers still set it on success with an identical value, so the success path is unchanged.

## Scope

Refs #1720 — this addresses the second signal in that issue, and does not close it.

That issue contains two distinct failures:

- **The 220ms init crash** (`is_error:true`, `num_turns:1`, `cost:0`, zero tool calls) appears resolved by the Claude Code / Agent SDK bumps in v1.0.202–205; a downstream consumer reported it cleared on that bump. Not addressed here, and nothing to address.
- **The Aug 24 follow-up** — a 5m32s run that did real work and posted a genuine review, yet returned empty `session_id` and `structured_output` — is still present on `main`. That is what this fixes.

`base-action/src/run-claude-sdk.ts` is unchanged from `v1.0.193` through `main` apart from #1608's model-limits logging, which does not touch this path, so no version bump has covered it.

This deliberately does not touch `structured_output`. On that path the SDK never returned one — which is why the code throws — so there is nothing to publish. That half of #1720 remains open.

## Testing

Four tests added to `base-action/test/run-claude-sdk.test.ts`, in the file's existing mock-the-SDK-generator style:

- `--json-schema` set but no `structured_output` returned (the #1720 shape)
- result reports `is_error`
- successful run still sets it (no regression)
- init message carrying no session id sets nothing

Reverting the change in `base-action/src/run-claude-sdk.ts` makes the first three fail; they pass with it. The fourth asserts absence and correctly passes either way.

- `bun test base-action/test/run-claude-sdk.test.ts` — 8 pass, 0 fail
- `bun test` — 970 pass, 0 fail
- `bun run typecheck` — clean
- `bun run format:check` — clean
