### PR TITLE
fix: encode branch names in git ref API URLs

### DIFF
--- a/src/mcp/git-ref-url.ts
+++ b/src/mcp/git-ref-url.ts
@@ -1,0 +1,17 @@
+import { GITHUB_API_URL } from "../github/api/config";
+import { encodeBranchNameForUrl } from "../github/operations/comments/common";
+
+/**
+ * Builds the REST URL for a branch's git reference.
+ *
+ * The branch name is percent-encoded per path segment so that characters
+ * that are valid in a ref name but significant in a URL (notably `#`, which
+ * starts a fragment) reach GitHub instead of being dropped by the client.
+ */
+export function buildBranchRefUrl(
+  owner: string,
+  repo: string,
+  branch: string,
+): string {
+  return `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${encodeBranchNameForUrl(branch)}`;
+}

--- a/src/mcp/github-file-ops-server.ts
+++ b/src/mcp/github-file-ops-server.ts
@@ -10,6 +10,7 @@ import { GITHUB_API_URL } from "../github/api/config";
 import { isBinaryContent } from "./binary-detection";
 import { validatePathWithinRepo } from "./path-validation";
 import { updateGitReference } from "./update-git-reference";
+import { buildBranchRefUrl } from "./git-ref-url";
 import {
   commitFilesInputSchema,
   deleteFilesInputSchema,
@@ -66,7 +67,7 @@ async function getOrCreateBranchRef(
   githubToken: string,
 ): Promise<string> {
   // Try to get the branch reference
-  const refUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`;
+  const refUrl = buildBranchRefUrl(owner, repo, branch);
   const refResponse = await fetch(refUrl, {
     headers: {
       Accept: "application/vnd.github+json",
@@ -87,7 +88,7 @@ async function getOrCreateBranchRef(
   const baseBranch = process.env.BASE_BRANCH!;
 
   // Get the SHA of the base branch
-  const baseRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${baseBranch}`;
+  const baseRefUrl = buildBranchRefUrl(owner, repo, baseBranch);
   const baseRefResponse = await fetch(baseRefUrl, {
     headers: {
       Accept: "application/vnd.github+json",
@@ -119,7 +120,7 @@ async function getOrCreateBranchRef(
     const defaultBranch = repoData.default_branch;
 
     // Try default branch
-    const defaultRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${defaultBranch}`;
+    const defaultRefUrl = buildBranchRefUrl(owner, repo, defaultBranch);
     const defaultRefResponse = await fetch(defaultRefUrl, {
       headers: {
         Accept: "application/vnd.github+json",

--- a/src/mcp/update-git-reference.ts
+++ b/src/mcp/update-git-reference.ts
@@ -1,5 +1,5 @@
 import fetch, { type RequestInit, type Response } from "node-fetch";
-import { GITHUB_API_URL } from "../github/api/config";
+import { buildBranchRefUrl } from "./git-ref-url";
 import { retryWithBackoff, type RetryOptions } from "../utils/retry";
 
 type GitHubFetch = (
@@ -44,7 +44,7 @@ export async function updateGitReference({
   fetchFn = fetch,
   retryOptions,
 }: UpdateGitReferenceOptions): Promise<void> {
-  const updateRefUrl = `${GITHUB_API_URL}/repos/${owner}/${repo}/git/refs/heads/${branch}`;
+  const updateRefUrl = buildBranchRefUrl(owner, repo, branch);
 
   await retryWithBackoff(
     async () => {

--- a/test/git-ref-url.test.ts
+++ b/test/git-ref-url.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { GITHUB_API_URL } from "../src/github/api/config";
+import { buildBranchRefUrl } from "../src/mcp/git-ref-url";
+
+describe("buildBranchRefUrl", () => {
+  it("builds the refs/heads URL for a plain branch name", () => {
+    expect(buildBranchRefUrl("owner", "repo", "main")).toBe(
+      `${GITHUB_API_URL}/repos/owner/repo/git/refs/heads/main`,
+    );
+  });
+
+  it("keeps slashes in the branch name as path separators", () => {
+    expect(buildBranchRefUrl("owner", "repo", "feature/x")).toBe(
+      `${GITHUB_API_URL}/repos/owner/repo/git/refs/heads/feature/x`,
+    );
+  });
+
+  it("percent-encodes characters that would otherwise be parsed as a URL fragment", () => {
+    const url = buildBranchRefUrl("owner", "repo", "fix/#123-description");
+
+    expect(url).toBe(
+      `${GITHUB_API_URL}/repos/owner/repo/git/refs/heads/fix/%23123-description`,
+    );
+    // The full branch name survives URL parsing instead of being truncated
+    // to `refs/heads/fix/` with the rest dropped as a fragment.
+    const parsed = new URL(url);
+    expect(parsed.hash).toBe("");
+    expect(
+      parsed.pathname.endsWith("/git/refs/heads/fix/%23123-description"),
+    ).toBe(true);
+  });
+});

--- a/test/update-git-reference.test.ts
+++ b/test/update-git-reference.test.ts
@@ -37,6 +37,21 @@ describe("updateGitReference", () => {
     });
   });
 
+  it("should percent-encode URL-significant characters in the branch name", async () => {
+    // `#` is valid in a ref name (see validateBranchName) but starts a URL
+    // fragment, so an unencoded branch would be sent as `refs/heads/fix/`.
+    await updateGitReference({
+      ...reference,
+      branch: "fix/#123-description",
+      fetchFn: async (url) => {
+        expect(url).toBe(
+          `${GITHUB_API_URL}/repos/owner/repo/git/refs/heads/fix/%23123-description`,
+        );
+        return response(200);
+      },
+    });
+  });
+
   it("should not retry deterministic client errors", async () => {
     for (const status of [400, 404, 409, 422]) {
       let attempts = 0;


### PR DESCRIPTION
## Summary

- Percent-encode branch names in the `/git/refs/heads/...` request URLs built by the file ops MCP server and `updateGitReference`.
- New `buildBranchRefUrl(owner, repo, branch)` in `src/mcp/git-ref-url.ts` wraps the existing `encodeBranchNameForUrl` (the same per-segment encoding #1713 applied to link URLs) and is used at all four sites.
- The JSON body `ref: refs/heads/<branch>` used when creating a ref is intentionally left raw.

## Problem

`validateBranchName` allows `#` (e.g. `fix/#123-description`, #1167), but the branch, base branch and default branch were interpolated raw into `fetch()` URLs. `#` starts a URL fragment, so GitHub received `GET /repos/o/r/git/refs/heads/fix/` and `commit_files` / `delete_files` failed under `use_commit_signing` with `undefined is not an object (evaluating '(await refResponse.json()).object.sha')`.

Closes #1777

## Fix

The helper is a separate module rather than an inline change because `github-file-ops-server.ts` has import-time side effects (env check, `process.exit`, `runServer()`) and cannot be imported by tests; `update-git-reference.ts` and `path-validation.ts` are already split out the same way. The now-unused `GITHUB_API_URL` import in `update-git-reference.ts` is removed (`noUnusedLocals`).

## Tests

- New `test/git-ref-url.test.ts`: plain names, slash-preserving encoding, and `#` encoded as `%23` (no fragment).
- New case in `test/update-git-reference.test.ts` (which already injects `fetchFn` and asserts the URL): branch `fix/#123-description` produces a PATCH URL ending in `/git/refs/heads/fix/%23123-description`. This case fails on `main`.
- End-to-end against a local fake API over stdio (script kept out of the repo): with the fix the server sends `GET .../git/refs/heads/fix/%23123-description` and proceeds to `GET /git/commits/<sha>`; `main` sends `GET .../git/refs/heads/fix/` and fails as described.
- `bun run typecheck`, `bun run format:check`: clean. `bun test`: the only failures are the pre-existing Windows-host failures (identical list on `main`); Linux CI should be fully green.
