### PR TITLE
fix: sanitize user request before writing claude-user-request.txt

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -883,6 +883,11 @@ f. If you are unable to complete certain steps, such as running a linter or test
  * This is used to send the user's actual command/request as a separate
  * content block, enabling slash command processing in the CLI.
  *
+ * The source text is sanitized first so that hidden content stripped from the
+ * <trigger_comment> block of the prompt (HTML comments, invisible characters,
+ * image alt text, hidden attributes) cannot reach the model through this
+ * second content block instead.
+ *
  * @param context - The prepared context containing event data and trigger phrase
  * @param githubData - The fetched GitHub data containing issue/PR body content
  * @returns The extracted user request text (e.g., "/review-pr" or "fix this bug"),
@@ -907,13 +912,16 @@ function extractUserRequestFromContext(
       eventData.eventName === "pull_request_review_comment" ||
       eventData.eventName === "pull_request_review")
   ) {
-    return extractUserRequest(eventData.commentBody, triggerPhrase);
+    return extractUserRequest(
+      sanitizeContent(eventData.commentBody),
+      triggerPhrase,
+    );
   }
 
   // For issue/PR events triggered by body content, extract from the body
   if (githubData.contextData?.body) {
     const request = extractUserRequest(
-      githubData.contextData.body,
+      sanitizeContent(githubData.contextData.body),
       triggerPhrase,
     );
     if (request) {

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -1,14 +1,27 @@
 #!/usr/bin/env bun
 
-import { describe, test, expect, beforeAll } from "bun:test";
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  spyOn,
+} from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
 import {
   generatePrompt,
   getEventTypeAndContext,
   buildAllowedToolsString,
   buildDisallowedToolsString,
   prepareContext,
+  createPrompt,
 } from "../src/create-prompt";
 import type { PreparedContext } from "../src/create-prompt";
+import type { FetchDataResult } from "../src/github/data/fetcher";
 import { createMockContext } from "./mockContext";
 
 beforeAll(() => {
@@ -1385,5 +1398,154 @@ describe("prepareContext validation errors", () => {
     expect(() => prepareContext(context, commentId)).toThrow(
       "CLAUDE_BRANCH is required for issue_comment event",
     );
+  });
+});
+
+describe("createPrompt", () => {
+  const originalEnv = {
+    RUNNER_TEMP: process.env.RUNNER_TEMP,
+    GITHUB_ENV: process.env.GITHUB_ENV,
+  };
+  let tempDir: string;
+  let consoleLogSpy: ReturnType<typeof spyOn>;
+
+  const issueData: FetchDataResult = {
+    contextData: {
+      title: "Test issue",
+      body: "Issue body",
+      author: { login: "someone" },
+      createdAt: "2024-01-01T00:00:00Z",
+      state: "OPEN",
+      labels: { nodes: [] },
+      comments: { nodes: [] },
+    },
+    comments: [],
+    changedFiles: [],
+    changedFilesWithSHA: [],
+    reviewData: null,
+    imageUrlMap: new Map<string, string>(),
+  };
+
+  const issueCommentContext = (commentBody: string) =>
+    createMockContext({
+      eventName: "issue_comment",
+      eventAction: "created",
+      isPR: false,
+      entityNumber: 1,
+      inputs: { triggerPhrase: "@claude" },
+      payload: {
+        action: "created",
+        issue: { number: 1, title: "Test issue", body: "Issue body" },
+        comment: {
+          id: 55,
+          body: commentBody,
+          user: { login: "someone", id: 9 },
+        },
+      } as any,
+    });
+
+  const readUserRequest = () =>
+    readFile(
+      path.join(tempDir, "claude-prompts", "claude-user-request.txt"),
+      "utf-8",
+    );
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "create-prompt-test-"));
+    process.env.RUNNER_TEMP = tempDir;
+    process.env.GITHUB_ENV = path.join(tempDir, "github_env");
+    await writeFile(process.env.GITHUB_ENV, "");
+    consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("strips hidden content from the user request file", async () => {
+    // The same hidden channels sanitizeContent removes from the
+    // <trigger_comment> block must not reach the model through the separate
+    // user request block either.
+    const context = issueCommentContext(
+      "@claude summarize this issue <!-- injected --> \u200Bplease ![hidden alt text](https://example.com/image.png)",
+    );
+
+    await createPrompt(
+      1,
+      "main",
+      "claude/issue-1-20240101-1200",
+      issueData,
+      context,
+    );
+
+    const userRequest = await readUserRequest();
+    expect(userRequest).not.toContain("<!--");
+    expect(userRequest).not.toContain("injected");
+    expect(userRequest).not.toContain("\u200B");
+    expect(userRequest).not.toContain("hidden alt text");
+    expect(userRequest).toContain("summarize this issue");
+    expect(userRequest).toContain("please ![](https://example.com/image.png)");
+  });
+
+  test("keeps slash commands intact in the user request file", async () => {
+    const context = issueCommentContext(
+      "@claude /review-pr please check the auth module",
+    );
+
+    await createPrompt(
+      1,
+      "main",
+      "claude/issue-1-20240101-1200",
+      issueData,
+      context,
+    );
+
+    expect(await readUserRequest()).toBe(
+      "/review-pr please check the auth module",
+    );
+  });
+
+  test("sanitizes the issue body before extracting the user request", async () => {
+    const context = createMockContext({
+      eventName: "issues",
+      eventAction: "opened",
+      isPR: false,
+      entityNumber: 1,
+      inputs: { triggerPhrase: "@claude" },
+      payload: {
+        action: "opened",
+        issue: {
+          number: 1,
+          title: "Test issue",
+          body: "@claude fix the login bug <!-- injected -->",
+          user: { login: "someone", id: 9 },
+        },
+      } as any,
+    });
+    const data: FetchDataResult = {
+      ...issueData,
+      contextData: {
+        ...issueData.contextData,
+        body: "@claude fix the login bug <!-- injected -->",
+      },
+    };
+
+    await createPrompt(
+      1,
+      "main",
+      "claude/issue-1-20240101-1200",
+      data,
+      context,
+    );
+
+    expect(await readUserRequest()).toBe("fix the login bug");
   });
 });


### PR DESCRIPTION
## Summary

- Run the trigger comment and the issue/PR body through `sanitizeContent` before `extractUserRequest` derives the text written to `claude-user-request.txt`.

## Problem

The prompt's `<trigger_comment>` block is sanitized, but the user-request file, which `base-action/src/run-claude-sdk.ts` sends to the model as a second text block of the same user message, was extracted from the raw body. HTML comments, zero-width characters, image alt text and hidden attributes therefore bypassed `sanitizeContent` entirely.

Closes #1779

## Fix

Sanitize both extraction inputs inside `extractUserRequestFromContext`, so the file is exactly consistent with the sanitized `<trigger_comment>` block. Sanitizing the inputs rather than the output also means a trigger phrase hidden in an HTML comment cannot shift the extraction point. Slash-command requests (#785) are untouched because `sanitizeContent` only removes hidden content; `/review-pr please check the auth module` survives verbatim (covered by a test).

## Tests

New `createPrompt` tests in `test/create-prompt.test.ts` using temporary `RUNNER_TEMP` / `GITHUB_ENV` paths:

- a comment containing `<!-- injected -->`, U+200B and an image with alt text produces a user-request file with none of those markers and the visible text intact (fails on `main`);
- `/review-pr ...` is preserved verbatim (passes on `main` too, as a regression guard);
- the issue-body path is sanitized as well (fails on `main`).

`bun run typecheck`, `bun run format:check`: clean. `bun test`: the only failures are the pre-existing Windows-host failures (identical list on `main`); Linux CI should be fully green.
