### PR TITLE
Allow semicolons in branch names

### DIFF
--- a/src/create-prompt/index.ts
+++ b/src/create-prompt/index.ts
@@ -454,7 +454,7 @@ function getCommitInstructions(
           Bash(git commit -m "<message>\\n\\n${coAuthorLine}")`
             : ""
         }
-        - Push to the remote: Bash(${GIT_PUSH_WRAPPER} origin ${branchName})`;
+        - Push to the remote: Bash(${GIT_PUSH_WRAPPER} origin '${branchName}')`;
     }
   }
 }

--- a/src/github/operations/branch.ts
+++ b/src/github/operations/branch.ts
@@ -74,12 +74,15 @@ export function validateBranchName(branchName: string): void {
   //   "_release/v1.2.3"), which previously failed validation as a PR's base branch.
   // Parentheses are valid per git-check-ref-format and commonly appear in branch names that
   //   use Conventional Commit-style scopes (e.g. "feat(parser)-handle-empty-input").
+  // ; is valid per git-check-ref-format and appears in branch names generated from ticket
+  //   titles by some trackers (e.g. "FIDA-3971;-adjust-mapping"), which previously failed
+  //   validation as a PR's head ref and blocked review-only runs on those PRs entirely.
   // All git calls use execFileSync (not shell interpolation), so none of these characters carry injection risk.
-  const validPattern = /^[a-zA-Z0-9@_][a-zA-Z0-9/_.#+,@()-]*$/;
+  const validPattern = /^[a-zA-Z0-9@_][a-zA-Z0-9/_.#+,@();-]*$/;
 
   if (!validPattern.test(branchName)) {
     throw new Error(
-      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character, underscore, or '@' and contain only alphanumeric characters, forward slashes, hyphens, underscores, periods, hashes (#), plus signs (+), commas (,), at signs (@), or parentheses.`,
+      `Invalid branch name: "${branchName}". Branch names must start with an alphanumeric character, underscore, or '@' and contain only alphanumeric characters, forward slashes, hyphens, underscores, periods, hashes (#), plus signs (+), commas (,), at signs (@), parentheses, or semicolons (;).`,
     );
   }
 

--- a/test/create-prompt.test.ts
+++ b/test/create-prompt.test.ts
@@ -181,6 +181,30 @@ describe("generatePrompt", () => {
     ); // from review comments
   });
 
+  test("should single-quote the branch in the push instruction", async () => {
+    // The live grant is Bash(<wrapper>:*), a prefix match, so anything the model appends to
+    // that command is permitted and the shell splits it. An unquoted branch carrying a
+    // metacharacter would turn the suggested push into two commands.
+    const envVars: PreparedContext = {
+      repository: "owner/repo",
+      claudeCommentId: "12345",
+      triggerPhrase: "@claude",
+      eventData: {
+        eventName: "issues",
+        eventAction: "opened",
+        isPR: false,
+        issueNumber: "789",
+        baseBranch: "main",
+        claudeBranch: "feat;-scoped-branch",
+      },
+    };
+
+    const prompt = await generatePrompt(envVars, mockGitHubData, false, "tag");
+
+    expect(prompt).toContain("origin 'feat;-scoped-branch'");
+    expect(prompt).not.toContain("origin feat;-scoped-branch");
+  });
+
   test("should generate prompt for issue opened event", async () => {
     const envVars: PreparedContext = {
       repository: "owner/repo",

--- a/test/validate-branch-name.test.ts
+++ b/test/validate-branch-name.test.ts
@@ -38,6 +38,15 @@ describe("validateBranchName", () => {
       ).not.toThrow();
     });
 
+    it("should accept branch names containing semicolons", () => {
+      expect(() =>
+        validateBranchName("FIDA-3971;-adjust-mapping"),
+      ).not.toThrow();
+      expect(() =>
+        validateBranchName("FIDA-3983;-+3P-prod-costs-fix"),
+      ).not.toThrow();
+    });
+
     it("should accept typical branch name formats", () => {
       expect(() =>
         validateBranchName("claude/issue-123-20250101-1234"),


### PR DESCRIPTION
## Problem

`validateBranchName` rejects semicolons, but they are valid per `git-check-ref-format`:

```
$ git check-ref-format --branch 'FIDA-3971;-adjust-mapping'   # exits 0
```

The consequence is larger than a naming inconvenience, because `setupBranch` validates **the PR's own head and base refs**, not just a branch the action would create:

```ts
// src/github/operations/branch.ts, open-PR path
const branchName = prData.headRefName;
validateBranchName(branchName);        // ~line 195
const baseBranch = prData.baseRefName;
validateBranchName(baseBranch);        // ~line 220
```

`prepareTagMode` calls `setupBranch` unconditionally, before the prompt is built and before the model starts. So a repository whose tickets produce branch names like `FIDA-3971;-adjust-mapping` cannot run the action **at all** on those PRs — including a pure review-only run that never creates a branch, never commits, and never pushes. It fails in the prepare step with:

```
Invalid branch name: "FIDA-3971;-adjust-mapping". Branch names must start with an alphanumeric character...
```

There is no input that skips it, and the head ref belongs to the repository rather than to the action.

We hit this on 16 runs in a month in one repo, whose Jira integration puts the ticket id and title into the branch name with a separator the tracker chooses.

## Change

Adds `;` to the whitelist, following the same reasoning already recorded for `#`, `+`, `,`, `@` and `()`:

> All git calls use `execFileSync` (not shell interpolation), so none of these characters carry injection risk.

**That reasoning turned out to be incomplete, and review caught it.** It covers the git operations but not the prompt, where the branch is interpolated into a suggested `Bash(<wrapper> origin <branch>)` and the live grant prefix-matches — so a semicolon there would have become a second command. The second commit single-quotes it at that site; see the discussion below.

The error message gains `semicolons (;)` alongside the other named characters, and a comment records the reasoning in the same style as its neighbours.

## Verification

Two cases added to `test/validate-branch-name.test.ts`, matching the shape of the existing parentheses test, plus a prompt-generation regression test for the quoting.

Checked that the change does not weaken anything else: the separate metacharacter guard still rejects `~ ^ : ? * [ ] \`, spaces and control characters, and the follow-on guards still reject a leading dash, a leading or trailing period, a trailing slash, `//`, `..`, `.lock`, `@{`, and a bare `@`. A name like `semi;colon~tilde` is still rejected, on the tilde.

I was not able to run `bun test` locally (no Bun on this machine), so CI is the first real run of the new cases.