### PR TITLE
feat: add token_only input to mint the App token without running Claude

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -137,6 +137,10 @@ inputs:
     description: "Force tag mode with tracking comments for pull_request and issue events. Only applicable to pull_request (opened, synchronize, ready_for_review, reopened, labeled) and issue (opened, edited, labeled, assigned) events."
     required: false
     default: "false"
+  token_only:
+    description: "Mint the GitHub App token (github_token output) and exit immediately, without running Claude. For automation that needs to act on GitHub as the Claude Code App's own identity -- picking up the App's repository permissions and satisfying checks scoped to that identity -- but has no use for the agent itself, such as a separate step in the same job performing a deterministic gh/API call. Skips the write-permission and trigger checks entirely, since neither is meaningful when no prompt will run. If github_token is also provided, setup does not mint a new App token -- it echoes the provided one back as the output instead, same as every other mode."
+    required: false
+    default: "false"
   include_fix_links:
     description: "Include 'Fix this' links in PR code review feedback that open Claude Code with context to fix the identified issue"
     required: false
@@ -311,6 +315,7 @@ runs:
         BOT_ID: ${{ inputs.bot_id }}
         BOT_NAME: ${{ inputs.bot_name }}
         TRACK_PROGRESS: ${{ inputs.track_progress }}
+        TOKEN_ONLY: ${{ inputs.token_only }}
         INCLUDE_FIX_LINKS: ${{ inputs.include_fix_links }}
         ADDITIONAL_PERMISSIONS: ${{ inputs.additional_permissions }}
         CLAUDE_ARGS: ${{ inputs.claude_args }}

--- a/src/entrypoints/run.ts
+++ b/src/entrypoints/run.ts
@@ -184,11 +184,17 @@ async function run() {
       throw error;
     }
 
-    octokit = createOctokit(githubToken);
-
     // Set GITHUB_TOKEN and GH_TOKEN in process env for downstream usage
     process.env.GITHUB_TOKEN = githubToken;
     process.env.GH_TOKEN = githubToken;
+
+    if (context.inputs.tokenOnly) {
+      console.log("token_only is set, exiting after minting the GitHub token");
+      core.setOutput("github_token", githubToken);
+      return;
+    }
+
+    octokit = createOctokit(githubToken);
 
     // Check write permissions for entity contexts, and for workflow_run
     // events, whose upstream run may have been started by an actor without

--- a/src/github/context.ts
+++ b/src/github/context.ts
@@ -99,6 +99,7 @@ type BaseContext = {
     allowedBots: string;
     allowedNonWriteUsers: string;
     trackProgress: boolean;
+    tokenOnly: boolean;
     includeFixLinks: boolean;
     includeCommentsByActor: string;
     excludeCommentsByActor: string;
@@ -161,6 +162,7 @@ export function parseGitHubContext(): GitHubContext {
       allowedBots: process.env.ALLOWED_BOTS ?? "",
       allowedNonWriteUsers: process.env.ALLOWED_NON_WRITE_USERS ?? "",
       trackProgress: process.env.TRACK_PROGRESS === "true",
+      tokenOnly: process.env.TOKEN_ONLY === "true",
       includeFixLinks: process.env.INCLUDE_FIX_LINKS === "true",
       includeCommentsByActor: process.env.INCLUDE_COMMENTS_BY_ACTOR ?? "",
       excludeCommentsByActor: process.env.EXCLUDE_COMMENTS_BY_ACTOR ?? "",

--- a/test/install-mcp-server.test.ts
+++ b/test/install-mcp-server.test.ts
@@ -40,6 +40,7 @@ describe("prepareMcpConfig", () => {
       allowedBots: "",
       allowedNonWriteUsers: "",
       trackProgress: false,
+      tokenOnly: false,
       includeFixLinks: true,
       includeCommentsByActor: "",
       excludeCommentsByActor: "",

--- a/test/mockContext.ts
+++ b/test/mockContext.ts
@@ -27,6 +27,7 @@ const defaultInputs = {
   allowedBots: "",
   allowedNonWriteUsers: "",
   trackProgress: false,
+  tokenOnly: false,
   includeFixLinks: true,
   includeCommentsByActor: "",
   excludeCommentsByActor: "",

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -27,6 +27,7 @@ describe("detectMode with enhanced routing", () => {
       allowedBots: "",
       allowedNonWriteUsers: "",
       trackProgress: false,
+      tokenOnly: false,
       includeFixLinks: true,
       includeCommentsByActor: "",
       excludeCommentsByActor: "",

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -76,6 +76,7 @@ describe("checkWritePermissions", () => {
       allowedBots: "",
       allowedNonWriteUsers: "",
       trackProgress: false,
+      tokenOnly: false,
       includeFixLinks: true,
       includeCommentsByActor: "",
       excludeCommentsByActor: "",


### PR DESCRIPTION
## Summary

The GitHub App installation token is already minted early in `run()` (`setupGitHubToken()`) and exposed as the `github_token` output — but every existing code path always continues on to actually run Claude after that. There's currently no way for a caller to get just the App-identity token (e.g. to authenticate a separate, deterministic `gh`/API call elsewhere in the same job) without also paying for a real agent turn.

This adds a `token_only` input. When set, the action mints/returns the token exactly as today, sets it as the `github_token` output, and returns immediately — before the write-permission check and the trigger-detection logic, both of which are meaningless when no prompt is ever going to run. When `github_token` is already supplied as an override, `setupGitHubToken()` already just echoes it back unchanged rather than minting a new one (existing behavior, unaffected by this change).

### Motivating use case

A downstream workflow (in our case, an auto-merge job) wants its GitHub API calls attributed to the same GitHub App identity `claude-code-action` runs, so it participates in the same permission/branch-protection posture as Claude's own reviews — without needing to run Claude itself for what is otherwise a deterministic script.

## Implementation

- `action.yml`: new `token_only` input (default `"false"`), mapped to a `TOKEN_ONLY` env var alongside the existing `TRACK_PROGRESS` mapping.
- `src/github/context.ts`: `tokenOnly: boolean` added to `ParsedGitHubContext`/`AutomationContext`'s shared `inputs` type, parsed the same way as `trackProgress`.
- `src/entrypoints/run.ts`: early return right after `core.setOutput("github_token", githubToken)`, placed before the write-permission check and the `containsTrigger` logic.
- Test fixtures (`test/mockContext.ts`, `test/modes/detector.test.ts`, `test/permissions.test.ts`, `test/install-mcp-server.test.ts`) updated for the new required field on the shared inputs type.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run format:check` passes
- [x] `bun test`: 943 pass, 0 new failures. The 23 pre-existing failures (`test/restore-config.test.ts`, `test/branch-cleanup-restored-config.test.ts`) reproduce identically on a clean, unmodified clone of `main` in this same environment (a local git config issue unrelated to this change — `git add` refusing paths matched by a global gitignore) and are unaffected either way.
- [ ] Not tested against a real GitHub Actions run (no push access to trigger one in a repo with the App installed) — happy to have a maintainer verify, or point me at a way to test this live.

## Note on maintainer bandwidth

Aware this is a fairly narrow addition to a widely-used action, and may not be something you want to take on/maintain — submitting it anyway in case the underlying capability (or a differently-shaped version of it) is useful. Happy to adjust the approach if a different shape fits better (e.g. a separate lightweight action, or scoping token_only's early return differently).