### PR TITLE
fix: verify Code binary exists after installation

### DIFF
--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -65,6 +65,11 @@ async function installClaudeCode(): Promise<string> {
         "PATH_TO_CLAUDE_CODE_EXECUTABLE contains control characters (e.g. newlines), which is not allowed",
       );
     }
+    if (!existsSync(customExecutable)) {
+      throw new Error(
+        `PATH_TO_CLAUDE_CODE_EXECUTABLE points to a non-existent file: ${customExecutable}`,
+      );
+    }
     console.log(`Using custom Claude Code executable: ${customExecutable}`);
     const claudeDir = dirname(customExecutable);
     // Add to PATH by appending to GITHUB_PATH
@@ -98,12 +103,23 @@ async function installClaudeCode(): Promise<string> {
       console.log("Claude Code installed successfully");
       // Add to PATH
       const homeBin = `${process.env.HOME}/.local/bin`;
+      const claudePath = `${homeBin}/claude`;
+
+      // Verify the binary actually exists after installation
+      if (!existsSync(claudePath)) {
+        throw new Error(
+          `Claude Code installer exited successfully but the binary was not found at ${claudePath}. ` +
+          `This may indicate a regression in the installer (e.g., ${homeBin} directory not created). ` +
+          `Try using PATH_TO_CLAUDE_CODE_EXECUTABLE to specify an alternative installation location.`
+        );
+      }
+
       const githubPath = process.env.GITHUB_PATH;
       if (githubPath) {
         await appendFile(githubPath, `${homeBin}\n`);
       }
       process.env.PATH = `${homeBin}:${process.env.PATH}`;
-      return `${homeBin}/claude`;
+      return claudePath;
     } catch (error) {
       if (attempt === 3) {
         throw new Error(


### PR DESCRIPTION
## Summary

The action failed when the Code installer exited successfully (code 0) but did not place the binary at `~/.local/bin/code`. This occurred due to a regression in specific upstream installer releases that fail to create the directory but still report success. The action's `installCode()` function unconditionally returned the expected path without verification, causing downstream operations (plugin installation, SDK execution) to fail with ENOENT errors.

## Changes

- Added `existsSync()` check in `installCode()` after the installer completes to verify the binary was actually placed at the expected path
- If the binary is missing, the function now throws a descriptive error that explains the likely cause (installer regression, missing directory) and suggests using `PATH_TO_CODE_EXECUTABLE` as a workaround
- Added the same verification for custom executables specified via `PATH_TO_CODE_EXECUTABLE` to fail fast with a clear message if the path is invalid

## Root cause

Between v2.1.129 releases, the upstream `install` script began failing silently on runners where `~/.local/bin` doesn't exist. The installer exits 0 with misleading "successfully installed" messaging but emits warnings that the binary couldn't be placed. The action trusted the exit code without verifying the binary exists, leading to failures when spawning the non-existent executable.

Fixes #1290