### PR TITLE
fix: paginate comment lookup for sticky comments

### DIFF
--- a/src/github/operations/comments/create-initial.ts
+++ b/src/github/operations/comments/create-initial.ts
@@ -33,12 +33,18 @@ export async function createInitialComment(
       context.isPR &&
       isPullRequestEvent(context)
     ) {
-      const comments = await octokit.rest.issues.listComments({
-        owner,
-        repo,
-        issue_number: context.entityNumber,
-      });
-      const existingComment = comments.data.find((comment) => {
+      // Paginate so the existing sticky comment is found even when it is not
+      // on the first page (listComments defaults to 30 comments per page).
+      const comments = await octokit.paginate(
+        octokit.rest.issues.listComments,
+        {
+          owner,
+          repo,
+          issue_number: context.entityNumber,
+          per_page: 100,
+        },
+      );
+      const existingComment = comments.find((comment) => {
         const idMatch = comment.user?.id === CLAUDE_APP_BOT_ID;
         const botNameMatch =
           comment.user?.type === "Bot" &&

--- a/test/create-initial.test.ts
+++ b/test/create-initial.test.ts
@@ -1,0 +1,145 @@
+import {
+  describe,
+  test,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+  spyOn,
+} from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises";
+import os from "os";
+import path from "path";
+import type { Octokit } from "@octokit/rest";
+import { createInitialComment } from "../src/github/operations/comments/create-initial";
+import type { ParsedGitHubContext } from "../src/github/context";
+import { mockPullRequestOpenedContext } from "./mockContext";
+
+const STICKY_COMMENT_ID = 4242;
+const NEW_COMMENT_ID = 9999;
+// Mirrors the app bot id that create-initial.ts matches existing comments on.
+const CLAUDE_APP_BOT_ID = 209825114;
+
+function humanComment(index: number) {
+  return {
+    id: 1000 + index,
+    body: `human comment ${index}`,
+    user: { id: 500 + index, login: `user${index}`, type: "User" },
+  };
+}
+
+// 35 comments: more than one default page (30), with the existing Claude
+// sticky comment sitting on the second page.
+function commentsWithStickyOnSecondPage() {
+  const comments = Array.from({ length: 35 }, (_, i) => humanComment(i));
+  comments[32] = {
+    id: STICKY_COMMENT_ID,
+    body: "Claude Code is working…",
+    user: { id: CLAUDE_APP_BOT_ID, login: "claude[bot]", type: "Bot" },
+  };
+  return comments;
+}
+
+function createMockOctokit(comments: ReturnType<typeof humanComment>[]) {
+  return {
+    paginate: jest.fn().mockResolvedValue(comments),
+    rest: {
+      issues: {
+        listComments: jest.fn(),
+        updateComment: jest
+          .fn()
+          .mockResolvedValue({ data: { id: STICKY_COMMENT_ID } }),
+        createComment: jest
+          .fn()
+          .mockResolvedValue({ data: { id: NEW_COMMENT_ID } }),
+      },
+      pulls: {
+        createReplyForReviewComment: jest.fn(),
+      },
+    },
+  };
+}
+
+describe("createInitialComment with use_sticky_comment", () => {
+  const originalGithubOutput = process.env.GITHUB_OUTPUT;
+  let tempDir: string;
+  let githubOutputPath: string;
+  let consoleLogSpy: ReturnType<typeof spyOn>;
+
+  const stickyContext: ParsedGitHubContext = {
+    ...mockPullRequestOpenedContext,
+    inputs: { ...mockPullRequestOpenedContext.inputs, useStickyComment: true },
+  };
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "create-initial-test-"));
+    githubOutputPath = path.join(tempDir, "github_output");
+    await writeFile(githubOutputPath, "");
+    process.env.GITHUB_OUTPUT = githubOutputPath;
+    consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    if (originalGithubOutput === undefined) {
+      delete process.env.GITHUB_OUTPUT;
+    } else {
+      process.env.GITHUB_OUTPUT = originalGithubOutput;
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("updates an existing sticky comment beyond the first page of comments", async () => {
+    const octokit = createMockOctokit(commentsWithStickyOnSecondPage());
+
+    const result = await createInitialComment(
+      octokit as unknown as Octokit,
+      stickyContext,
+    );
+
+    expect(octokit.paginate).toHaveBeenCalledWith(
+      octokit.rest.issues.listComments,
+      {
+        owner: "test-owner",
+        repo: "test-repo",
+        issue_number: 456,
+        per_page: 100,
+      },
+    );
+    expect(octokit.rest.issues.updateComment).toHaveBeenCalledTimes(1);
+    expect(octokit.rest.issues.updateComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: "test-owner",
+        repo: "test-repo",
+        comment_id: STICKY_COMMENT_ID,
+      }),
+    );
+    expect(octokit.rest.issues.createComment).not.toHaveBeenCalled();
+    expect(result.id).toBe(STICKY_COMMENT_ID);
+    expect(await readFile(githubOutputPath, "utf-8")).toBe(
+      `claude_comment_id=${STICKY_COMMENT_ID}\n`,
+    );
+  });
+
+  test("creates a new comment when no sticky comment exists", async () => {
+    const octokit = createMockOctokit(
+      Array.from({ length: 35 }, (_, i) => humanComment(i)),
+    );
+
+    const result = await createInitialComment(
+      octokit as unknown as Octokit,
+      stickyContext,
+    );
+
+    expect(octokit.rest.issues.updateComment).not.toHaveBeenCalled();
+    expect(octokit.rest.issues.createComment).toHaveBeenCalledTimes(1);
+    expect(octokit.rest.issues.createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: "test-owner",
+        repo: "test-repo",
+        issue_number: 456,
+      }),
+    );
+    expect(result.id).toBe(NEW_COMMENT_ID);
+  });
+});


### PR DESCRIPTION
## Summary

- Use `octokit.paginate(octokit.rest.issues.listComments, { ..., per_page: 100 })` when searching for the existing sticky comment, then `.find` over the full list.

## Problem

`createInitialComment` called `issues.listComments` once (30 per page) and searched only that page, so on PRs with more than 30 comments `use_sticky_comment` ("Use just one comment to deliver issue/PR comments") created a new comment on every run. `src/github/data/fetcher.ts` already paginates the same call, and #1629 fixed the same class of bug in the CI server.

Closes #1781

## Tests

New `test/create-initial.test.ts` (there was none): `paginate` is mocked to return 35 comments with the Claude comment at position 33; the test asserts `updateComment` is called with the existing id, `createComment` is not called, and `GITHUB_OUTPUT` (temp file) receives the existing id. A second case covers the no-existing-comment path. The first case fails on `main`. `test/modes/tag.test.ts`, which spies on `createInitialComment`, is unaffected.

`bun run typecheck`, `bun run format:check`: clean. `bun test`: the only failures are the pre-existing Windows-host failures (identical list on `main`); Linux CI should be fully green.

Observation for maintainers, out of scope here: `create-initial.ts` hardcodes `CLAUDE_APP_BOT_ID = 209825114` while `src/github/constants.ts` exports `CLAUDE_APP_BOT_ID = 41898282` (the `github-actions[bot]` id, see #759); the test mirrors the local constant.
