### PR TITLE
fix(base-action): don't reject successful runs when num_turns exceeds maxTurns

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -238,16 +238,13 @@ export async function runClaudeWithSdk(
     throw new Error("No result message received from Claude");
   }
 
-  if (
-    resultMessage.subtype === "success" &&
-    !resultMessage.is_error &&
-    sdkOptions.maxTurns !== undefined &&
-    resultMessage.num_turns > sdkOptions.maxTurns
-  ) {
-    const message = `Claude reported a successful result after ${resultMessage.num_turns} turns, exceeding the configured maximum of ${sdkOptions.maxTurns}`;
-    core.error(message);
-    throw new Error(message);
-  }
+  // maxTurns bounds model round trips, but result.num_turns counts every turn in
+  // the transcript, and batched tool calls inflate that well past the round-trip
+  // count. Comparing the two rejected runs the SDK itself reported as successful
+  // within the limit (a --max-turns 14 run returning num_turns 27). A genuine
+  // overrun is reported by the SDK as a non-success subtype (error_max_turns),
+  // which the isSuccess check below already treats as failure, so there is
+  // nothing to re-check against num_turns here.
 
   // subtype "success" with is_error:true means the run errored without producing
   // a real result — treat it as failure so CI does not show a misleading green check.

--- a/base-action/test/run-claude-sdk.test.ts
+++ b/base-action/test/run-claude-sdk.test.ts
@@ -218,15 +218,11 @@ describe("runClaudeWithSdk", () => {
     }
   });
 
-  test("fails closed when a successful result exceeds maxTurns", async () => {
+  test("accepts a successful result whose num_turns exceeds maxTurns (batched tool calls)", async () => {
     const consoleErrorSpy = spyOn(console, "error").mockImplementation(
       () => {},
     );
     const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
-    const coreErrorSpy = spyOn(
-      await import("@actions/core"),
-      "error",
-    ).mockImplementation(() => {});
 
     tempDir = await mkdtemp(join(tmpdir(), "claude-sdk-"));
     process.env.RUNNER_TEMP = tempDir;
@@ -241,12 +237,16 @@ describe("runClaudeWithSdk", () => {
       model: "claude-opus-4-7",
     };
 
+    // maxTurns bounds model round trips; num_turns counts every transcript turn,
+    // which batched tool calls inflate past the round-trip count. A --max-turns 14
+    // run returning num_turns 27 is the reported case (#1758): the SDK considered
+    // it a success within the limit, so the action must not reject it.
     const successResultMessage = {
       type: "result",
       subtype: "success",
       is_error: false,
       duration_ms: 960000,
-      num_turns: 73,
+      num_turns: 27,
       total_cost_usd: 0,
       permission_denials: [],
     };
@@ -263,25 +263,68 @@ describe("runClaudeWithSdk", () => {
 
       await expect(
         runClaudeWithSdk(promptPath, {
-          sdkOptions: { maxTurns: 60 },
+          sdkOptions: { maxTurns: 14 },
           showFullOutput: false,
           hasJsonSchema: false,
         }),
-      ).rejects.toThrow(
-        "Claude reported a successful result after 73 turns, exceeding the configured maximum of 60",
-      );
-
-      const executionFile = join(tempDir, "claude-execution-output.json");
-      await expect(readFile(executionFile, "utf-8")).resolves.toBe(
-        JSON.stringify([initMessage, successResultMessage], null, 2),
-      );
-      expect(coreErrorSpy).toHaveBeenCalledWith(
-        "Claude reported a successful result after 73 turns, exceeding the configured maximum of 60",
-      );
+      ).resolves.toMatchObject({ conclusion: "success" });
     } finally {
       consoleErrorSpy.mockRestore();
       consoleLogSpy.mockRestore();
-      coreErrorSpy.mockRestore();
+    }
+  });
+
+  test("fails when the SDK reports a max-turns overrun", async () => {
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => {},
+    );
+    const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    tempDir = await mkdtemp(join(tmpdir(), "claude-sdk-"));
+    process.env.RUNNER_TEMP = tempDir;
+
+    const promptPath = join(tempDir, "prompt.txt");
+    await writeFile(promptPath, "test prompt");
+
+    const initMessage = {
+      type: "system",
+      subtype: "init",
+      session_id: "session-123",
+      model: "claude-opus-4-7",
+    };
+
+    // A genuine overrun is the SDK's call: it reports a non-success subtype, and
+    // that must still fail the run so enforcement is preserved.
+    const errorResultMessage = {
+      type: "result",
+      subtype: "error_max_turns",
+      is_error: true,
+      duration_ms: 960000,
+      num_turns: 14,
+      total_cost_usd: 0,
+      permission_denials: [],
+    };
+
+    mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+      query: async function* () {
+        yield initMessage;
+        yield errorResultMessage;
+      },
+    }));
+
+    try {
+      const { runClaudeWithSdk } = await import("../src/run-claude-sdk");
+
+      await expect(
+        runClaudeWithSdk(promptPath, {
+          sdkOptions: { maxTurns: 14 },
+          showFullOutput: false,
+          hasJsonSchema: false,
+        }),
+      ).rejects.toThrow("Claude execution failed");
+    } finally {
+      consoleErrorSpy.mockRestore();
+      consoleLogSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
Fixes #1758.

`run-claude-sdk.ts` re-checked the SDK's result with `num_turns > maxTurns` and threw on a run the SDK had already reported as `subtype: "success", is_error: false`. The two quantities aren't comparable: `maxTurns` bounds model round trips, while `num_turns` counts every turn in the transcript, and batched tool calls inflate it well past the round-trip count. The issue has a concrete trace, a `--max-turns 14` run returning `num_turns: 27`, reported as a success by the SDK and then failed by this guard, leaving the tracking comment stuck.

Dropping the guard doesn't lose genuine enforcement. A real overrun is reported by the SDK as a non-success subtype (`error_max_turns`), which the existing `isSuccess` check (`subtype === "success" && !is_error`) already treats as a failure and throws on. So typed `maxTurns` enforcement, `is_error` handling, and timeouts all stay intact; the only thing removed is the second-guess against a metric that doesn't line up.

### Changes
- Remove the post-result `num_turns > maxTurns` throw in `base-action/src/run-claude-sdk.ts`, with a comment on why the comparison isn't valid.
- Tests: the old fixture asserted the wrong behavior (`num_turns: 73 / maxTurns: 60` rejected). Replaced it with a batching-aware fixture (`num_turns: 27 / maxTurns: 14` stays a success, matching the issue's trace), and added a test that an `error_max_turns` result still fails.

### Testing
- `bun test base-action/test/run-claude-sdk.test.ts` — 5 pass
- `bun run typecheck` clean, `prettier --check` clean

Follow-up to #1607 / #1577. Per the issue, this keeps genuine `error_max_turns` enforcement rather than raising budgets or accepting failures.
