### PR TITLE
refactor: build the trigger regex once and drop the no-op ternary

### DIFF
--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -22,6 +22,14 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     return true;
   }
 
+  // Built once and shared by every branch below: an exact match for the trigger
+  // phrase as a whole token, preceded by start-of-string or whitespace and
+  // followed by whitespace, sentence punctuation, or end-of-string. A single
+  // instance means the branches cannot drift apart - a widened character class
+  // that reached only some of them would make the trigger fire on comments but
+  // not on PR descriptions, or vice versa.
+  const regex = buildTriggerRegex(triggerPhrase);
+
   // Check for assignee trigger
   if (isIssuesAssignedEvent(context)) {
     // Remove @ symbol from assignee_trigger if present
@@ -51,11 +59,6 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
   if (isIssuesEvent(context) && context.eventAction === "opened") {
     const issueBody = context.payload.issue.body || "";
     const issueTitle = context.payload.issue.title || "";
-    // Check for exact match with word boundaries or punctuation
-    const regex = new RegExp(
-      `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
-      "i",
-    );
 
     // Check in body
     if (regex.test(issueBody)) {
@@ -78,11 +81,6 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
   if (isPullRequestEvent(context)) {
     const prBody = context.payload.pull_request.body || "";
     const prTitle = context.payload.pull_request.title || "";
-    // Check for exact match with word boundaries or punctuation
-    const regex = new RegExp(
-      `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
-      "i",
-    );
 
     // Check in body
     if (regex.test(prBody)) {
@@ -107,11 +105,6 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     (context.eventAction === "submitted" || context.eventAction === "edited")
   ) {
     const reviewBody = context.payload.review.body || "";
-    // Check for exact match with word boundaries or punctuation
-    const regex = new RegExp(
-      `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
-      "i",
-    );
     if (regex.test(reviewBody)) {
       console.log(
         `Pull request review contains exact trigger phrase '${triggerPhrase}'`,
@@ -125,14 +118,8 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     isIssueCommentEvent(context) ||
     isPullRequestReviewCommentEvent(context)
   ) {
-    const commentBody = isIssueCommentEvent(context)
-      ? context.payload.comment.body
-      : context.payload.comment.body;
-    // Check for exact match with word boundaries or punctuation
-    const regex = new RegExp(
-      `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
-      "i",
-    );
+    // Both event payloads expose comment.body, so no narrowing is needed here.
+    const commentBody = context.payload.comment.body;
     if (regex.test(commentBody)) {
       console.log(`Comment contains exact trigger phrase '${triggerPhrase}'`);
       return true;
@@ -146,6 +133,18 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
 
 export function escapeRegExp(string: string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Builds the matcher for a trigger phrase: the phrase as a whole token, bounded
+ * by start-of-string or whitespace on the left and by whitespace, sentence
+ * punctuation, or end-of-string on the right. Case-insensitive.
+ */
+function buildTriggerRegex(triggerPhrase: string): RegExp {
+  return new RegExp(
+    `(^|\\s)${escapeRegExp(triggerPhrase)}([\\s.,!?;:]|$)`,
+    "i",
+  );
 }
 
 export async function checkTriggerAction(context: ParsedGitHubContext) {

--- a/test/trigger-validation.test.ts
+++ b/test/trigger-validation.test.ts
@@ -470,6 +470,84 @@ describe("checkContainsTrigger", () => {
       });
     });
   });
+
+  describe("matcher consistency across event types", () => {
+    // The trigger matcher used to be rebuilt independently in each branch.
+    // These pin the invariant that every event type applies the same rule, so a
+    // future change to the pattern cannot reach some branches and miss others.
+    const withTrigger = (
+      base: ParsedGitHubContext,
+      overrides: Partial<ParsedGitHubContext>,
+    ): ParsedGitHubContext => ({
+      ...base,
+      ...overrides,
+      inputs: { ...base.inputs, triggerPhrase: "@claude", prompt: "" },
+    });
+
+    const cases: Array<[string, (body: string) => ParsedGitHubContext]> = [
+      [
+        "issue body",
+        (body) =>
+          withTrigger(mockIssueOpenedContext, {
+            payload: {
+              ...mockIssueOpenedContext.payload,
+              issue: {
+                ...(mockIssueOpenedContext.payload as IssuesEvent).issue,
+                body,
+              },
+            } as IssuesEvent,
+          }),
+      ],
+      [
+        "issue comment",
+        (body) =>
+          withTrigger(mockIssueCommentContext, {
+            payload: {
+              ...mockIssueCommentContext.payload,
+              comment: {
+                ...(mockIssueCommentContext.payload as IssueCommentEvent)
+                  .comment,
+                body,
+              },
+            } as IssueCommentEvent,
+          }),
+      ],
+      [
+        "review body",
+        (body) =>
+          withTrigger(mockPullRequestReviewContext, {
+            payload: {
+              ...mockPullRequestReviewContext.payload,
+              review: {
+                ...(
+                  mockPullRequestReviewContext.payload as PullRequestReviewEvent
+                ).review,
+                body,
+              },
+            } as PullRequestReviewEvent,
+          }),
+      ],
+    ];
+
+    const shouldMatch = [
+      "@claude please look",
+      "hey @claude",
+      "@claude, thoughts?",
+      "@claude",
+    ];
+    const shouldNotMatch = ["email@claude.com", "foo@claudebot", "claude"];
+
+    for (const [name, build] of cases) {
+      it(`matches the trigger phrase the same way in the ${name}`, () => {
+        for (const body of shouldMatch) {
+          expect(checkContainsTrigger(build(body))).toBe(true);
+        }
+        for (const body of shouldNotMatch) {
+          expect(checkContainsTrigger(build(body))).toBe(false);
+        }
+      });
+    }
+  });
 });
 
 describe("escapeRegExp", () => {


### PR DESCRIPTION
Closes #1766.

## Problem

Two small defects in `checkContainsTrigger`, the function that decides whether the action runs at all.

**1. A ternary whose branches are identical.**

```ts
const commentBody = isIssueCommentEvent(context)
  ? context.payload.comment.body
  : context.payload.comment.body;
```

The enclosing `if` has already narrowed the type, and both event payloads expose `comment.body`. The ternary does nothing but suggest the two shapes differ.

**2. The same matcher is constructed independently in every branch.**

```ts
const regex = new RegExp(
  `(^|\s)${escapeRegExp(triggerPhrase)}([\s.,!?;:]|$)`,
  "i",
);
```

appears verbatim in the issue, pull request, review, and comment branches — four copies that must stay in agreement. Widening the character class (say to accept a trailing `)`) in some but not all of them would make `@claude` fire on comments but not on PR descriptions. That divergence is invisible until a user reports it.

> Correction to the issue: it says *five* copies, counting the issue-title check separately. That is wrong — the title check reuses the `regex` already declared in the issue branch. There are **four** `new RegExp` sites. I have commented on #1766 with the correction.

## Change

- Extract `buildTriggerRegex(triggerPhrase)` next to `escapeRegExp`, which it uses, and build the matcher once at the top of `checkContainsTrigger`.
- Replace the ternary with the direct property access.

No behaviour change. The regex source and flags are byte-identical to the four originals (verified with `diff`, modulo indentation).

## Why sharing one instance is safe

Hoisting a `RegExp` out of its branches is only sound if it carries no state. This one has the `i` flag and **no `g` flag**, so `.test()` does not advance `lastIndex` and repeated calls across branches cannot interfere. There is no `g` anywhere in the file. Worth stating explicitly, since it is the one way this refactor could have gone wrong.

The regex is now built on every call that gets past the `prompt` short-circuit, rather than lazily inside a matching branch. `escapeRegExp` on a short trigger phrase is negligible, and the construction is unconditional-but-cheap in exchange for a single source of truth.

## Tests

Three tests added under `matcher consistency across event types`, asserting that the issue body, issue comment, and review body all accept the same four trigger forms and reject the same three near-misses (`email@claude.com`, `foo@claudebot`, `claude`).

To be clear about what these are: they **pass on `main` as well** — the four copies are identical today, so there is no bug to regress against. They are an invariant pin, not a regression test. Their value is that they now fail if a future change reaches some branches and not others, which is exactly the failure mode this PR removes the opportunity for.

## Verification

- `bun run typecheck` — passes
- `bun run format:check` — passes on both changed files
- `bun test` — 928 pass / 41 fail, against a `main` baseline of 925 pass / 41 fail; `test/trigger-validation.test.ts` alone goes 27 → 30, confirming the three additions and no lost tests. The 41 failures are pre-existing and specific to my Windows machine (`EPERM ... symlink` needing elevation, POSIX path separators in expectations, `0o600` mode assertions), unrelated to this change.
