### PR TITLE
fix(sanitizer): strip the invisible ranges the list was missing

### DIFF
--- a/src/github/utils/sanitizer.ts
+++ b/src/github/utils/sanitizer.ts
@@ -1,3 +1,15 @@
+/**
+ * Removes characters that render as nothing, so text a reader cannot see does
+ * not survive into content we pass on.
+ *
+ * The ranges are enumerated rather than matched as `\p{Cf}`. The format category
+ * is wider than this function wants: it also contains the Arabic number signs
+ * (U+0600-U+0605), the end-of-ayah mark used in Quranic text (U+06DD), the
+ * Syriac abbreviation mark, the Kaithi number sign and the musical beam and
+ * slur symbols. Those are content, not concealment, and a category match would
+ * silently delete them. The bidi marks U+200E and U+200F are left alone for the
+ * same reason, while the overrides and isolates below are not.
+ */
 export function stripInvisibleCharacters(content: string): string {
   content = content.replace(/[\u200B\u200C\u200D\uFEFF]/g, "");
   content = content.replace(
@@ -6,6 +18,8 @@ export function stripInvisibleCharacters(content: string): string {
   );
   content = content.replace(/\u00AD/g, "");
   content = content.replace(/[\u202A-\u202E\u2066-\u2069]/g, "");
+  content = content.replace(/[\u180E\u2060-\u2064\uFFF9-\uFFFB]/g, "");
+  content = content.replace(/[\u{E0000}-\u{E007F}]/gu, "");
   return content;
 }
 

--- a/test/sanitizer.test.ts
+++ b/test/sanitizer.test.ts
@@ -41,6 +41,70 @@ describe("stripInvisibleCharacters", () => {
   });
 });
 
+// A table rather than individual assertions, so a code point that stops being
+// handled shows up as a named failing case instead of going unnoticed.
+describe("stripInvisibleCharacters code point coverage", () => {
+  const removed: Array<[string, number]> = [
+    ["U+00AD soft hyphen", 0x00ad],
+    ["U+180E mongolian vowel separator", 0x180e],
+    ["U+200B zero width space", 0x200b],
+    ["U+200D zero width joiner", 0x200d],
+    ["U+2060 word joiner", 0x2060],
+    ["U+2061 function application", 0x2061],
+    ["U+202E right-to-left override", 0x202e],
+    ["U+2066 left-to-right isolate", 0x2066],
+    ["U+FEFF byte order mark", 0xfeff],
+    ["U+FFF9 interlinear annotation anchor", 0xfff9],
+    ["U+E0001 language tag", 0xe0001],
+    ["U+E0053 tag letter S", 0xe0053],
+    ["U+0000 null", 0x0000],
+    ["U+001F unit separator", 0x001f],
+    ["U+007F delete", 0x007f],
+  ];
+
+  const preserved: Array<[string, number]> = [
+    ["tab", 0x0009],
+    ["newline", 0x000a],
+    ["carriage return", 0x000d],
+    ["space", 0x0020],
+    ["U+2800 braille pattern blank", 0x2800],
+    ["U+3164 hangul filler", 0x3164],
+    ["U+115F hangul choseong filler", 0x115f],
+    // Format characters that carry meaning. A \p{Cf} category match would
+    // remove these, which is why the ranges above are enumerated.
+    ["U+0600 arabic number sign", 0x0600],
+    ["U+06DD arabic end of ayah", 0x06dd],
+    ["U+061C arabic letter mark", 0x061c],
+    ["U+070F syriac abbreviation mark", 0x070f],
+    ["U+200E left-to-right mark", 0x200e],
+    ["U+1D173 musical symbol begin beam", 0x1d173],
+  ];
+
+  for (const [name, cp] of removed) {
+    it(`removes ${name}`, () => {
+      expect(
+        stripInvisibleCharacters("A" + String.fromCodePoint(cp) + "B"),
+      ).toBe("AB");
+    });
+  }
+
+  for (const [name, cp] of preserved) {
+    it(`preserves ${name}`, () => {
+      const ch = String.fromCodePoint(cp);
+      expect(stripInvisibleCharacters("A" + ch + "B")).toBe("A" + ch + "B");
+    });
+  }
+
+  it("removes a run of tag characters without touching the visible text", () => {
+    const tagged = [..."HIDDEN"]
+      .map((c) => String.fromCodePoint(0xe0000 + c.codePointAt(0)!))
+      .join("");
+    expect(stripInvisibleCharacters(`before ${tagged}after`)).toBe(
+      "before after",
+    );
+  });
+});
+
 describe("stripMarkdownImageAltText", () => {
   it("should remove alt text from markdown images", () => {
     expect(stripMarkdownImageAltText("![example alt text](image.png)")).toBe(


### PR DESCRIPTION
`stripInvisibleCharacters` handles the zero-width set, the bidi overrides and isolates, the soft hyphen and the byte order mark. Other ranges render as nothing and pass through unchanged: the Mongolian vowel separator `U+180E`, the word joiner and invisible operators `U+2060` to `U+2064`, the interlinear annotation marks `U+FFF9` to `U+FFFB`, and the Tags block `U+E0000` to `U+E007F`.

Root cause is the enumeration in `src/github/utils/sanitizer.ts:1-10`. This adds two lines to it and removes nothing.

Kept as an enumeration rather than switching to `\p{Cf}`, which was the obvious alternative. That category also holds the Arabic number signs `U+0600` to `U+0605`, the end-of-ayah mark used in Quranic text `U+06DD`, the Syriac abbreviation mark, the Kaithi number sign and the musical beam and slur symbols. Those are content rather than concealment, and a category match would delete them silently. `U+200E` and `U+200F` stay untouched for the same reason, which matches the existing behaviour.

No API surface changes.

The behavioural difference is that four further ranges are now stripped, so text relying on a word joiner or an annotation mark surviving would lose it.

The tests are a code point table covering both what is removed and what is deliberately kept, so a regression in either direction fails by name.

## Test Plan

```
bun test test/sanitizer.test.ts     86 pass, 0 fail
bun test                            954 pass, 41 fail
bun run typecheck                   clean
bun run format:check                clean
```

Baseline on `a874e9e` is 925 pass, 41 fail, the same 41 both times and all pre-existing on Windows. With `src/` reverted and the tests kept, 6 of the new cases fail.
