### PR TITLE
fix: remove unreachable symlink branch from getFileMode

### DIFF
--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -168,25 +168,26 @@ async function getOrCreateBranchRef(
   return baseSha;
 }
 
-// Get the appropriate Git file mode for a file
+// Get the appropriate Git file mode for a file.
+//
+// There is deliberately no 120000 (symlink) case. stat() resolves symlinks, so
+// isSymbolicLink() is never true here, and readFile() in commit_files resolves
+// them too - a symlinked path is committed as a regular blob holding the
+// target's content. Returning 120000 would require the blob content to be the
+// link target path instead, so the mode cannot be changed on its own without
+// producing a corrupt tree entry.
 async function getFileMode(filePath: string): Promise<string> {
   try {
     const fileStat = await stat(filePath);
-    if (fileStat.isFile()) {
-      // Check if execute bit is set for user
-      if (fileStat.mode & constants.S_IXUSR) {
-        return "100755"; // Executable file
-      } else {
-        return "100644"; // Regular file
-      }
-    } else if (fileStat.isDirectory()) {
+    if (fileStat.isDirectory()) {
       return "040000"; // Directory (tree)
-    } else if (fileStat.isSymbolicLink()) {
-      return "120000"; // Symbolic link
-    } else {
-      // Fallback for unknown file types
-      return "100644";
     }
+    // Check if execute bit is set for user
+    if (fileStat.isFile() && fileStat.mode & constants.S_IXUSR) {
+      return "100755"; // Executable file
+    }
+    // Regular file, and the fallback for unknown file types
+    return "100644";
   } catch (error) {
     // If we can't stat the file, default to regular file
     console.warn(


### PR DESCRIPTION
Closes #1768.

## Problem

`getFileMode` branches on `fileStat.isSymbolicLink()` to return git's symlink mode `120000`, but it obtains the stats with `stat()`, which **follows** symlinks. The returned `Stats` therefore never describes a link, `isSymbolicLink()` is always `false`, and the branch is unreachable.

The result is code that documents behaviour it does not have: symlinks are silently dereferenced (both `stat()` here and `readFile()` in `commit_files` resolve them), so a symlinked path is committed as a regular blob holding the target's content.

## Change

Drops the dead branch and records why there is no `120000` case, so the next reader does not "fix" it by swapping in `lstat`.

Behaviour is unchanged. The old and new mappings are equivalent:

| input | before | after |
| --- | --- | --- |
| file with `S_IXUSR` | `100755` | `100755` |
| regular file | `100644` | `100644` |
| directory | `040000` | `040000` |
| anything else (fifo, socket, device) | `100644` | `100644` |
| `stat()` throws | `100644` | `100644` |

## Why not implement real symlink support

Swapping `stat` for `lstat` **in isolation would be a regression, not a fix.** Git stores a symlink as a blob whose content is the *target path*. With `lstat` alone the entry would get mode `120000` while `readFile` still supplies the *target file's content* as the blob, producing a committed "symlink" pointing at a path made of that file's bytes — a corrupt tree.

Preserving links properly means changing the mode and the blob content together (`lstat` + `readlink`, with `commit_files` supplying the link target as content), plus a decision about links that escape the repo. That is a behaviour change rather than a dead-code removal, so it is deliberately left out of this PR; #1768 records the option and its trade-offs if maintainers do want it.

## Verification

- `bun run typecheck` — passes
- `bun run format:check` — passes
- `bun test` — 925 pass / 41 fail, identical to the counts on `main` before this change. The 41 failures are pre-existing and environment-specific to my Windows machine (`EPERM ... symlink` where symlink creation needs elevation, POSIX path separators in test expectations, and `0o600` file-mode assertions); none involve `github-file-ops-server.ts`.
