### PR TITLE
fix: gate mention-triggered workflow examples on author_association

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -6,20 +6,20 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
 jobs:
   claude:
     # Only run for repository insiders; see examples/claude.yml for why the
-    # association guard is repeated per branch and why issues.assigned is exempt.
+    # association guard is repeated per branch, and for how to opt into
+    # assignee_trigger / label_trigger.
     if: |
       (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
-      (github.event_name == 'issues' && github.event.action == 'assigned')
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,14 @@ on:
 
 jobs:
   claude:
+    # Only run for repository insiders; see examples/claude.yml for why the
+    # association guard is repeated per branch and why issues.assigned is exempt.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,6 +160,9 @@ permissions:
 
 jobs:
   claude-ci-helper:
+    # Restrict triggering to repository insiders so an outside comment cannot
+    # start a billable run before the action's write-access check rejects it.
+    if: contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
     steps:
       - uses: anthropics/claude-code-action@v1

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned, labeled]
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
@@ -28,17 +28,20 @@ jobs:
     # front of the chain would apply only to the first branch and leave the rest
     # open.
     #
-    # The `assigned` and `labeled` branches are not association-gated because
-    # there the trigger is whoever assigned or labelled the issue rather than its
-    # author; gating on the author would break `assignee_trigger` and
-    # `label_trigger` on issues opened by outside contributors. Those paths are
-    # still covered by `checkWritePermissions` at runtime.
+    # To use `assignee_trigger` or `label_trigger`, add `assigned` / `labeled` to
+    # the issues types above and add a branch for it, e.g.
+    #   (github.event_name == 'issues' && github.event.action == 'assigned' &&
+    #    github.event.assignee.login == 'claude')
+    # Those triggers key off who assigned or labelled rather than the issue
+    # author, so they are not gated on `author_association`;
+    # `checkWritePermissions` still applies. They are left out by default so an
+    # assignment on an unrelated issue does not start a runner that cannot match
+    # a configured trigger.
     if: |
       (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
-      (github.event_name == 'issues' && (github.event.action == 'assigned' || github.event.action == 'labeled'))
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     steps:
       - uses: anthropics/claude-code-action@v1

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,29 @@ on:
 
 jobs:
   claude-response:
+    # Restrict who can trigger Claude. Without this, anyone who can comment on
+    # the repository can start a run, and on a public repository that is a
+    # billing exposure: the job occupies a runner and spends tokens before the
+    # action's own write-access check (`checkWritePermissions`) can reject the
+    # actor.
+    #
+    # The association check is repeated in each branch on purpose. Every event
+    # exposes its trigger's association on a different field, and `&&` binds
+    # tighter than `||` in GitHub Actions expressions — a single guard placed in
+    # front of the chain would apply only to the first branch and leave the rest
+    # open.
+    #
+    # The `assigned` and `labeled` branches are not association-gated because
+    # there the trigger is whoever assigned or labelled the issue rather than its
+    # author; gating on the author would break `assignee_trigger` and
+    # `label_trigger` on issues opened by outside contributors. Those paths are
+    # still covered by `checkWritePermissions` at runtime.
+    if: |
+      (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'issues' && (github.event.action == 'assigned' || github.event.action == 'labeled'))
     runs-on: ubuntu-latest
     steps:
       - uses: anthropics/claude-code-action@v1

--- a/examples/claude-wif.yml
+++ b/examples/claude-wif.yml
@@ -12,20 +12,20 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
 jobs:
   claude:
     # Only run for repository insiders; see examples/claude.yml for why the
-    # association guard is repeated per branch and why issues.assigned is exempt.
+    # association guard is repeated per branch, and for how to opt into
+    # assignee_trigger / label_trigger.
     if: |
       (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
-      (github.event_name == 'issues' && github.event.action == 'assigned')
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/examples/claude-wif.yml
+++ b/examples/claude-wif.yml
@@ -18,11 +18,14 @@ on:
 
 jobs:
   claude:
+    # Only run for repository insiders; see examples/claude.yml for why the
+    # association guard is repeated per branch and why issues.assigned is exempt.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/examples/claude.yml
+++ b/examples/claude.yml
@@ -6,7 +6,7 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
@@ -24,16 +24,19 @@ jobs:
     # binds tighter than `||` in GitHub Actions expressions, so a single leading
     # guard would apply only to the first branch and leave the rest unguarded.
     #
-    # issues.assigned is intentionally not association-gated: there the trigger is
-    # the person doing the assigning, not the issue author, so gating on the author
-    # would stop assignee_trigger from working on issues filed by outside
-    # contributors. That path is still covered by checkWritePermissions.
+    # To use assignee_trigger or label_trigger, add `assigned` / `labeled` to the
+    # issues types above and add a matching branch here, e.g.
+    #   (github.event_name == 'issues' && github.event.action == 'assigned' &&
+    #    github.event.assignee.login == 'claude-bot')
+    # Those triggers key off who assigned or labelled rather than the issue
+    # author, so they are not author_association-gated; checkWritePermissions
+    # still applies. Leaving them out by default keeps an assignment on an
+    # unrelated issue from starting a runner that cannot match a trigger.
     if: |
       (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
-      (github.event_name == 'issues' && github.event.action == 'assigned')
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/examples/claude.yml
+++ b/examples/claude.yml
@@ -12,11 +12,28 @@ on:
 
 jobs:
   claude:
+    # Only run for repository insiders. The action also enforces write access at
+    # runtime (checkWritePermissions), but that happens after the job has already
+    # started and consumed a runner, so gate here as well.
+    #
+    # The guard is repeated inside every branch rather than factored out in front
+    # of them, for two reasons: each event carries its trigger's association on a
+    # different field (comment.author_association for issue_comment and
+    # pull_request_review_comment, review.author_association for
+    # pull_request_review, issue.author_association for issues.opened), and `&&`
+    # binds tighter than `||` in GitHub Actions expressions, so a single leading
+    # guard would apply only to the first branch and leave the rest unguarded.
+    #
+    # issues.assigned is intentionally not association-gated: there the trigger is
+    # the person doing the assigning, not the issue author, so gating on the author
+    # would stop assignee_trigger from working on issues filed by outside
+    # contributors. That path is still covered by checkWritePermissions.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association) && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && github.event.action == 'opened' && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association) && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/test/workflow-author-association.test.ts
+++ b/test/workflow-author-association.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+
+/**
+ * The shipped mention-triggered workflows must gate on author_association.
+ *
+ * Without it, anyone who can comment can start a run: the job takes a runner
+ * and spends tokens before checkWritePermissions rejects the actor, which on a
+ * public repository is a billing exposure. See issue #1481.
+ */
+
+const INSIDERS = `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]')`;
+
+// Workflows that respond to an @claude mention, and the association field each
+// mention-bearing event carries its trigger on.
+const MENTION_WORKFLOWS = [
+  "../examples/claude.yml",
+  "../examples/claude-wif.yml",
+  "../.github/workflows/claude.yml",
+];
+
+function condition(path: string): string {
+  const raw = readFileSync(new URL(path, import.meta.url), "utf8");
+  // Grab the block-scalar `if:` body: subsequent lines indented deeper than
+  // the key, stopping at the next sibling key (e.g. `runs-on:`).
+  const match = raw.match(/^ {4}if: \|\n((?: {6}.*\n)+)/m);
+  if (!match?.[1]) throw new Error(`no block-scalar if: found in ${path}`);
+  return match[1];
+}
+
+/**
+ * Split the condition into its top-level `||` branches.
+ *
+ * Splitting on the literal "||" is wrong: the issues.opened branch contains a
+ * nested `(body || title)`, so a naive split fragments it. Track paren depth
+ * and only break on a `||` at depth zero.
+ */
+function topLevelBranches(cond: string): string[] {
+  const branches: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (let i = 0; i < cond.length; i++) {
+    const ch = cond[i]!;
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    if (depth === 0 && ch === "|" && cond[i + 1] === "|") {
+      branches.push(current);
+      current = "";
+      i++; // skip the second '|'
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) branches.push(current);
+  return branches.map((b) => b.trim()).filter((b) => b.length > 0);
+}
+
+describe("mention-triggered workflows gate on author_association", () => {
+  for (const path of MENTION_WORKFLOWS) {
+    describe(path, () => {
+      test("guards every branch that reads a mention body", () => {
+        const cond = condition(path);
+        const mentionBranches = topLevelBranches(cond).filter((branch) =>
+          branch.includes("@claude"),
+        );
+
+        expect(mentionBranches.length).toBeGreaterThan(0);
+        for (const branch of mentionBranches) {
+          expect(branch).toInclude(INSIDERS);
+        }
+      });
+
+      test("reads the association off the field the event actually carries", () => {
+        const cond = condition(path);
+        // A branch keyed to an event must not assert on another event's payload
+        // field, e.g. pull_request_review carries review.author_association.
+        for (const branch of topLevelBranches(cond)) {
+          if (branch.includes("'pull_request_review'")) {
+            expect(branch).toInclude("github.event.review.author_association");
+          } else if (branch.includes("'issue_comment'")) {
+            expect(branch).toInclude("github.event.comment.author_association");
+          } else if (branch.includes("'pull_request_review_comment'")) {
+            expect(branch).toInclude("github.event.comment.author_association");
+          }
+        }
+      });
+
+      test("does not rely on a single leading guard, which && would bind to only the first branch", () => {
+        const cond = condition(path);
+        // `&&` binds tighter than `||` in GitHub Actions expressions, so the
+        // guard has to appear in each mention branch rather than once up front.
+        const guardCount = cond.split(INSIDERS).length - 1;
+        const mentionBranchCount = topLevelBranches(cond).filter((b) =>
+          b.includes("@claude"),
+        ).length;
+        expect(guardCount).toBe(mentionBranchCount);
+      });
+
+      test("leaves assignee/label triggers reachable for outside-authored issues", () => {
+        const cond = condition(path);
+        // The trigger for these is whoever assigned/labelled, not the issue
+        // author, so gating them on issue.author_association would break
+        // assignee_trigger / label_trigger. checkWritePermissions still applies.
+        const assignBranch = topLevelBranches(cond).find((b) =>
+          b.includes("'assigned'"),
+        );
+        expect(assignBranch).toBeDefined();
+        expect(assignBranch).not.toInclude("author_association");
+      });
+    });
+  }
+});

--- a/test/workflow-author-association.test.ts
+++ b/test/workflow-author-association.test.ts
@@ -96,16 +96,34 @@ describe("mention-triggered workflows gate on author_association", () => {
         expect(guardCount).toBe(mentionBranchCount);
       });
 
-      test("leaves assignee/label triggers reachable for outside-authored issues", () => {
+      test("does not ship an unconditional assigned/labeled branch", () => {
         const cond = condition(path);
-        // The trigger for these is whoever assigned/labelled, not the issue
-        // author, so gating them on issue.author_association would break
-        // assignee_trigger / label_trigger. checkWritePermissions still applies.
-        const assignBranch = topLevelBranches(cond).find((b) =>
-          b.includes("'assigned'"),
-        );
-        expect(assignBranch).toBeDefined();
-        expect(assignBranch).not.toInclude("author_association");
+        // assignee_trigger / label_trigger are unset by default, so
+        // checkContainsTrigger cannot match on those events. An unguarded
+        // `action == 'assigned'` branch would start a runner for every
+        // assignment only to no-op — widening runner usage, which is the
+        // opposite of the point. Enabling them is documented instead.
+        for (const branch of topLevelBranches(cond)) {
+          const isAssignOrLabel =
+            branch.includes("'assigned'") || branch.includes("'labeled'");
+          if (!isAssignOrLabel) continue;
+          // If such a branch is ever added it must be qualified by the
+          // configured trigger, not left as a bare event/action match.
+          expect(branch).toMatch(/assignee\.login|label\.name/);
+        }
+      });
+
+      test("does not subscribe to issue actions it cannot act on", () => {
+        const raw = readFileSync(new URL(path, import.meta.url), "utf8");
+        const issuesTypes = raw.match(/^ {2}issues:\n {4}types: \[(.*)\]$/m);
+        expect(issuesTypes).not.toBeNull();
+        const types = issuesTypes![1]!.split(",").map((t) => t.trim());
+        const cond = condition(path);
+        // Every subscribed action needs a branch that can match it, otherwise
+        // the workflow wakes a runner for events it will always skip.
+        for (const type of types) {
+          expect(cond).toInclude(`'${type}'`);
+        }
       });
     });
   }


### PR DESCRIPTION
## Summary

The shipped `@claude` workflows have no actor filter, so on a public repository any user who can comment can start a run. `checkWritePermissions` does reject the actor — but only after the job has taken a runner and reached the action, so the guard belongs in the workflow `if:` as well.

This adds an `OWNER`/`MEMBER`/`COLLABORATOR` guard to every branch that reads a mention body, plus a regression test.

Fixes #1481.

## Current state

| File | Actor filter today |
| --- | --- |
| `docs/usage.md` | none — the example has no `if:` at all |
| `docs/configuration.md` (CI helper) | none |
| `examples/claude.yml` | trigger-phrase check only |
| `examples/claude-wif.yml` | trigger-phrase check only |
| `.github/workflows/claude.yml` (this repo) | trigger-phrase check only |

## Two things worth flagging

**1. The guard cannot be factored out in front of the chain.** `&&` binds tighter than `||` in [GitHub Actions expressions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions), so a single leading guard attaches only to the first branch:

```
G && (issue_comment...) || (pull_request_review_comment...) || ...
→ (G && issue_comment...) || (pull_request_review_comment...) || ...
```

Every later branch then runs unguarded — i.e. the shape suggested in #1481 would still let an outside user trigger via a review comment. So the guard is repeated inside each branch instead. The added test asserts this directly (guard count == mention-branch count), so the factored-out form cannot be reintroduced silently.

Each event also carries its trigger's association on a different field, which is the second reason a single check does not work:

| Event | Association field |
| --- | --- |
| `issue_comment` | `github.event.comment.author_association` |
| `pull_request_review_comment` | `github.event.comment.author_association` |
| `pull_request_review` | `github.event.review.author_association` |
| `issues` (`opened`) | `github.event.issue.author_association` |

**2. `issues.assigned` / `issues.labeled` are left out of the generic example.** Those triggers key off who assigned or labelled rather than the issue author, so gating them on `issue.author_association` would break `assignee_trigger` / `label_trigger` on issues filed by outside contributors. But shipping an unconditional `action == 'assigned'` branch is worse: `assigneeTrigger` has no default, so `checkContainsTrigger` can never match an assigned event out of the box, and the branch would start a runner for every assignment only to no-op. Both are now omitted from the default `if:` and the `issues:` types, with a comment showing how to opt in — qualified by the configured trigger (`github.event.assignee.login == '...'`) rather than left bare. Thanks to @sylvesterkaczmarek for catching this.

## Scope

Left unchanged on purpose:

- `examples/issue-deduplication.yml`, `base-action/examples/issue-triage.yml` — `prompt`-driven automations that are *meant* to run on outside-authored issues; an insider guard would defeat their purpose.
- `examples/agent-approval-check.yml` — itself a security gate, and its existing `if:` is load-bearing.
- `docs/custom-automations.md` — prose list of supported events, not a workflow.

Also not included: `checkHumanActor` already blocks bot actors by default (`allowed_bots` is opt-in), so the self-trigger-loop half of #1481 is largely handled in code today. I did not add a `sender.type != 'Bot'` clause, since that would duplicate an existing runtime gate rather than close a gap. Happy to add it if you'd prefer defence in depth at the workflow layer.

## Verification

- `bun test` — **981 pass / 0 fail** (2263 assertions, 58 files).
- `bun run typecheck` — clean.
- `bun run format:check` — the 6 files it flags (`ROADMAP.md`, `src/github/token.ts`, and 4 others) are untouched by this PR and already flagged on `main`; every file changed here is clean under Prettier.
- Both new invariants were confirmed to fail without their fix: reverting `examples/claude.yml` to the unguarded form turns 15 pass into 11 pass / 4 fail, and re-adding a bare `assigned` branch turns it into 14 pass / 1 fail.
