### PR TITLE
fix(sdk): report session failure before the --json-schema check

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -255,6 +255,29 @@ export async function runClaudeWithSdk(
     resultMessage.subtype === "success" && !resultMessage.is_error;
   result.conclusion = isSuccess ? "success" : "failure";
 
+  // Report session-level failure before the structured-output check. A failed
+  // session cannot produce structured_output, so checking --json-schema first
+  // would throw a message blaming the schema and discard the real error.
+  if (!isSuccess) {
+    if (resultMessage.subtype === "success" && resultMessage.is_error) {
+      core.error(
+        "Claude result reported subtype success with is_error:true (run did not complete successfully)",
+      );
+    }
+    if ("errors" in resultMessage && resultMessage.errors) {
+      core.error(`Execution failed: ${resultMessage.errors.join(", ")}`);
+    }
+    throw new Error(
+      `Claude execution failed: ${
+        resultMessage.subtype === "success" && resultMessage.is_error
+          ? "result is_error:true"
+          : "errors" in resultMessage && resultMessage.errors
+            ? resultMessage.errors.join(", ")
+            : "unknown error"
+      }`,
+    );
+  }
+
   // Handle structured output
   if (hasJsonSchema) {
     if (
@@ -275,26 +298,6 @@ export async function runClaudeWithSdk(
         `--json-schema was provided but Claude did not return structured_output. Result subtype: ${resultMessage.subtype}`,
       );
     }
-  }
-
-  if (!isSuccess) {
-    if (resultMessage.subtype === "success" && resultMessage.is_error) {
-      core.error(
-        "Claude result reported subtype success with is_error:true (run did not complete successfully)",
-      );
-    }
-    if ("errors" in resultMessage && resultMessage.errors) {
-      core.error(`Execution failed: ${resultMessage.errors.join(", ")}`);
-    }
-    throw new Error(
-      `Claude execution failed: ${
-        resultMessage.subtype === "success" && resultMessage.is_error
-          ? "result is_error:true"
-          : "errors" in resultMessage && resultMessage.errors
-            ? resultMessage.errors.join(", ")
-            : "unknown error"
-      }`,
-    );
   }
 
   return result;

--- a/base-action/test/run-claude-sdk.test.ts
+++ b/base-action/test/run-claude-sdk.test.ts
@@ -218,6 +218,78 @@ describe("runClaudeWithSdk", () => {
     }
   });
 
+  test("reports the session error, not the schema error, when is_error is true and --json-schema is set", async () => {
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => {},
+    );
+    const consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
+    const coreErrorSpy = spyOn(
+      await import("@actions/core"),
+      "error",
+    ).mockImplementation(() => {});
+
+    tempDir = await mkdtemp(join(tmpdir(), "claude-sdk-"));
+    process.env.RUNNER_TEMP = tempDir;
+
+    const promptPath = join(tempDir, "prompt.txt");
+    await writeFile(promptPath, "test prompt");
+
+    const initMessage = {
+      type: "system",
+      subtype: "init",
+      session_id: "session-123",
+      model: "claude-sonnet-5",
+    };
+
+    // The failure shape reported in #1720: the session errors out without
+    // producing structured_output, while subtype still reads "success".
+    const errorResultMessage = {
+      type: "result",
+      subtype: "success",
+      is_error: true,
+      duration_ms: 220,
+      num_turns: 1,
+      total_cost_usd: 0,
+      permission_denials: [],
+      errors: ["upstream session failure"],
+    };
+
+    mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+      query: async function* () {
+        yield initMessage;
+        yield errorResultMessage;
+      },
+    }));
+
+    try {
+      const { runClaudeWithSdk } = await import("../src/run-claude-sdk");
+
+      await expect(
+        runClaudeWithSdk(promptPath, {
+          sdkOptions: {},
+          showFullOutput: false,
+          hasJsonSchema: true,
+        }),
+      ).rejects.toThrow("result is_error:true");
+
+      // The session-level diagnostics must survive the --json-schema path.
+      expect(coreErrorSpy).toHaveBeenCalledWith(
+        "Claude result reported subtype success with is_error:true (run did not complete successfully)",
+      );
+      expect(coreErrorSpy).toHaveBeenCalledWith(
+        "Execution failed: upstream session failure",
+      );
+      // The schema message would misattribute the failure to the schema.
+      for (const call of coreErrorSpy.mock.calls) {
+        expect(String(call[0])).not.toContain("--json-schema was provided");
+      }
+    } finally {
+      consoleErrorSpy.mockRestore();
+      consoleLogSpy.mockRestore();
+      coreErrorSpy.mockRestore();
+    }
+  });
+
   test("fails closed when a successful result exceeds maxTurns", async () => {
     const consoleErrorSpy = spyOn(console, "error").mockImplementation(
       () => {},


### PR DESCRIPTION
## Summary

When a session fails with `subtype: "success"` and `is_error: true`, the `--json-schema` check runs before the session-failure check and throws first, discarding the real error. This reorders the two checks so the session error surfaces.

## The problem

`base-action/src/run-claude-sdk.ts` evaluates `hasJsonSchema` before `!isSuccess`. On a failed session with `--json-schema` set:

1. `isSuccess` is correctly `false` (`subtype === "success" && !is_error`)
2. `hasJsonSchema` is true; its success branch requires `isSuccess`, so it falls to `else`
3. it throws `--json-schema was provided but Claude did not return structured_output. Result subtype: success`
4. the `!isSuccess` block never runs, so neither the `is_error:true` diagnostic nor `resultMessage.errors` is emitted

The surfaced message blames the schema and reports `Result subtype: success` for a run that errored, while the actual error string is dropped. Users on `--json-schema` therefore get no usable diagnostic at all — see the reports in #1720, where this message is the only error output several people were able to capture.

## The fix

A failed session cannot produce `structured_output`, so the session-level check belongs first. This moves the `!isSuccess` block above the `hasJsonSchema` block. It is a block move with no content change; passing runs are unaffected, and the `--json-schema` message is unchanged for the case it actually describes (a successful run that returned no structured output).

## Tests

Existing coverage for this failure shape passes `hasJsonSchema: false`, so the interaction between the two checks went unnoticed. Added a regression test covering `hasJsonSchema: true` with `is_error: true`, asserting the session diagnostics survive and that the schema message is not emitted.

Verified the test fails without the source change, with exactly the message reported in #1720:

```
Expected substring: "result is_error:true"
Received message: "--json-schema was provided but Claude did not return structured_output. Result subtype: success"
```

- `bun test ./base-action/test/run-claude-sdk.test.ts` — 5 pass, 0 fail
- `bun test` — 967 pass, 0 fail
- `bun run typecheck` — clean
- `bun run format:check` — clean

## Scope

This is a reporting fix only. It does not address the underlying session failures discussed in #1720, whose cause still appears to be outside this action — it makes the existing diagnostic reachable for `--json-schema` users so those failures can be diagnosed. Refs #1720.
