### PR TITLE
fix: validate inline comment line numbers

### DIFF
--- a/src/mcp/github-inline-comment-server.ts
+++ b/src/mcp/github-inline-comment-server.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { createOctokit } from "../github/api/client";
 import { redactSecrets, sanitizeContent } from "../github/utils/sanitizer";
 import { removeBufferedComment } from "./inline-comment-buffer";
+import { diffLineSchema } from "./inline-comment-schema";
 
 // Get repository and PR information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -49,20 +50,12 @@ server.tool(
           "IMPORTANT: The suggestion block will REPLACE the ENTIRE line range (single line or startLine to line). " +
           "Ensure the replacement is syntactically complete and valid - it must work as a drop-in replacement for the selected lines.",
       ),
-    line: z
-      .number()
-      .nonnegative()
-      .optional()
-      .describe(
-        "Line number for single-line comments (required if startLine is not provided)",
-      ),
-    startLine: z
-      .number()
-      .nonnegative()
-      .optional()
-      .describe(
-        "Start line for multi-line comments (use with line parameter for the end line)",
-      ),
+    line: diffLineSchema.describe(
+      "Line number for single-line comments (required if startLine is not provided)",
+    ),
+    startLine: diffLineSchema.describe(
+      "Start line for multi-line comments (use with line parameter for the end line)",
+    ),
     side: z
       .enum(["LEFT", "RIGHT"])
       .optional()

--- a/src/mcp/inline-comment-schema.ts
+++ b/src/mcp/inline-comment-schema.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+export const diffLineSchema = z.number().int().positive().optional();

--- a/test/inline-comment-schema.test.ts
+++ b/test/inline-comment-schema.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import { diffLineSchema } from "../src/mcp/inline-comment-schema";
+
+describe("diffLineSchema", () => {
+  it("accepts positive integers and rejects invalid diff line numbers", () => {
+    expect(diffLineSchema.safeParse(1).success).toBe(true);
+    expect(diffLineSchema.safeParse(undefined).success).toBe(true);
+    expect(diffLineSchema.safeParse(0).success).toBe(false);
+    expect(diffLineSchema.safeParse(-1).success).toBe(false);
+    expect(diffLineSchema.safeParse(3.5).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- reject zero, negative, and fractional Git diff line numbers at the MCP tool boundary
- share the same validated schema between `line` and `startLine`
- cover valid, omitted, and invalid line-number inputs

Closes #1767.

## Validation

- `bun test test/inline-comment-schema.test.ts`
- `bun test` (967 passed)
- `bun run typecheck`
- `bun run format:check`

## Risk boundary

This only changes input validation for inline-comment line numbers. Positive integer inputs and omitted optional values retain their existing behavior; comment buffering and GitHub request construction are unchanged.

Drafted and implemented with AI assistance; all listed checks were run locally.