### PR TITLE
docs: add missing `labeled` action to track_progress supported events

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -134,6 +134,7 @@ The `track_progress` input only works with these GitHub events:
 - `synchronize` - PR updated with new commits
 - `ready_for_review` - Draft PR marked as ready
 - `reopened` - Previously closed PR reopened
+- `labeled` - Label added to PR
 
 **Issue Events:**
 


### PR DESCRIPTION
## Summary

`docs/migration-guide.md` lists the `pull_request` actions supported by `track_progress` and omits `labeled`, which has been supported since #1586. One line added; docs only, no behavior change.

## Why

Three places describe which `pull_request` actions `track_progress` accepts. Two agree, one does not:

| Source | Includes `labeled`? |
| --- | --- |
| `src/modes/detector.ts` (`validateTrackProgressEvent`, the `validActions` array) | yes |
| `action.yml` (`track_progress` input description) | yes |
| `docs/migration-guide.md` ("Supported Events for `track_progress`") | **no** |

#1586 (merged 2026-08-07) added `labeled` to `detector.ts` and to the `action.yml` description, but the migration guide was not updated in that change, so it has understated the supported actions for about a month.

## Why it is worth correcting

The list is immediately followed by:

> **Note**: Using `track_progress: true` with unsupported events will cause an error.

That framing makes the bullets read as exhaustive and enforced — omitting `labeled` tells a reader that configuring `on: pull_request: types: [labeled]` with `track_progress: true` will fail. It will not; it has worked since #1586.

`labeled` is also the most requested action for this input. #1095 asked for it as an explicit manual review trigger, with a follow-up confirming the failure on `v1.0.174`; #1585 was filed for the same use case and is what #1586 fixed. The migration guide is read primarily by people configuring `track_progress` for the first time while moving from v0.x — the exact audience for whom this omission is most likely to rule out the pattern they want.

## Change

```diff
  **Pull Request Events:**

  - `opened` - New PR created
  - `synchronize` - PR updated with new commits
  - `ready_for_review` - Draft PR marked as ready
  - `reopened` - Previously closed PR reopened
+ - `labeled` - Label added to PR
```

Phrasing matches the existing `labeled` bullet in the Issue Events list directly below.

## Scope

Deliberately limited to the one stale line, which can be verified directly against `detector.ts` and #1586.

While confirming this I noticed two adjacent things in the same section that are **not** included here, because both need a maintainer decision rather than a doc sync:

1. The **Issue Events** list names four actions (`opened`, `edited`, `labeled`, `assigned`), but `validateTrackProgressEvent` only validates actions for `pull_request` — there is no `issues` equivalent, so any issue action is accepted. Documenting the current behavior and adding an allowlist to match the docs are opposite fixes, and given #1095 (where the `pull_request` allowlist blocked a legitimate workflow and had to be widened) the choice is not obvious.
2. `validEvents` also accepts `issue_comment`, `pull_request_review_comment`, and `pull_request_review`, which this section does not mention.

Happy to follow up on either if there is a preferred direction.

## Verification

- `bun run format:check` — clean (Prettier covers Markdown)
- No code changed, so no tests are affected
