### PR TITLE
docs: reference claude_args --allowedTools instead of removed allowed_tools input

### DIFF
--- a/docs/capabilities-and-limitations.md
+++ b/docs/capabilities-and-limitations.md
@@ -19,7 +19,7 @@
 - **Approve PRs**: For security reasons, Claude cannot approve pull requests
 - **Post Multiple Comments**: Claude only acts by updating its initial comment
 - **Execute Commands Outside Its Context**: Claude only has access to the repository and PR/issue context it's triggered in
-- **Run Arbitrary Bash Commands**: By default, Claude cannot execute Bash commands unless explicitly allowed using the `allowed_tools` configuration
+- **Run Arbitrary Bash Commands**: By default, Claude cannot execute Bash commands unless explicitly allowed via `claude_args` with `--allowedTools`
 - **Perform Branch Operations**: Cannot merge branches, rebase, or perform other git operations beyond pushing commits
 
 ## How It Works


### PR DESCRIPTION
Fixes #1670.

`docs/capabilities-and-limitations.md` was the only place `allowed_tools` still read as current configuration guidance. It is not a declared input in `action.yml`; the replacement is `claude_args` with `--allowedTools`.

```diff
-- **Run Arbitrary Bash Commands**: By default, Claude cannot execute Bash commands unless explicitly allowed using the `allowed_tools` configuration
+- **Run Arbitrary Bash Commands**: By default, Claude cannot execute Bash commands unless explicitly allowed via `claude_args` with `--allowedTools`
```

The wording is the one proposed in the issue.

**Deliberately left unchanged**, since all three are correct as they stand:

- `docs/configuration.md:365` and `docs/usage.md:106` list `allowed_tools` in migration tables explicitly marked deprecated.
- `docs/usage.md:156` uses `allowed_tools: "Edit,Read,Write"` inside a `**Before (v0.x):**` snippet, where the removed input is the point of the example.

Docs only, no code paths touched.
