### PR TITLE
refactor: extract duplicated isAllowedBot into a shared module

### DIFF
--- a/src/github/utils/actor-filter.ts
+++ b/src/github/utils/actor-filter.ts
@@ -1,4 +1,38 @@
 /**
+ * Checks whether a bot actor is covered by the `allowed_bots` input.
+ *
+ * Entries and the actor are compared case-insensitively with any "[bot]" suffix
+ * removed, so "dependabot" and "dependabot[bot]" are the same entry. "*" allows
+ * every bot.
+ *
+ * Used by both authorization checks - `checkHumanActor` for non-User accounts
+ * and `checkWritePermissions` for actors the collaborator API cannot resolve -
+ * which must agree on whether a given bot is allowed.
+ *
+ * @param actor - Actor username to check
+ * @param allowedBots - Comma-separated allow-list, or "*" for all bots
+ * @returns true if the actor is allowed
+ */
+export function isAllowedBot(actor: string, allowedBots: string): boolean {
+  const trimmed = allowedBots.trim();
+  if (trimmed === "*") return true;
+  if (!trimmed) return false;
+
+  const allowedList = trimmed
+    .split(",")
+    .map((bot) =>
+      bot
+        .trim()
+        .toLowerCase()
+        .replace(/\[bot\]$/, ""),
+    )
+    .filter((bot) => bot.length > 0);
+
+  const normalizedActor = actor.toLowerCase().replace(/\[bot\]$/, "");
+  return allowedList.includes(normalizedActor);
+}
+
+/**
  * Parses actor filter string into array of patterns
  * @param filterString - Comma-separated actor names (e.g., "user1,user2,*[bot]")
  * @returns Array of actor patterns

--- a/src/github/validation/actor.ts
+++ b/src/github/validation/actor.ts
@@ -7,25 +7,7 @@
 
 import type { Octokit } from "@octokit/rest";
 import type { GitHubContext } from "../context";
-
-function isAllowedBot(actor: string, allowedBots: string): boolean {
-  const trimmed = allowedBots.trim();
-  if (trimmed === "*") return true;
-  if (!trimmed) return false;
-
-  const allowedList = trimmed
-    .split(",")
-    .map((bot) =>
-      bot
-        .trim()
-        .toLowerCase()
-        .replace(/\[bot\]$/, ""),
-    )
-    .filter((bot) => bot.length > 0);
-
-  const normalizedActor = actor.toLowerCase().replace(/\[bot\]$/, "");
-  return allowedList.includes(normalizedActor);
-}
+import { isAllowedBot } from "../utils/actor-filter";
 
 export async function checkHumanActor(
   octokit: Octokit,

--- a/src/github/validation/permissions.ts
+++ b/src/github/validation/permissions.ts
@@ -1,28 +1,7 @@
 import * as core from "@actions/core";
 import { isWorkflowRunEvent, type GitHubContext } from "../context";
 import type { Octokit } from "@octokit/rest";
-
-/**
- * Check if a bot actor is in the allowed bots list.
- */
-function isAllowedBot(actor: string, allowedBots: string): boolean {
-  const trimmed = allowedBots.trim();
-  if (trimmed === "*") return true;
-  if (!trimmed) return false;
-
-  const allowedList = trimmed
-    .split(",")
-    .map((bot) =>
-      bot
-        .trim()
-        .toLowerCase()
-        .replace(/\[bot\]$/, ""),
-    )
-    .filter((bot) => bot.length > 0);
-
-  const normalizedActor = actor.toLowerCase().replace(/\[bot\]$/, "");
-  return allowedList.includes(normalizedActor);
-}
+import { isAllowedBot } from "../utils/actor-filter";
 
 /**
  * Collect the actors whose repository access should be checked. This is

--- a/test/actor-filter.test.ts
+++ b/test/actor-filter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isAllowedBot,
   parseActorFilter,
   actorMatchesPattern,
   resolveActorName,
@@ -215,5 +216,45 @@ describe("resolveActorName", () => {
     expect(shouldIncludeCommentByActor(actor, [], ["dependabot[bot]"])).toBe(
       false,
     );
+  });
+});
+
+describe("isAllowedBot", () => {
+  test("allows every bot when set to *", () => {
+    expect(isAllowedBot("dependabot[bot]", "*")).toBe(true);
+    expect(isAllowedBot("anything", "  *  ")).toBe(true);
+  });
+
+  test("allows nothing when empty", () => {
+    expect(isAllowedBot("dependabot[bot]", "")).toBe(false);
+    expect(isAllowedBot("dependabot[bot]", "   ")).toBe(false);
+  });
+
+  test("matches with or without the [bot] suffix on either side", () => {
+    expect(isAllowedBot("dependabot[bot]", "dependabot")).toBe(true);
+    expect(isAllowedBot("dependabot", "dependabot[bot]")).toBe(true);
+    expect(isAllowedBot("dependabot[bot]", "dependabot[bot]")).toBe(true);
+    expect(isAllowedBot("dependabot", "dependabot")).toBe(true);
+  });
+
+  test("matches case-insensitively", () => {
+    expect(isAllowedBot("Copilot", "copilot")).toBe(true);
+    expect(isAllowedBot("copilot", "COPILOT[BOT]")).toBe(true);
+  });
+
+  test("handles whitespace and empty entries in the list", () => {
+    expect(isAllowedBot("renovate[bot]", " dependabot , renovate ,, ")).toBe(
+      true,
+    );
+  });
+
+  test("rejects an actor that is not listed", () => {
+    expect(isAllowedBot("renovate[bot]", "dependabot,copilot")).toBe(false);
+  });
+
+  test("does not treat * as a wildcard inside a list", () => {
+    // "*" allows all bots only as the entire value; "*[bot]" is an exact entry
+    // here, unlike actorMatchesPattern which does support it as a wildcard.
+    expect(isAllowedBot("dependabot[bot]", "*[bot]")).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #1765.

## Problem

The `allowed_bots` matcher exists twice, as two private copies in two different files, and both sit on the action's authorization path:

- `src/github/validation/actor.ts` — used by `checkHumanActor` for non-`User` account types and for actors the Users API cannot resolve
- `src/github/validation/permissions.ts` — used by `checkActorWritePermissions` when the collaborator-permission API reports the actor "is not a user"

They are byte-identical today:

```
$ diff <(sed -n 8,26p src/github/validation/permissions.ts) \
       <(sed -n 11,29p src/github/validation/actor.ts)
# (no output)
```

Both call sites decide whether an automated actor may trigger Claude. Hardening applied to one copy — trimming inside entries, supporting the `*[bot]` wildcard the way `actorMatchesPattern` does, normalising a different suffix — silently does not apply to the other, and the two checks then disagree about whether a given bot is allowed. For an authorization predicate that is the worst outcome: one layer permits what the other denies, and which one wins depends on the code path the event happens to take. Nothing currently tests that they agree.

## Change

Move the function to `src/github/utils/actor-filter.ts` and import it in both validators. That module already owns the neighbouring concerns (`parseActorFilter`, `resolveActorName`, `actorMatchesPattern`, `shouldIncludeCommentByActor`), has no imports of its own so there is no cycle risk, and already has a test file.

This is a **pure move** — no behaviour change. The extracted body is byte-identical to what was removed:

```
$ diff <(git show main:src/github/validation/actor.ts | sed -n 11,29p) \
       <(sed -n 16,34p src/github/utils/actor-filter.ts | sed 's/^export //')
# (no output)
```

All three call sites are unchanged.

## Tests

Seven tests added to `test/actor-filter.test.ts`, pinning the behaviour that previously had none of its own:

- `*` allows every bot; empty/whitespace allows none
- `[bot]` suffix optional on either side (`dependabot` ≡ `dependabot[bot]`)
- case-insensitive matching
- whitespace and empty entries tolerated in the list
- unlisted actor rejected
- `*[bot]` is an **exact entry**, not a wildcard, here

That last one is worth flagging for reviewers: `isAllowedBot` and its neighbour `actorMatchesPattern` in the same file treat `*[bot]` differently — the latter supports it as a wildcard. Since `allowed_bots` documents `*` for "all bots", the existing behaviour is defensible, so this PR pins it as-is rather than changing it. Having both functions in one file makes the difference visible instead of accidental.

## Verification

- `bun run typecheck` — passes
- `bun run format:check` — passes on all four changed files
- `bun test` — 932 pass / 41 fail, against a `main` baseline of 925 pass / 41 fail. The +7 are the new tests; the 41 failures are pre-existing and specific to my Windows machine (`EPERM ... symlink` needing elevation, POSIX path separators in expectations, `0o600` mode assertions), unrelated to this change.
- `test/actor.test.ts` and `test/permissions.test.ts` pass unchanged, confirming both call sites still behave as before.
