### PR TITLE
fix: tolerate non-JSON error bodies in app token exchange

### DIFF
--- a/src/github/token.ts
+++ b/src/github/token.ts
@@ -53,6 +53,44 @@ function isWorkflowValidationError(
   );
 }
 
+// Cap how much of a non-JSON error body is surfaced. A gateway can answer with
+// a whole HTML page; the opening lines are enough to identify what replied.
+const MAX_ERROR_BODY_CHARS = 500;
+
+/**
+ * Read a failed response's body without letting a non-JSON body mask the
+ * failure.
+ *
+ * The exchange endpoint answers with JSON, but a proxy or gateway in front of
+ * it can return an HTML error page or an empty body. `response.json()` then
+ * throws a SyntaxError that replaces the real failure: the status and
+ * statusText are never logged, `isWorkflowValidationError` never gets to run,
+ * and `retryWithBackoff` retries a response that will never parse.
+ */
+async function readErrorResponseBody(
+  response: Response,
+): Promise<AppTokenExchangeErrorResponse> {
+  let rawBody: string;
+  try {
+    rawBody = await response.text();
+  } catch {
+    return {};
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(rawBody);
+    if (parsed !== null && typeof parsed === "object") {
+      return parsed as AppTokenExchangeErrorResponse;
+    }
+  } catch {
+    // Not JSON. Fall through and surface the body as plain text instead, so
+    // the status line below still reaches the user.
+  }
+
+  const snippet = rawBody.trim().slice(0, MAX_ERROR_BODY_CHARS);
+  return snippet ? { message: snippet } : {};
+}
+
 async function getOidcToken(): Promise<string> {
   try {
     const oidcToken = await core.getIDToken("claude-code-github-action");
@@ -123,8 +161,7 @@ async function exchangeForAppToken(
   );
 
   if (!response.ok) {
-    const responseJson =
-      (await response.json()) as AppTokenExchangeErrorResponse;
+    const responseJson = await readErrorResponseBody(response);
 
     if (isWorkflowValidationError(response.status, responseJson)) {
       const message = getAppTokenExchangeErrorMessage(responseJson);
@@ -135,11 +172,13 @@ async function exchangeForAppToken(
       throw new WorkflowValidationSkipError(message);
     }
 
+    // Keep the status in the thrown error, not just in the log line: it is the
+    // most actionable part of the failure, and for an empty body it is the only
+    // information there is.
     const message = getAppTokenExchangeErrorMessage(responseJson);
-    console.error(
-      `App token exchange failed: ${response.status} ${response.statusText} - ${message}`,
-    );
-    throw new Error(message);
+    const failure = `App token exchange failed: ${response.status} ${response.statusText} - ${message}`;
+    console.error(failure);
+    throw new Error(failure);
   }
 
   const appTokenData = (await response.json()) as {

--- a/src/github/token.ts
+++ b/src/github/token.ts
@@ -57,9 +57,72 @@ function isWorkflowValidationError(
 // a whole HTML page; the opening lines are enough to identify what replied.
 const MAX_ERROR_BODY_CHARS = 500;
 
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
 /**
- * Read a failed response's body without letting a non-JSON body mask the
- * failure.
+ * Narrow a parsed body to the fields we understand, keeping only the ones that
+ * really are strings.
+ *
+ * A body being JSON says nothing about its shape: a gateway can answer a 401
+ * with `{"message":{"error":"unauthorized"}}`. Casting such a body to
+ * `AppTokenExchangeErrorResponse` puts a non-string where the callers expect a
+ * string, and `isWorkflowValidationError` then throws a TypeError on
+ * `message.toLowerCase()` - masking the status exactly like the SyntaxError
+ * this path exists to avoid.
+ *
+ * Returns undefined when the body carries none of the fields we read, so the
+ * caller can fall back to the raw snippet rather than pass on an empty shape.
+ */
+function narrowErrorResponse(
+  parsed: unknown,
+): AppTokenExchangeErrorResponse | undefined {
+  const root = asRecord(parsed);
+  if (!root) {
+    return undefined;
+  }
+
+  const errorObject = asRecord(root.error);
+  // `error` is documented as an object, but tolerate `{"error":"unauthorized"}`
+  // rather than discard the only message the response carries.
+  const errorMessage = asString(errorObject?.message) ?? asString(root.error);
+  const errorCode = asString(asRecord(errorObject?.details)?.error_code);
+  const message = asString(root.message);
+
+  if (
+    message === undefined &&
+    errorMessage === undefined &&
+    errorCode === undefined
+  ) {
+    return undefined;
+  }
+
+  const narrowed: AppTokenExchangeErrorResponse = {};
+  if (message !== undefined) {
+    narrowed.message = message;
+  }
+  if (errorMessage !== undefined || errorCode !== undefined) {
+    narrowed.error = {};
+    if (errorMessage !== undefined) {
+      narrowed.error.message = errorMessage;
+    }
+    if (errorCode !== undefined) {
+      narrowed.error.details = { error_code: errorCode };
+    }
+  }
+
+  return narrowed;
+}
+
+/**
+ * Read a failed response's body without letting that body mask the failure.
  *
  * The exchange endpoint answers with JSON, but a proxy or gateway in front of
  * it can return an HTML error page or an empty body. `response.json()` then
@@ -78,15 +141,17 @@ async function readErrorResponseBody(
   }
 
   try {
-    const parsed: unknown = JSON.parse(rawBody);
-    if (parsed !== null && typeof parsed === "object") {
-      return parsed as AppTokenExchangeErrorResponse;
+    const narrowed = narrowErrorResponse(JSON.parse(rawBody));
+    if (narrowed) {
+      return narrowed;
     }
   } catch {
-    // Not JSON. Fall through and surface the body as plain text instead, so
-    // the status line below still reaches the user.
+    // Not JSON.
   }
 
+  // Either not JSON, or a shape none of the callers can read. Surface the body
+  // as plain text instead, so the status line below still reaches the user
+  // along with whatever the gateway actually said.
   const snippet = rawBody.trim().slice(0, MAX_ERROR_BODY_CHARS);
   return snippet ? { message: snippet } : {};
 }

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -141,6 +141,55 @@ describe("setupGitHubToken", () => {
     expect(warningSpy).not.toHaveBeenCalled();
   });
 
+  test("reports the status when the error body is not JSON", async () => {
+    fetchSpy.mockImplementation(
+      async () =>
+        new Response("<html><body>502 Bad Gateway</body></html>", {
+          status: 502,
+          statusText: "Bad Gateway",
+        }),
+    );
+
+    // Without a guarded parse this rejects with a SyntaxError
+    // ("Unexpected token '<'"), losing the status entirely.
+    await expect(setupGitHubToken()).rejects.toThrow(
+      "App token exchange failed: 502 Bad Gateway",
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  test("reports the status when the error body is empty", async () => {
+    fetchSpy.mockImplementation(
+      async () =>
+        new Response("", { status: 503, statusText: "Service Unavailable" }),
+    );
+
+    await expect(setupGitHubToken()).rejects.toThrow(
+      "App token exchange failed: 503 Service Unavailable - Unknown error",
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  test("still skips on a plain-text workflow validation body", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response("Workflow validation failed for this run", {
+        status: 401,
+        statusText: "Unauthorized",
+      }),
+    );
+
+    // Previously unreachable: the parse threw before isWorkflowValidationError
+    // could inspect the body.
+    await expect(setupGitHubToken()).rejects.toBeInstanceOf(
+      WorkflowValidationSkipError,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   test("does not skip message-only workflow validation errors with unexpected status", async () => {
     const message =
       "Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.";

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -190,6 +190,92 @@ describe("setupGitHubToken", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  test("reports the status when a JSON body has a non-string message", async () => {
+    const body = JSON.stringify({ message: { error: "unauthorized" } });
+    fetchSpy.mockImplementation(
+      async () =>
+        new Response(body, { status: 401, statusText: "Unauthorized" }),
+    );
+
+    // Casting this shape instead of checking it made
+    // isWorkflowValidationError call message.toLowerCase() on an object,
+    // masking the status with a TypeError.
+    await expect(setupGitHubToken()).rejects.toThrow(
+      `App token exchange failed: 401 Unauthorized - ${body}`,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  test("reports the status when a JSON body has a non-string error message", async () => {
+    const body = JSON.stringify({ error: { message: { code: 500 } } });
+    fetchSpy.mockImplementation(
+      async () =>
+        new Response(body, {
+          status: 500,
+          statusText: "Internal Server Error",
+        }),
+    );
+
+    await expect(setupGitHubToken()).rejects.toThrow(
+      `App token exchange failed: 500 Internal Server Error - ${body}`,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  test("reports the status when the JSON body is an array", async () => {
+    const body = JSON.stringify([{ message: "unauthorized" }]);
+    fetchSpy.mockImplementation(
+      async () =>
+        new Response(body, { status: 401, statusText: "Unauthorized" }),
+    );
+
+    await expect(setupGitHubToken()).rejects.toThrow(
+      `App token exchange failed: 401 Unauthorized - ${body}`,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  test("keeps a string error field as the message", async () => {
+    fetchSpy.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ error: "unauthorized" }), {
+          status: 401,
+          statusText: "Unauthorized",
+        }),
+    );
+
+    await expect(setupGitHubToken()).rejects.toThrow(
+      "App token exchange failed: 401 Unauthorized - unauthorized",
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+  });
+
+  test("still skips when a workflow validation body has a non-string error code", async () => {
+    const message = "Workflow validation failed for this run";
+    fetchSpy.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: { message, details: { error_code: { value: 42 } } },
+        }),
+        { status: 401, statusText: "Unauthorized" },
+      ),
+    );
+
+    await expect(setupGitHubToken()).rejects.toBeInstanceOf(
+      WorkflowValidationSkipError,
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(warningSpy).toHaveBeenCalledWith(
+      `Skipping action due to workflow validation: ${message}`,
+    );
+  });
+
   test("does not skip message-only workflow validation errors with unexpected status", async () => {
     const message =
       "Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.";


### PR DESCRIPTION
Closes #1764.

## Problem

On a non-OK response, `exchangeForAppToken` unconditionally does `await response.json()`. When the body is not JSON — an HTML error page from a proxy, an empty `502`/`503` — that call throws a `SyntaxError` which **replaces** the real failure. Three things go wrong at once:

1. **The status is lost.** The user sees `Unexpected token '<', "<html>..." is not valid JSON` instead of `502 Bad Gateway`. The `console.error` line that carries `response.status`/`statusText` sits *after* the parse, so it never runs.
2. **The workflow-validation skip is missed.** `isWorkflowValidationError` never gets to inspect the body, so a `401` whose body is plain text rather than JSON is treated as a hard failure instead of the intended graceful skip (`skipped_due_to_workflow_validation_mismatch`).
3. **It retries pointlessly.** `retryWithBackoff`'s `shouldRetry` only excludes `WorkflowValidationSkipError`, so the `SyntaxError` is retried three times with backoff against an endpoint that will never return JSON.

## Change

- Add `readErrorResponseBody`: read the body once as text, parse it as JSON if it parses, otherwise fall back to surfacing the body as a `message` string (capped at 500 chars, since a gateway can return an entire HTML page). A body that fails even to read yields `{}`.
- Keep `response.status` and `statusText` in the **thrown** error, not only in the log line. For an empty body the status is the only information available, so without this the failure surfaces as a bare `Unknown error`.

The happy path is untouched — `response.json()` on a successful response is unchanged.

## Effect on the retry path

`isWorkflowValidationError` already inspects `responseJson.message`, so a `401` with a plain-text `workflow validation failed` body now takes the skip path and stops retrying, which is what the surrounding code intends. Genuine `4xx`/`5xx` failures still retry exactly as before.

## Tests

Three tests added to `test/token.test.ts`, all of which **fail on `main`** (verified by stashing the source change and re-running):

- non-JSON `502` body → rejects with `App token exchange failed: 502 Bad Gateway`, retried 3x
- empty `503` body → rejects with the status rather than a bare `Unknown error`
- plain-text `401` workflow-validation body → rejects with `WorkflowValidationSkipError` after a single attempt (previously unreachable, since the parse threw first)

The existing tests are unaffected: they assert on substrings of the thrown message, which the status prefix preserves.

## Verification

- `bun run typecheck` — passes
- `bun run format:check` — passes on both changed files
- `bun test` — 928 pass / 41 fail, against a `main` baseline of 925 pass / 41 fail. The +3 are the new tests; the 41 failures are pre-existing and specific to my Windows machine (`EPERM ... symlink` needing elevation, POSIX path separators in expectations, `0o600` mode assertions), unrelated to this change.

## Note on the error text

The non-JSON fallback puts a slice of the response body into the error message. That message reaches `core.setFailed` and the tracking comment through paths that already run it through `redactSecrets` (`run.ts`, `comment-logic.ts`), and the 500-char cap bounds how much of a stray page can be echoed.
