### PR TITLE
fix(git): run git against the checkout, not the ambient working directory

### DIFF
--- a/src/github/operations/fetch-depth.ts
+++ b/src/github/operations/fetch-depth.ts
@@ -16,16 +16,17 @@ import { execFileSync } from "child_process";
  * lose, so the limit still applies there and large repositories keep the fetch
  * savings it was added for.
  */
-export function fetchDepthArgs(depth: number): string[] {
-  return isShallowRepository() ? [`--depth=${depth}`] : [];
+export function fetchDepthArgs(depth: number, cwd?: string): string[] {
+  return isShallowRepository(cwd) ? [`--depth=${depth}`] : [];
 }
 
-function isShallowRepository(): boolean {
+function isShallowRepository(cwd?: string): boolean {
   try {
     const output = execFileSync(
       "git",
       ["rev-parse", "--is-shallow-repository"],
       {
+        cwd,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
       },

--- a/src/github/operations/git-config.ts
+++ b/src/github/operations/git-config.ts
@@ -11,6 +11,7 @@ import { join } from "path";
 import { homedir } from "os";
 import type { GitHubContext } from "../context";
 import { GITHUB_SERVER_URL } from "../api/config";
+import { repositoryDir } from "./repo-dir";
 
 const SSH_SIGNING_KEY_PATH = join(homedir(), ".ssh", "claude_signing_key");
 
@@ -25,6 +26,7 @@ export async function configureGitAuth(
   user: GitUser,
 ) {
   console.log("Configuring git authentication for non-signing mode");
+  const repoDir = repositoryDir();
 
   // Determine the noreply email domain based on GITHUB_SERVER_URL
   const serverUrl = new URL(GITHUB_SERVER_URL);
@@ -38,8 +40,10 @@ export async function configureGitAuth(
   const botName = user.login;
   const botId = user.id;
   console.log(`Setting git user as ${botName}...`);
-  await $`git config user.name "${botName}"`;
-  await $`git config user.email "${botId}+${botName}@${noreplyDomain}"`;
+  await $`git config user.name "${botName}"`.cwd(repoDir);
+  await $`git config user.email "${botId}+${botName}@${noreplyDomain}"`.cwd(
+    repoDir,
+  );
   console.log(`✓ Set git user as ${botName}`);
 
   await replaceCheckoutCredentials(githubToken, context);
@@ -72,25 +76,29 @@ export async function replaceCheckoutCredentials(
   context: GitHubContext,
 ) {
   const serverUrl = new URL(GITHUB_SERVER_URL);
+  const repoDir = repositoryDir();
 
   // Remove the authorization header that actions/checkout sets
   console.log("Removing existing git authentication headers...");
   const extraheaderKey = `http.${GITHUB_SERVER_URL}/.extraheader`;
   let removedHeader = false;
   try {
-    await $`git config --unset-all ${extraheaderKey}`;
+    await $`git config --unset-all ${extraheaderKey}`.cwd(repoDir);
     removedHeader = true;
   } catch {
     // No extraheader in the local config (expected on the v6+ include layout).
   }
   try {
-    const includePaths =
-      await $`git config --local --get-all include.path`.text();
+    const includePaths = await $`git config --local --get-all include.path`
+      .cwd(repoDir)
+      .text();
     for (const includePath of includePaths.split("\n")) {
       const path = includePath.trim();
       if (!path) continue;
       try {
-        await $`git config --file ${path} --unset-all ${extraheaderKey}`;
+        await $`git config --file ${path} --unset-all ${extraheaderKey}`.cwd(
+          repoDir,
+        );
         removedHeader = true;
       } catch {
         // This include does not define the header; leave it untouched.
@@ -123,14 +131,14 @@ export async function replaceCheckoutCredentials(
       { mode: 0o700 },
     );
     const cleanUrl = `https://${serverUrl.host}/${context.repository.owner}/${context.repository.repo}.git`;
-    await $`git remote set-url origin ${cleanUrl}`;
-    await $`git config credential.helper ${helperPath}`;
+    await $`git remote set-url origin ${cleanUrl}`.cwd(repoDir);
+    await $`git config credential.helper ${helperPath}`.cwd(repoDir);
     console.log("✓ Configured credential helper");
   } else {
     // Update the remote URL to include the token for authentication
     console.log("Updating remote URL with authentication...");
     const remoteUrl = `https://x-access-token:${githubToken}@${serverUrl.host}/${context.repository.owner}/${context.repository.repo}.git`;
-    await $`git remote set-url origin ${remoteUrl}`;
+    await $`git remote set-url origin ${remoteUrl}`.cwd(repoDir);
     console.log("✓ Updated remote URL with authentication token");
   }
 }
@@ -167,9 +175,10 @@ export async function setupSshSigning(sshSigningKey: string): Promise<void> {
   console.log(`✓ SSH signing key written to ${SSH_SIGNING_KEY_PATH}`);
 
   // Configure git to use SSH signing
-  await $`git config gpg.format ssh`;
-  await $`git config user.signingkey ${SSH_SIGNING_KEY_PATH}`;
-  await $`git config commit.gpgsign true`;
+  const repoDir = repositoryDir();
+  await $`git config gpg.format ssh`.cwd(repoDir);
+  await $`git config user.signingkey ${SSH_SIGNING_KEY_PATH}`.cwd(repoDir);
+  await $`git config commit.gpgsign true`.cwd(repoDir);
 
   console.log("✓ Git configured to use SSH signing for commits");
 }

--- a/src/github/operations/repo-dir.ts
+++ b/src/github/operations/repo-dir.ts
@@ -1,0 +1,18 @@
+/**
+ * The checkout this action operates on.
+ *
+ * Actions points GITHUB_WORKSPACE at the directory `actions/checkout` writes
+ * into, and the rest of the action already locates the repository that way: the
+ * MCP file-ops server is handed `GITHUB_WORKSPACE || cwd` as its REPO_DIR
+ * (see install-mcp-server.ts), and the CLI's permission model scopes edits to
+ * $GITHUB_WORKSPACE. The git calls in this directory instead inherited whatever
+ * working directory the composite step happened to run in, so a run where the
+ * two differ sends git looking outside the checkout — it exits 128 with
+ * "not a git repository" and takes the job down with it.
+ *
+ * Falls back to the process working directory so local runs and the unit tests,
+ * which have no GITHUB_WORKSPACE, keep behaving as before.
+ */
+export function repositoryDir(): string {
+  return process.env.GITHUB_WORKSPACE || process.cwd();
+}

--- a/src/github/operations/restore-config.ts
+++ b/src/github/operations/restore-config.ts
@@ -12,8 +12,9 @@ import {
   statSync,
   writeFileSync,
 } from "fs";
-import { dirname, join, posix, relative, sep } from "path";
+import { dirname, isAbsolute, join, posix, relative, sep } from "path";
 import { fetchDepthArgs } from "./fetch-depth";
+import { repositoryDir } from "./repo-dir";
 
 // Paths that are both PR-controllable and read from cwd at CLI startup.
 //
@@ -48,9 +49,9 @@ type TrackedPaths = { files: Set<string>; dirs: Set<string> };
 // Built from the superproject only: `git ls-files` reports a submodule as a
 // single entry, so paths inside a checked-out submodule are in neither set and
 // links into one are recorded as placeholders.
-function listTrackedPaths(): TrackedPaths {
+function listTrackedPaths(cwd: string): TrackedPaths {
   const gitPathList = (args: string[]) =>
-    execFileSync("git", args, { encoding: "utf8", maxBuffer: Infinity })
+    execFileSync("git", args, { cwd, encoding: "utf8", maxBuffer: Infinity })
       .split("\0")
       .filter(Boolean);
   const modified = new Set(
@@ -101,6 +102,7 @@ function listTrackedPaths(): TrackedPaths {
 // resolves anywhere else.
 function shouldSnapshotContent(
   entryPath: string,
+  workTreeDir: string,
   workTreeRealPath: string,
   tracked: TrackedPaths,
 ): boolean {
@@ -123,7 +125,7 @@ function shouldSnapshotContent(
     }
     const literalPath = join(
       workTreeRealPath,
-      relative(process.cwd(), entryPath),
+      relative(workTreeDir, entryPath),
     );
     if (targetRealPath === literalPath) {
       return true;
@@ -162,6 +164,7 @@ function recordPlaceholder(src: string, dest: string): void {
 function snapshotSensitivePath(
   src: string,
   dest: string,
+  workTreeDir: string,
   workTreeRealPath: string,
   tracked: TrackedPaths,
 ): void {
@@ -180,7 +183,7 @@ function snapshotSensitivePath(
       recursive: true,
       dereference: true,
       filter: keepOrExclude((entry) =>
-        shouldSnapshotContent(entry, workTreeRealPath, tracked),
+        shouldSnapshotContent(entry, workTreeDir, workTreeRealPath, tracked),
       ),
     });
   } catch (error) {
@@ -206,12 +209,14 @@ function snapshotSensitivePath(
   }
 }
 
-function ensureClaudePrExcludedFromGit(): void {
-  const excludePath = execFileSync(
+function ensureClaudePrExcludedFromGit(cwd: string): void {
+  const gitPath = execFileSync(
     "git",
     ["rev-parse", "--git-path", "info/exclude"],
-    { encoding: "utf8" },
+    { cwd, encoding: "utf8" },
   ).trim();
+  // `--git-path` answers relative to the repository when it can.
+  const excludePath = isAbsolute(gitPath) ? gitPath : join(cwd, gitPath);
 
   const excludeContents = existsSync(excludePath)
     ? readFileSync(excludePath, "utf8")
@@ -277,19 +282,28 @@ export function restoreConfigFromBase(baseBranch: string): string[] {
   // PR-authored version. Links are followed only to tracked, unmodified content
   // inside the working tree; anything else is recorded as a placeholder file,
   // so the snapshot itself never contains links.
-  rmSync(".claude-pr", { recursive: true, force: true });
-  const workTreeRealPath = realpathSync(process.cwd());
-  const tracked = listTrackedPaths();
+  const workTreeDir = repositoryDir();
+  const snapshotDir = join(workTreeDir, ".claude-pr");
+  rmSync(snapshotDir, { recursive: true, force: true });
+  const workTreeRealPath = realpathSync(workTreeDir);
+  const tracked = listTrackedPaths(workTreeDir);
   for (const p of SENSITIVE_PATHS) {
-    if (lstatSync(p, { throwIfNoEntry: false })) {
-      snapshotSensitivePath(p, `.claude-pr/${p}`, workTreeRealPath, tracked);
+    const entryPath = join(workTreeDir, p);
+    if (lstatSync(entryPath, { throwIfNoEntry: false })) {
+      snapshotSensitivePath(
+        entryPath,
+        join(snapshotDir, p),
+        workTreeDir,
+        workTreeRealPath,
+        tracked,
+      );
     }
   }
-  if (existsSync(".claude-pr")) {
+  if (existsSync(snapshotDir)) {
     console.log(
       "Preserved PR's sensitive paths -> .claude-pr/ for review agents (not executed)",
     );
-    ensureClaudePrExcludedFromGit();
+    ensureClaudePrExcludedFromGit(workTreeDir);
   }
 
   // Delete PR-controlled versions BEFORE fetching so the attacker-controlled
@@ -302,7 +316,7 @@ export function restoreConfigFromBase(baseBranch: string): string[] {
   // the safe fallback (no attacker-controlled config). A bare `git checkout`
   // alone wouldn't remove files the PR added, so nuke first.
   for (const p of SENSITIVE_PATHS) {
-    rmSync(p, { recursive: true, force: true });
+    rmSync(join(workTreeDir, p), { recursive: true, force: true });
   }
 
   // --no-recurse-submodules: explicitly suppress submodule fetching regardless of
@@ -313,10 +327,11 @@ export function restoreConfigFromBase(baseBranch: string): string[] {
       "fetch",
       "origin",
       baseBranch,
-      ...fetchDepthArgs(1),
+      ...fetchDepthArgs(1, workTreeDir),
       "--no-recurse-submodules",
     ],
     {
+      cwd: workTreeDir,
       stdio: "inherit",
       env: process.env,
     },
@@ -325,6 +340,7 @@ export function restoreConfigFromBase(baseBranch: string): string[] {
   for (const p of SENSITIVE_PATHS) {
     try {
       execFileSync("git", ["checkout", `origin/${baseBranch}`, "--", p], {
+        cwd: workTreeDir,
         stdio: "pipe",
       });
     } catch {
@@ -336,6 +352,7 @@ export function restoreConfigFromBase(baseBranch: string): string[] {
   // revert doesn't silently leak into commits the CLI makes later.
   try {
     execFileSync("git", ["reset", "--", ...SENSITIVE_PATHS], {
+      cwd: workTreeDir,
       stdio: "pipe",
     });
   } catch {

--- a/test/git-config.test.ts
+++ b/test/git-config.test.ts
@@ -61,6 +61,7 @@ describe("git-config", () => {
   let originalActionPath: string | undefined;
   let originalNonWriteUsers: string | undefined;
   let originalGhToken: string | undefined;
+  let originalWorkspace: string | undefined;
   let originalGitEnv: Record<string, string | undefined>;
   let consoleLogSpy: any;
 
@@ -69,6 +70,8 @@ describe("git-config", () => {
     originalActionPath = process.env.GITHUB_ACTION_PATH;
     originalNonWriteUsers = process.env.ALLOWED_NON_WRITE_USERS;
     originalGhToken = process.env.GH_TOKEN;
+    originalWorkspace = process.env.GITHUB_WORKSPACE;
+    delete process.env.GITHUB_WORKSPACE;
     delete process.env.ALLOWED_NON_WRITE_USERS;
     originalGitEnv = {};
     for (const name of GIT_ENV_OVERRIDES) {
@@ -110,6 +113,7 @@ describe("git-config", () => {
     restoreEnv("GITHUB_ACTION_PATH", originalActionPath);
     restoreEnv("ALLOWED_NON_WRITE_USERS", originalNonWriteUsers);
     restoreEnv("GH_TOKEN", originalGhToken);
+    restoreEnv("GITHUB_WORKSPACE", originalWorkspace);
     for (const name of GIT_ENV_OVERRIDES) {
       restoreEnv(name, originalGitEnv[name]);
     }
@@ -174,6 +178,30 @@ describe("git-config", () => {
       );
       expect(gitConfigGetAll(EXTRAHEADER_KEY)).toBe("");
       expect(remoteUrl()).toBe(
+        `https://x-access-token:test-token@${SERVER.host}/test-owner/test-repo.git`,
+      );
+    });
+  });
+
+  describe("working directory", () => {
+    // The action runs as a composite step and has always taken the repository
+    // from the process working directory. Everything else in the action locates
+    // the checkout through GITHUB_WORKSPACE (see install-mcp-server.ts), so when
+    // the two disagree these git calls ran outside the checkout and git exited
+    // 128 with "not in a git directory" (issue #1591).
+    test("configures the checkout named by GITHUB_WORKSPACE, not the process cwd", async () => {
+      process.chdir(tempDir);
+      process.env.GITHUB_WORKSPACE = repoDir;
+
+      await configureGitAuth("test-token", createMockAutomationContext(), {
+        login: "claude[bot]",
+        id: 42,
+      });
+
+      expect(
+        runGit(["config", "--local", "--get-all", "user.name"], repoDir),
+      ).toBe("claude[bot]");
+      expect(runGit(["remote", "get-url", "origin"], repoDir)).toBe(
         `https://x-access-token:test-token@${SERVER.host}/test-owner/test-repo.git`,
       );
     });

--- a/test/restore-config.test.ts
+++ b/test/restore-config.test.ts
@@ -18,12 +18,15 @@ const CLAUDE_PR_EXCLUDE_PATTERN = "/.claude-pr/";
 
 describe("restoreConfigFromBase", () => {
   let originalCwd: string;
+  let originalWorkspace: string | undefined;
   let tempDir = "";
   let repoDir: string;
   let remoteDir: string;
 
   beforeEach(() => {
     originalCwd = process.cwd();
+    originalWorkspace = process.env.GITHUB_WORKSPACE;
+    delete process.env.GITHUB_WORKSPACE;
     tempDir = mkdtempSync(join("/tmp", "restore-config-"));
     repoDir = join(tempDir, "repo");
     remoteDir = join(tempDir, "origin.git");
@@ -60,6 +63,11 @@ describe("restoreConfigFromBase", () => {
 
   afterEach(() => {
     process.chdir(originalCwd);
+    if (originalWorkspace === undefined) {
+      delete process.env.GITHUB_WORKSPACE;
+    } else {
+      process.env.GITHUB_WORKSPACE = originalWorkspace;
+    }
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -423,6 +431,32 @@ describe("restoreConfigFromBase", () => {
     expect(
       git(["diff", "--name-only", "origin/main...HEAD"]).trim().split("\n"),
     ).toEqual([".claude/settings.json", "CLAUDE.md"]);
+  });
+
+  // The restore is a security control: it replaces PR-controlled config with
+  // the base-branch version before the CLI reads it. It located the checkout
+  // through the process working directory, while the rest of the action uses
+  // GITHUB_WORKSPACE, so when the two disagreed the git calls exited 128 with
+  // "not a git repository" and the whole job failed (issue #1591).
+  test("restores the checkout named by GITHUB_WORKSPACE, not the process cwd", () => {
+    process.chdir(tempDir);
+    process.env.GITHUB_WORKSPACE = repoDir;
+
+    const restored = restoreConfigFromBase("main");
+
+    expect(restored).toContain("CLAUDE.md");
+    expect(readFileSync(join(repoDir, "CLAUDE.md"), "utf8")).toBe(
+      "base claude instructions\n",
+    );
+    expect(
+      readFileSync(join(repoDir, ".claude/settings.json"), "utf8"),
+    ).toContain('"base"');
+    // The PR-authored version is snapshotted inside the checkout ...
+    expect(readFileSync(join(repoDir, ".claude-pr/CLAUDE.md"), "utf8")).toBe(
+      "pr claude instructions\n",
+    );
+    // ... and nothing is written next to the unrelated working directory.
+    expect(existsSync(join(tempDir, ".claude-pr"))).toBe(false);
   });
 
   function git(args: string[]): string {


### PR DESCRIPTION
Fixes #1591.

## API surface touched, up front

`fetchDepthArgs(depth: number)` becomes `fetchDepthArgs(depth: number, cwd?: string)`. Existing calls compile and behave identically. `repo-dir.ts` is a new internal module. Nothing in `base-action/` is touched, so the published `@anthropic-ai/claude-code-base-action` surface is unchanged.

## What breaks

`configureGitAuth` and `restoreConfigFromBase` run git with no `cwd`, so both inherit whatever directory the composite step happens to be in. When that directory is not the checkout, git exits 128:

```
Configuring git user...
fatal: not in a git directory
Failed to configure git authentication: ...
    at configureGitAuth (src/github/operations/git-config.ts:41:9)

Restoring .claude, .mcp.json, ... from origin/main (PR head is untrusted)
fatal: not a git repository (or any of the parent directories): .git
##[error]Action failed with error: Command failed: git fetch origin main --depth=1 --no-recurse-submodules
```

The first failure is swallowed by the `try/catch` in `prepareAgentMode`. The second kills the job, so no `structured_output` is produced. For anyone whose review gate is fail-closed on a missing verdict, that reads as a review block, and it looks identical to a real finding. The reporter of #1591 hit it on four PRs in one window, three consecutive runs each including `gh run rerun --failed`, and had to read raw run logs to tell infrastructure failures apart from review results.

## Root cause

The rest of the action locates the checkout through `GITHUB_WORKSPACE`. `src/mcp/install-mcp-server.ts:142` hands the file-ops server `GITHUB_WORKSPACE || cwd` as its `REPO_DIR`, and the CLI permission model scopes edits to `$GITHUB_WORKSPACE` (`src/create-prompt/index.ts:33`, `src/modes/tag/index.ts:132`). These two files are the exception. They take the repository from ambient `process.cwd()` instead.

Every git call in them lacked a working directory:

- `src/github/operations/git-config.ts:41,42,81,88,93,126,127,133,170-172`
- `src/github/operations/restore-config.ts:53,210,310,327,338`
- `src/github/operations/fetch-depth.ts:25`, reached from the restore's fetch

`restoreConfigFromBase` also does its filesystem work relative to `process.cwd()`: `rmSync(".claude-pr")`, the `lstatSync(p)` loop over `SENSITIVE_PATHS`, and `realpathSync(process.cwd())` at line 281.

## What the issue gets wrong

The follow-up comment groups #907, #1236, #1509, #1510, #1559 and #1543 with this one as a single class of "raw git subprocess calls run without an explicit cwd". I read all of them, and that grouping does not hold. #907 and #1236 are credential problems: an installation token without write access, and `git fetch` running before the action configures its own auth under `persist-credentials: false`. Neither turns on the working directory. #1591 is the only report in that list whose symptom is git failing to find a repository.

## What changed

`repositoryDir()` in a new `src/github/operations/repo-dir.ts` returns `process.env.GITHUB_WORKSPACE || process.cwd()`, matching what `install-mcp-server.ts` already does. Both files now pass it explicitly to git.

The filesystem operations in `restoreConfigFromBase` move with the git calls. Anchoring only the git side would leave a restore that fetches in the checkout while snapshotting and deleting somewhere else, which is worse than the crash it replaces. The security restore would report success while the CLI went on reading PR-controlled `.claude/` from the real checkout. That is a silent failure where there is currently a loud one. `shouldSnapshotContent` and `snapshotSensitivePath` take the literal working-tree directory alongside the resolved real path, since the containment checks need the real path and `relative()` needs the literal one.

`fetchDepthArgs` takes an optional `cwd`. `restore-config.ts` passes its directory; `branch.ts` calls it unchanged and keeps inheriting the process directory, so its behaviour is untouched.

## What I did not change

The issue proposes a second change: a distinguishable output so a consumer can tell an infrastructure failure in the action's git plumbing from a real review failure. That is not in here. It needs a decision about what the action exposes, whether a new output, an exit code or an annotation, and it deserves its own PR rather than riding along behind a working-directory fix. This change reduces how often that situation arises, which is not the same as solving it.

`branch.ts:146`, `branch-cleanup.ts` and `fetcher.ts:495` invoke git the same way, with no `cwd`. They are outside the two functions this issue names, `setupBranch` has its own open reports, and moving them is a larger blast radius than one bug fix should carry. Leaving `fetchDepthArgs`'s parameter optional keeps `branch.ts` internally consistent: today it probes and fetches in the same directory, and forcing the probe onto the workspace while the fetch stayed on cwd would break that.

## Behavioural difference

When `GITHUB_WORKSPACE` is set and differs from the process working directory, these operations now act on the workspace rather than on cwd. That is the point of the change, and it is a real difference, not a no-op. It also covers `setupSshSigning`, which writes `gpg.format`, `user.signingkey` and `commit.gpgsign` into the repository config: those land in the workspace checkout now. When the variable is unset, or set to the directory the process is already in, behaviour is byte-for-byte what it was, which is the path every existing test exercises.

I could not reproduce the hosted-runner conditions that make the two diverge, and I am not claiming to know what changed on `ubuntu-latest` on 2026-08-03. What I can show is that the action contains two subsystems that disagree about where the repository is. Point git at a directory that is not the checkout and it fails exactly as reported, with both of the issue's error strings reproduced in a unit test. If a workflow checks out to a subdirectory with the `path:` input, `GITHUB_WORKSPACE` is not the repository either and this does not help that case.

## Test Plan

Two regression tests, one per file. Both set `GITHUB_WORKSPACE` to the temp repository and `chdir` somewhere else, which is the condition the issue describes. The restore test also asserts that nothing is written next to the unrelated working directory, so it fails if the fix anchors git but leaves the filesystem work behind.

Existing tests now delete an ambient `GITHUB_WORKSPACE` in `beforeEach`. Actions sets that variable, so without this the suite would resolve to the action's own checkout instead of the temp repository it builds.

Environment: Ubuntu 26.04 under WSL2, bun 1.4.0, git 2.53.0. CI pins bun 1.2.12 for the test and typecheck jobs.

New tests against unmodified source:

```
$ bun test test/restore-config.test.ts test/git-config.test.ts
(fail) restoreConfigFromBase > restores the checkout named by GITHUB_WORKSPACE, not the process cwd
(fail) git-config > working directory > configures the checkout named by GITHUB_WORKSPACE, not the process cwd
 20 pass
 2 fail

error: Command failed: git diff --name-only -z --relative --ignore-submodules HEAD --
fatal: not in a git directory
```

That is the same command and the same message quoted in the issue.

Full suite, pristine `main` at a874e9e:

```
$ bun test
 957 pass
 9 fail
Ran 966 tests across 57 files.
```

Full suite with this branch:

```
$ bun test
 959 pass
 9 fail
Ran 968 tests across 57 files.
```

The nine failures are identical in both runs, all in `GitHub API client endpoint routing`, each timing out at roughly 5000 ms against the network. They are unrelated to this change and fail the same way before it.

```
$ bun run typecheck
$ tsc --noEmit
(clean)

$ bun run format:check
$ prettier --check .
All matched files use Prettier code style!
```
