### PR TITLE
fix: require positive integer line numbers for inline comments

### DIFF
--- a/src/mcp/github-inline-comment-schemas.ts
+++ b/src/mcp/github-inline-comment-schemas.ts
@@ -3,11 +3,12 @@ import { z } from "zod";
 /**
  * Raw shape passed to `server.tool` for create_inline_comment.
  *
- * `line` and `startLine` are constrained to positive integers. Diff line
- * numbers are 1-based, so 0 is never valid, and the handler tests them for
- * falsiness (`!line`, `!startLine`) rather than for presence - so a 0 that got
- * past the schema would be read as "absent" and silently change the request
- * rather than be rejected.
+ * `line` and `startLine` are constrained to positive integers: diff line
+ * numbers are 1-based, so 0 and fractions are never valid, and a 0 reaching
+ * the handler would be indistinguishable from an omitted argument.
+ *
+ * Rules that involve both fields live in `createInlineCommentPayloadSchema`
+ * below, which is what the handler parses through.
  */
 export const createInlineCommentInputSchema = {
   path: z
@@ -27,7 +28,7 @@ export const createInlineCommentInputSchema = {
     .positive()
     .optional()
     .describe(
-      "Line number for single-line comments (required if startLine is not provided)",
+      "Line number for the comment. Always required: the line for a single-line comment, or the END line of the range when startLine is given.",
     ),
   startLine: z
     .number()
@@ -35,7 +36,7 @@ export const createInlineCommentInputSchema = {
     .positive()
     .optional()
     .describe(
-      "Start line for multi-line comments (use with line parameter for the end line)",
+      "Start line for multi-line comments. Must be provided together with line (the end line), and must not be greater than it.",
     ),
   side: z
     .enum(["LEFT", "RIGHT"])
@@ -59,6 +60,42 @@ export const createInlineCommentInputSchema = {
     ),
 };
 
-export const createInlineCommentPayloadSchema = z.object(
-  createInlineCommentInputSchema,
-);
+/**
+ * Full payload schema, including the rules that span more than one field.
+ *
+ * `server.tool` is registered with the raw shape above, which is converted to
+ * JSON Schema key by key and so cannot express the relationship between `line`
+ * and `startLine`. The handler parses through this schema instead, so those
+ * rules are enforced in one place rather than re-implemented as ad-hoc checks.
+ *
+ * `line` is required either way: it is the line for a single-line comment and
+ * the end line of the range for a multi-line one. A `startLine` without it
+ * would be sent to GitHub as `start_line` with `line: undefined`.
+ */
+export const createInlineCommentPayloadSchema = z
+  .object(createInlineCommentInputSchema)
+  .superRefine((data, ctx) => {
+    if (data.line === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["line"],
+        message:
+          data.startLine === undefined
+            ? "Either 'line' for single-line comments or both 'startLine' and 'line' for multi-line comments must be provided"
+            : "'line' is required when 'startLine' is provided: it is the end line of the multi-line range",
+      });
+      return;
+    }
+
+    if (data.startLine !== undefined && data.startLine > data.line) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["startLine"],
+        message: `'startLine' (${data.startLine}) must not be greater than 'line' (${data.line}), which is the end of the range`,
+      });
+    }
+  })
+  // Every branch above requires `line`, so it is present by the time the
+  // transform runs. Restating that here keeps the handler from having to
+  // re-check it before passing the value to the GitHub API.
+  .transform((data) => ({ ...data, line: data.line as number }));

--- a/src/mcp/github-inline-comment-schemas.ts
+++ b/src/mcp/github-inline-comment-schemas.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+/**
+ * Raw shape passed to `server.tool` for create_inline_comment.
+ *
+ * `line` and `startLine` are constrained to positive integers. Diff line
+ * numbers are 1-based, so 0 is never valid, and the handler tests them for
+ * falsiness (`!line`, `!startLine`) rather than for presence - so a 0 that got
+ * past the schema would be read as "absent" and silently change the request
+ * rather than be rejected.
+ */
+export const createInlineCommentInputSchema = {
+  path: z
+    .string()
+    .describe("The file path to comment on (e.g., 'src/index.js')"),
+  body: z
+    .string()
+    .describe(
+      "The comment text (supports markdown and GitHub code suggestion blocks). " +
+        "For code suggestions, use: ```suggestion\\nreplacement code\\n```. " +
+        "IMPORTANT: The suggestion block will REPLACE the ENTIRE line range (single line or startLine to line). " +
+        "Ensure the replacement is syntactically complete and valid - it must work as a drop-in replacement for the selected lines.",
+    ),
+  line: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      "Line number for single-line comments (required if startLine is not provided)",
+    ),
+  startLine: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      "Start line for multi-line comments (use with line parameter for the end line)",
+    ),
+  side: z
+    .enum(["LEFT", "RIGHT"])
+    .optional()
+    .default("RIGHT")
+    .describe(
+      "Side of the diff to comment on: LEFT (old code) or RIGHT (new code)",
+    ),
+  commit_id: z
+    .string()
+    .optional()
+    .describe("Specific commit SHA to comment on (defaults to latest commit)"),
+  confirmed: z
+    .boolean()
+    .optional()
+    .describe(
+      "Set true to post immediately. When omitted, the call is buffered " +
+        "and classified after the session completes — real review comments " +
+        "post, test/probe comments are dropped. Set false to buffer and " +
+        "never post. Only set true when posting final review comments.",
+    ),
+};
+
+export const createInlineCommentPayloadSchema = z.object(
+  createInlineCommentInputSchema,
+);

--- a/src/mcp/github-inline-comment-server.ts
+++ b/src/mcp/github-inline-comment-server.ts
@@ -3,7 +3,10 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { appendFileSync } from "fs";
 import { createOctokit } from "../github/api/client";
-import { createInlineCommentInputSchema } from "./github-inline-comment-schemas";
+import {
+  createInlineCommentInputSchema,
+  createInlineCommentPayloadSchema,
+} from "./github-inline-comment-schemas";
 import { redactSecrets, sanitizeContent } from "../github/utils/sanitizer";
 import { removeBufferedComment } from "./inline-comment-buffer";
 
@@ -38,8 +41,23 @@ server.tool(
   "create_inline_comment",
   "Create an inline comment on a specific line or lines in a PR file",
   createInlineCommentInputSchema,
-  async ({ path, body, line, startLine, side, commit_id, confirmed }) => {
+  async (args) => {
     try {
+      // The tool is registered with the raw shape, which cannot express the
+      // rules that span `line` and `startLine`. Re-parsing here applies them
+      // before the comment is buffered or sent, so an unusable range is
+      // reported back to the caller instead of reaching the GitHub API.
+      const validated = createInlineCommentPayloadSchema.safeParse(args);
+
+      if (!validated.success) {
+        throw new Error(
+          validated.error.issues.map((issue) => issue.message).join(" "),
+        );
+      }
+
+      const { path, body, line, startLine, side, commit_id, confirmed } =
+        validated.data;
+
       const githubToken = process.env.GITHUB_TOKEN;
 
       if (!githubToken) {
@@ -52,13 +70,6 @@ server.tool(
 
       // Sanitize the comment body to remove potential prompt injections and redact secrets
       const sanitizedBody = redactSecrets(sanitizeContent(body));
-
-      // Validate that either line or both startLine and line are provided
-      if (!line && !startLine) {
-        throw new Error(
-          "Either 'line' for single-line comments or both 'startLine' and 'line' for multi-line comments must be provided",
-        );
-      }
 
       if (CLASSIFY_ENABLED && confirmed !== true) {
         appendFileSync(
@@ -99,7 +110,7 @@ server.tool(
 
       // If only line is provided, it's a single-line comment
       // If both startLine and line are provided, it's a multi-line comment
-      const isSingleLine = !startLine;
+      const isSingleLine = startLine === undefined;
 
       const octokit = createOctokit(githubToken).rest;
 

--- a/src/mcp/github-inline-comment-server.ts
+++ b/src/mcp/github-inline-comment-server.ts
@@ -2,8 +2,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { appendFileSync } from "fs";
-import { z } from "zod";
 import { createOctokit } from "../github/api/client";
+import { createInlineCommentInputSchema } from "./github-inline-comment-schemas";
 import { redactSecrets, sanitizeContent } from "../github/utils/sanitizer";
 import { removeBufferedComment } from "./inline-comment-buffer";
 
@@ -37,55 +37,7 @@ const server = new McpServer({
 server.tool(
   "create_inline_comment",
   "Create an inline comment on a specific line or lines in a PR file",
-  {
-    path: z
-      .string()
-      .describe("The file path to comment on (e.g., 'src/index.js')"),
-    body: z
-      .string()
-      .describe(
-        "The comment text (supports markdown and GitHub code suggestion blocks). " +
-          "For code suggestions, use: ```suggestion\\nreplacement code\\n```. " +
-          "IMPORTANT: The suggestion block will REPLACE the ENTIRE line range (single line or startLine to line). " +
-          "Ensure the replacement is syntactically complete and valid - it must work as a drop-in replacement for the selected lines.",
-      ),
-    line: z
-      .number()
-      .nonnegative()
-      .optional()
-      .describe(
-        "Line number for single-line comments (required if startLine is not provided)",
-      ),
-    startLine: z
-      .number()
-      .nonnegative()
-      .optional()
-      .describe(
-        "Start line for multi-line comments (use with line parameter for the end line)",
-      ),
-    side: z
-      .enum(["LEFT", "RIGHT"])
-      .optional()
-      .default("RIGHT")
-      .describe(
-        "Side of the diff to comment on: LEFT (old code) or RIGHT (new code)",
-      ),
-    commit_id: z
-      .string()
-      .optional()
-      .describe(
-        "Specific commit SHA to comment on (defaults to latest commit)",
-      ),
-    confirmed: z
-      .boolean()
-      .optional()
-      .describe(
-        "Set true to post immediately. When omitted, the call is buffered " +
-          "and classified after the session completes — real review comments " +
-          "post, test/probe comments are dropped. Set false to buffer and " +
-          "never post. Only set true when posting final review comments.",
-      ),
-  },
+  createInlineCommentInputSchema,
   async ({ path, body, line, startLine, side, commit_id, confirmed }) => {
     try {
       const githubToken = process.env.GITHUB_TOKEN;

--- a/test/inline-comment-schema.test.ts
+++ b/test/inline-comment-schema.test.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env bun
+
+import { describe, expect, test } from "bun:test";
+import { createInlineCommentPayloadSchema } from "../src/mcp/github-inline-comment-schemas";
+
+const base = { path: "src/index.ts", body: "Looks good" };
+
+describe("createInlineCommentPayloadSchema", () => {
+  test("accepts positive integer line numbers", () => {
+    const parsed = createInlineCommentPayloadSchema.parse({
+      ...base,
+      line: 12,
+    });
+    expect(parsed.line).toBe(12);
+    expect(parsed.side).toBe("RIGHT");
+  });
+
+  test("accepts a multi-line range", () => {
+    const parsed = createInlineCommentPayloadSchema.parse({
+      ...base,
+      startLine: 8,
+      line: 12,
+    });
+    expect(parsed.startLine).toBe(8);
+    expect(parsed.line).toBe(12);
+  });
+
+  test("allows both line fields to be omitted", () => {
+    // The handler, not the schema, enforces that at least one is present, so
+    // that it can return its own explanatory message.
+    const parsed = createInlineCommentPayloadSchema.parse(base);
+    expect(parsed.line).toBeUndefined();
+    expect(parsed.startLine).toBeUndefined();
+  });
+
+  test("rejects line 0", () => {
+    // Diff line numbers are 1-based. The handler checks `!line`, so a 0 that
+    // reached it would be read as "line not provided" and rejected with a
+    // message about a missing argument instead of an out-of-range one.
+    expect(() =>
+      createInlineCommentPayloadSchema.parse({ ...base, line: 0 }),
+    ).toThrow();
+  });
+
+  test("rejects startLine 0", () => {
+    // The handler derives `isSingleLine = !startLine`, so a startLine of 0
+    // would silently collapse a multi-line comment into a single-line one on
+    // the end line, reporting success for a request it did not carry out.
+    expect(() =>
+      createInlineCommentPayloadSchema.parse({
+        ...base,
+        startLine: 0,
+        line: 12,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects negative line numbers", () => {
+    expect(() =>
+      createInlineCommentPayloadSchema.parse({ ...base, line: -1 }),
+    ).toThrow();
+    expect(() =>
+      createInlineCommentPayloadSchema.parse({
+        ...base,
+        startLine: -3,
+        line: 12,
+      }),
+    ).toThrow();
+  });
+
+  test("rejects non-integer line numbers", () => {
+    // A fractional line was previously accepted here and rejected by the
+    // GitHub API as a 422, well after the model had been told nothing was wrong.
+    expect(() =>
+      createInlineCommentPayloadSchema.parse({ ...base, line: 3.5 }),
+    ).toThrow();
+    expect(() =>
+      createInlineCommentPayloadSchema.parse({
+        ...base,
+        startLine: 1.5,
+        line: 12,
+      }),
+    ).toThrow();
+  });
+});

--- a/test/inline-comment-schema.test.ts
+++ b/test/inline-comment-schema.test.ts
@@ -25,27 +25,51 @@ describe("createInlineCommentPayloadSchema", () => {
     expect(parsed.line).toBe(12);
   });
 
-  test("allows both line fields to be omitted", () => {
-    // The handler, not the schema, enforces that at least one is present, so
-    // that it can return its own explanatory message.
-    const parsed = createInlineCommentPayloadSchema.parse(base);
-    expect(parsed.line).toBeUndefined();
-    expect(parsed.startLine).toBeUndefined();
+  test("rejects a payload with neither line nor startLine", () => {
+    expect(() => createInlineCommentPayloadSchema.parse(base)).toThrow(
+      /Either 'line' for single-line comments/,
+    );
+  });
+
+  test("rejects startLine without line", () => {
+    // `line` is the end of the range, so a startLine on its own used to reach
+    // the API as start_line with line: undefined.
+    expect(() =>
+      createInlineCommentPayloadSchema.parse({ ...base, startLine: 5 }),
+    ).toThrow(/'line' is required when 'startLine' is provided/);
+  });
+
+  test("rejects a range that ends before it starts", () => {
+    expect(() =>
+      createInlineCommentPayloadSchema.parse({
+        ...base,
+        startLine: 12,
+        line: 8,
+      }),
+    ).toThrow(/must not be greater than/);
+  });
+
+  test("accepts a range whose start and end are the same line", () => {
+    const parsed = createInlineCommentPayloadSchema.parse({
+      ...base,
+      startLine: 8,
+      line: 8,
+    });
+    expect(parsed.startLine).toBe(8);
+    expect(parsed.line).toBe(8);
   });
 
   test("rejects line 0", () => {
-    // Diff line numbers are 1-based. The handler checks `!line`, so a 0 that
-    // reached it would be read as "line not provided" and rejected with a
-    // message about a missing argument instead of an out-of-range one.
+    // Diff line numbers are 1-based, so 0 is never a line anyone can comment
+    // on - GitHub rejects it with a 422 long after the model has moved on.
     expect(() =>
       createInlineCommentPayloadSchema.parse({ ...base, line: 0 }),
     ).toThrow();
   });
 
   test("rejects startLine 0", () => {
-    // The handler derives `isSingleLine = !startLine`, so a startLine of 0
-    // would silently collapse a multi-line comment into a single-line one on
-    // the end line, reporting success for a request it did not carry out.
+    // A 0 here is treated as a real start of a range rather than as an absent
+    // argument, so it would be sent on as start_line: 0 and rejected there.
     expect(() =>
       createInlineCommentPayloadSchema.parse({
         ...base,


### PR DESCRIPTION
Closes #1767.

## Problem

`create_inline_comment` validates `line` and `startLine` with `.nonnegative()`, which permits `0`. Diff line numbers are 1-based, so `0` is never valid — and both consumers test the values for **falsiness** rather than presence, so a `0` is silently reinterpreted instead of rejected.

```ts
if (!line && !startLine) { throw new Error("Either 'line' ... must be provided"); }
const isSingleLine = !startLine;
```

**`startLine: 0, line: 12`** — accepted by the schema. `isSingleLine` is `true`, so `start_line`/`start_side` are never set and the requested 0–12 range is posted as a **single-line** comment on line 12. The tool reports success; the model has no way to see that its range was dropped.

**`line: 0`** — accepted by the schema, then rejected by the handler with *"Either 'line' for single-line comments or both 'startLine' and 'line' ... must be provided"*, even though `line` **was** provided. That sends the model looking for a missing argument rather than an out-of-range one.

Neither field was constrained to an integer either, so `line: 3.5` passed validation and was rejected by the GitHub API as a 422, long after the model had been told nothing was wrong.

## Change

Constrain both fields to `.int().positive()`. With `0` and non-integers excluded at the boundary, the existing `!line` / `!startLine` checks become correct as written, so no handler change is needed.

To make that testable, the tool's input shape moves into `src/mcp/github-inline-comment-schemas.ts`, mirroring the existing pattern in `src/mcp/github-file-ops-schemas.ts` (raw shape for `server.tool`, plus a `z.object(...)` payload schema for tests). The server imports the shape; the handler is untouched.

The extracted shape is otherwise identical to the original — a `diff` against `main` shows only the two intended `.nonnegative()` → `.int().positive()` changes, plus one cosmetic Prettier reflow of the `commit_id` description onto a single line, which now fits after the two-space de-indent.

## Tests

New `test/inline-comment-schema.test.ts`, seven tests. Three of them **fail on `main`** (verified by temporarily restoring `.nonnegative()` and re-running):

- rejects `line: 0`
- rejects `startLine: 0`
- rejects non-integer line numbers

The other four pin behaviour that must not change: positive integers accepted, multi-line ranges accepted, `side` defaulting to `RIGHT`, and both line fields still permitted to be absent — the schema deliberately does not enforce "at least one", so the handler can keep returning its own explanatory message.

## Note on the replay path

`src/entrypoints/post-buffered-inline-comments.ts` has the same falsiness assumption (`if (c.startLine)`). It is unreachable once the schema rejects `0`, since nothing can write such an entry to the buffer, so it is left alone here rather than widening this PR — worth knowing it exists if the schema is ever loosened again.

## Verification

- `bun run typecheck` — passes
- `bun run format:check` — passes on all three files
- `bun test` — 932 pass / 41 fail, against a `main` baseline of 925 pass / 41 fail. The +7 are the new tests; the 41 failures are pre-existing and specific to my Windows machine (`EPERM ... symlink` needing elevation, POSIX path separators in expectations, `0o600` mode assertions), unrelated to this change.
