### PR TITLE
fix: post buffered inline comments as a single review

### DIFF
--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -15,6 +15,10 @@ import { redactSecrets } from "../github/utils/sanitizer";
 
 const BUFFER_PATH = "/tmp/inline-comments-buffer.jsonl";
 
+// Summary line for the batched review. event=COMMENT requires a non-empty body,
+// and this is what appears above the grouped inline comments on the PR.
+export const REVIEW_BODY = "Claude finished reviewing this pull request.";
+
 type BufferedComment = {
   ts: string;
   path: string;
@@ -107,6 +111,32 @@ async function classifyComments(bodies: string[]): Promise<boolean[] | null> {
     );
     return null;
   }
+}
+
+/**
+ * Build the `comments[]` payload for a single batched review.
+ *
+ * Exported for testing: the review payload uses a different shape from
+ * createReviewComment (no commit_id/pull_number per entry, and multi-line
+ * hunks use start_line + line), so the mapping is worth pinning down.
+ */
+export function buildReviewComments(
+  comments: BufferedComment[],
+): Array<Record<string, unknown>> {
+  return comments.map((c) => {
+    const side = c.side || "RIGHT";
+    const entry: Record<string, unknown> = {
+      path: c.path,
+      body: redactSecrets(c.body),
+      side,
+    };
+    if (c.startLine) {
+      entry.start_line = c.startLine;
+      entry.start_side = side;
+    }
+    entry.line = c.line;
+    return entry;
+  });
 }
 
 async function postComment(
@@ -218,6 +248,34 @@ async function main() {
   const headSha = pr.data.head.sha;
 
   console.log(`Posting ${toPost.length} classified-as-real comment(s)`);
+
+  // Post as one review so the PR shows a single "reviewed" entry containing
+  // every inline comment, rather than one standalone review per comment.
+  try {
+    await octokit.pulls.createReview({
+      owner,
+      repo,
+      pull_number,
+      commit_id: headSha,
+      event: "COMMENT",
+      // Required by the API whenever event is COMMENT: a review submitted with
+      // event=COMMENT and no body is rejected with 422. The typings mark body
+      // optional, so this is not caught at compile time.
+      body: REVIEW_BODY,
+      comments: buildReviewComments(toPost) as never,
+    });
+    console.log(`Posted ${toPost.length}/${toPost.length} in a single review`);
+    return;
+  } catch (e) {
+    // createReview is atomic: one unmappable line (e.g. outside the diff, or
+    // stale after a force-push) rejects the whole batch. Rather than drop
+    // every comment, fall back to posting them individually — the pre-batch
+    // behaviour — so partial delivery still beats none.
+    console.log(
+      `::warning::Batched review failed (${e instanceof Error ? e.message : String(e)}) — falling back to individual comments`,
+    );
+  }
+
   let posted = 0;
   for (const c of toPost) {
     if (await postComment(octokit, owner, repo, pull_number, headSha, c)) {
@@ -228,7 +286,11 @@ async function main() {
   console.log(`Posted ${posted}/${toPost.length}`);
 }
 
-main().catch((e) => {
-  console.error("post-buffered-inline-comments failed:", e);
-  process.exit(1);
-});
+// Guarded so the module can be imported by tests without running the posting
+// flow, matching the other entrypoints (prepare.ts, run.ts, ...).
+if (import.meta.main) {
+  main().catch((e) => {
+    console.error("post-buffered-inline-comments failed:", e);
+    process.exit(1);
+  });
+}

--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -139,6 +139,44 @@ export function buildReviewComments(
   });
 }
 
+/**
+ * Whether a failed createReview definitively means nothing was created.
+ *
+ * 4xx responses (except 408/429) are request-validation failures: GitHub
+ * rejected the payload and committed nothing, so replaying individually is
+ * safe. Transport errors, timeouts and 5xx are ambiguous — the review may have
+ * been created even though the response was lost — so those must be reconciled
+ * before any replay, or duplicate comments get posted.
+ */
+export function isDeterministicRejection(error: unknown): boolean {
+  const status = (error as { status?: number } | null)?.status;
+  if (typeof status !== "number") return false;
+  if (status === 408 || status === 429) return false;
+  return status >= 400 && status < 500;
+}
+
+/**
+ * Look for a review we already created for this commit, so an ambiguous
+ * failure does not cause every comment to be posted twice.
+ */
+async function reviewAlreadyPosted(
+  octokit: ReturnType<typeof createOctokit>["rest"],
+  owner: string,
+  repo: string,
+  pull_number: number,
+  headSha: string,
+): Promise<boolean> {
+  const { data } = await octokit.pulls.listReviews({
+    owner,
+    repo,
+    pull_number,
+    per_page: 100,
+  });
+  return data.some(
+    (r) => r.commit_id === headSha && (r.body ?? "").includes(REVIEW_BODY),
+  );
+}
+
 async function postComment(
   octokit: ReturnType<typeof createOctokit>["rest"],
   owner: string,
@@ -147,7 +185,10 @@ async function postComment(
   headSha: string,
   c: BufferedComment,
 ): Promise<boolean> {
-  const params: Parameters<typeof octokit.rest.pulls.createReviewComment>[0] = {
+  // NOTE: octokit here is already the `.rest` client (see main), so members are
+  // reached as octokit.pulls.*. This previously read octokit.rest.pulls.*, which
+  // is undefined at runtime and made every individual post throw.
+  const params: Parameters<typeof octokit.pulls.createReviewComment>[0] = {
     owner,
     repo,
     pull_number,
@@ -164,7 +205,7 @@ async function postComment(
     params.line = c.line;
   }
   try {
-    await octokit.rest.pulls.createReviewComment(params);
+    await octokit.pulls.createReviewComment(params);
     return true;
   } catch (e) {
     console.log(
@@ -174,7 +215,7 @@ async function postComment(
   }
 }
 
-async function main() {
+export async function main() {
   let raw: string;
   try {
     raw = readFileSync(BUFFER_PATH, "utf8");
@@ -268,11 +309,45 @@ async function main() {
     return;
   } catch (e) {
     // createReview is atomic: one unmappable line (e.g. outside the diff, or
-    // stale after a force-push) rejects the whole batch. Rather than drop
-    // every comment, fall back to posting them individually — the pre-batch
+    // stale after a force-push) rejects the whole batch. Rather than drop every
+    // comment, fall back to posting them individually — the pre-batch
     // behaviour — so partial delivery still beats none.
+    //
+    // But only when the failure definitively means nothing was created. A lost
+    // response or a 5xx may follow a review GitHub already committed, and
+    // replaying then double-posts every comment. For those, reconcile against
+    // the API first and skip the replay if the review is already there.
+    const message = e instanceof Error ? e.message : String(e);
+
+    if (!isDeterministicRejection(e)) {
+      let alreadyPosted: boolean;
+      try {
+        alreadyPosted = await reviewAlreadyPosted(
+          octokit,
+          owner,
+          repo,
+          pull_number,
+          headSha,
+        );
+      } catch (checkError) {
+        // Cannot confirm either way. Posting nothing is recoverable by re-running;
+        // double-posting N comments onto a PR is not, so do not replay.
+        console.log(
+          `::warning::Batched review failed (${message}) and the follow-up check also failed (${checkError instanceof Error ? checkError.message : String(checkError)}) — not replaying, to avoid duplicate comments`,
+        );
+        return;
+      }
+
+      if (alreadyPosted) {
+        console.log(
+          `Batched review failed (${message}) but the review exists on the PR — not replaying`,
+        );
+        return;
+      }
+    }
+
     console.log(
-      `::warning::Batched review failed (${e instanceof Error ? e.message : String(e)}) — falling back to individual comments`,
+      `::warning::Batched review failed (${message}) — falling back to individual comments`,
     );
   }
 

--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -185,9 +185,10 @@ async function postComment(
   headSha: string,
   c: BufferedComment,
 ): Promise<boolean> {
-  // NOTE: octokit here is already the `.rest` client (see main), so members are
-  // reached as octokit.pulls.*. This previously read octokit.rest.pulls.*, which
-  // is undefined at runtime and made every individual post throw.
+  // octokit here is already the `.rest` client (see main), so members are
+  // reached as octokit.pulls.*, matching pulls.get / createReview elsewhere in
+  // this file. (@octokit/rest also self-references as .rest, so the previous
+  // octokit.rest.pulls.* worked too; this is only for consistency.)
   const params: Parameters<typeof octokit.pulls.createReviewComment>[0] = {
     owner,
     repo,

--- a/test/post-buffered-inline-comments.test.ts
+++ b/test/post-buffered-inline-comments.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "bun:test";
+import {
+  buildReviewComments,
+  REVIEW_BODY,
+} from "../src/entrypoints/post-buffered-inline-comments";
+
+/**
+ * Buffered inline comments are posted as one review rather than one
+ * createReviewComment call each, so the PR shows a single "reviewed" entry
+ * containing every comment instead of N standalone reviews. See issue #433.
+ *
+ * These cover the payload mapping, which differs from the single-comment API:
+ * no per-entry commit_id / pull_number, and multi-line hunks carry start_line
+ * plus start_side.
+ */
+describe("buildReviewComments", () => {
+  const base = { ts: "2026-09-04T00:00:00.000Z", body: "looks wrong" };
+
+  it("maps every buffered comment into one batch", () => {
+    const out = buildReviewComments([
+      { ...base, path: "a.ts", line: 10 },
+      { ...base, path: "b.ts", line: 20 },
+      { ...base, path: "c.ts", line: 30 },
+    ]);
+    expect(out).toHaveLength(3);
+    expect(out.map((c) => c.path)).toEqual(["a.ts", "b.ts", "c.ts"]);
+    expect(out.map((c) => c.line)).toEqual([10, 20, 30]);
+  });
+
+  it("defaults side to RIGHT and preserves an explicit side", () => {
+    const [right, left] = buildReviewComments([
+      { ...base, path: "a.ts", line: 5 },
+      { ...base, path: "b.ts", line: 6, side: "LEFT" },
+    ]);
+    expect(right!.side).toBe("RIGHT");
+    expect(left!.side).toBe("LEFT");
+  });
+
+  it("emits start_line and a matching start_side for multi-line comments", () => {
+    const [entry] = buildReviewComments([
+      { ...base, path: "a.ts", startLine: 4, line: 9, side: "LEFT" },
+    ]);
+    expect(entry!.start_line).toBe(4);
+    expect(entry!.start_side).toBe("LEFT");
+    expect(entry!.line).toBe(9);
+  });
+
+  it("omits start_line for single-line comments", () => {
+    const [entry] = buildReviewComments([{ ...base, path: "a.ts", line: 9 }]);
+    expect(entry).not.toHaveProperty("start_line");
+    expect(entry).not.toHaveProperty("start_side");
+    expect(entry!.line).toBe(9);
+  });
+
+  it("does not carry per-comment commit_id or pull_number", () => {
+    // The batched review sets commit_id once at the review level; repeating it
+    // per entry is rejected by the API.
+    const [entry] = buildReviewComments([
+      { ...base, path: "a.ts", line: 9, commit_id: "deadbeef" },
+    ]);
+    expect(entry).not.toHaveProperty("commit_id");
+    expect(entry).not.toHaveProperty("pull_number");
+  });
+
+  it("redacts secrets in the comment body", () => {
+    const [entry] = buildReviewComments([
+      {
+        ...base,
+        path: "a.ts",
+        line: 1,
+        body: "token ghp_1234567890abcdefghijklmnopqrstuvwxyz here",
+      },
+    ]);
+    expect(entry!.body).not.toContain(
+      "ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+    );
+  });
+
+  it("returns an empty batch for no comments", () => {
+    expect(buildReviewComments([])).toEqual([]);
+  });
+});
+
+describe("REVIEW_BODY", () => {
+  it("is non-empty, because event=COMMENT rejects an empty body with 422", () => {
+    // The Octokit typings mark `body` optional, so an empty value would only
+    // surface as a runtime 422 against the real API.
+    expect(REVIEW_BODY.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/test/post-buffered-inline-comments.test.ts
+++ b/test/post-buffered-inline-comments.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import {
   buildReviewComments,
+  isDeterministicRejection,
   REVIEW_BODY,
 } from "../src/entrypoints/post-buffered-inline-comments";
 
@@ -86,5 +87,35 @@ describe("REVIEW_BODY", () => {
     // The Octokit typings mark `body` optional, so an empty value would only
     // surface as a runtime 422 against the real API.
     expect(REVIEW_BODY.trim().length).toBeGreaterThan(0);
+  });
+});
+
+describe("isDeterministicRejection", () => {
+  // Only a definitive rejection proves nothing was created. Anything else may
+  // have succeeded server-side with the response lost, and replaying the
+  // comments individually would post them all a second time.
+  it("treats request-validation failures as deterministic", () => {
+    for (const status of [400, 401, 403, 404, 410, 422]) {
+      expect(isDeterministicRejection({ status })).toBe(true);
+    }
+  });
+
+  it("treats server errors as ambiguous", () => {
+    for (const status of [500, 502, 503, 504]) {
+      expect(isDeterministicRejection({ status })).toBe(false);
+    }
+  });
+
+  it("treats timeout and rate-limit as ambiguous", () => {
+    // 408/429 are 4xx but retryable, and GitHub may have applied the write.
+    expect(isDeterministicRejection({ status: 408 })).toBe(false);
+    expect(isDeterministicRejection({ status: 429 })).toBe(false);
+  });
+
+  it("treats transport errors with no status as ambiguous", () => {
+    expect(isDeterministicRejection(new Error("socket hang up"))).toBe(false);
+    expect(isDeterministicRejection({ code: "ECONNRESET" })).toBe(false);
+    expect(isDeterministicRejection(undefined)).toBe(false);
+    expect(isDeterministicRejection(null)).toBe(false);
   });
 });

--- a/test/post-buffered-review-recovery.test.ts
+++ b/test/post-buffered-review-recovery.test.ts
@@ -31,7 +31,7 @@ function installOctokitStub(opts: {
     listReviews: 0,
   };
 
-  const rest = {
+  const rest: Record<string, unknown> = {
     pulls: {
       get: async () => ({ data: { head: { sha: "headsha" } } }),
       createReview: async () => {
@@ -50,6 +50,10 @@ function installOctokitStub(opts: {
       },
     },
   };
+  // The real @octokit/rest client exposes a self-referencing `.rest`, so
+  // `client.rest.pulls.x` and `client.pulls.x` are the same function. Mirror
+  // that here: a stub without it makes correct production code look broken.
+  rest.rest = rest;
 
   mock.module("../src/github/api/client", () => ({
     createOctokit: () => ({ rest }),

--- a/test/post-buffered-review-recovery.test.ts
+++ b/test/post-buffered-review-recovery.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+/**
+ * Regression cover for the error-after-success case on the batched review.
+ *
+ * `pulls.createReview` can fail with the write already applied — a dropped
+ * response, a proxy 502, a timeout. Replaying the comments individually then
+ * posts every one of them a second time. These drive main() with a stubbed
+ * Octokit and assert on whether the per-comment path runs.
+ */
+
+const BUFFER_PATH = "/tmp/inline-comments-buffer.jsonl";
+
+type Calls = {
+  createReview: number;
+  createReviewComment: number;
+  listReviews: number;
+};
+
+function installOctokitStub(opts: {
+  createReviewError?: unknown;
+  existingReviews?: Array<{ commit_id: string; body: string }>;
+  listReviewsError?: unknown;
+}): Calls {
+  const calls: Calls = {
+    createReview: 0,
+    createReviewComment: 0,
+    listReviews: 0,
+  };
+
+  const rest = {
+    pulls: {
+      get: async () => ({ data: { head: { sha: "headsha" } } }),
+      createReview: async () => {
+        calls.createReview++;
+        if (opts.createReviewError) throw opts.createReviewError;
+        return { data: {} };
+      },
+      listReviews: async () => {
+        calls.listReviews++;
+        if (opts.listReviewsError) throw opts.listReviewsError;
+        return { data: opts.existingReviews ?? [] };
+      },
+      createReviewComment: async () => {
+        calls.createReviewComment++;
+        return { data: {} };
+      },
+    },
+  };
+
+  mock.module("../src/github/api/client", () => ({
+    createOctokit: () => ({ rest }),
+  }));
+
+  return calls;
+}
+
+async function runMain(): Promise<void> {
+  // Fresh module instance each time so the stub above is picked up.
+  const mod = await import(
+    `../src/entrypoints/post-buffered-inline-comments?t=${Date.now()}${Math.random()}`
+  );
+  await mod.main();
+}
+
+describe("batched review: error-after-success handling", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "buffered-"));
+    process.env.GITHUB_TOKEN = "t";
+    process.env.REPO_OWNER = "o";
+    process.env.REPO_NAME = "r";
+    process.env.PR_NUMBER = "1";
+    delete process.env.ANTHROPIC_API_KEY; // skip classification
+    writeFileSync(
+      BUFFER_PATH,
+      [
+        JSON.stringify({ ts: "t", path: "a.ts", line: 1, body: "real one" }),
+        JSON.stringify({ ts: "t", path: "b.ts", line: 2, body: "real two" }),
+      ].join("\n") + "\n",
+    );
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(BUFFER_PATH, { force: true });
+  });
+
+  it("does not replay when the response was lost but the review exists", async () => {
+    const calls = installOctokitStub({
+      createReviewError: new Error("socket hang up"),
+      existingReviews: [
+        {
+          commit_id: "headsha",
+          body: "Claude finished reviewing this pull request.",
+        },
+      ],
+    });
+
+    await runMain();
+
+    expect(calls.createReview).toBe(1);
+    expect(calls.listReviews).toBe(1);
+    // The comments are already on the PR inside that review.
+    expect(calls.createReviewComment).toBe(0);
+  });
+
+  it("replays when an ambiguous failure left no review behind", async () => {
+    const calls = installOctokitStub({
+      createReviewError: Object.assign(new Error("bad gateway"), {
+        status: 502,
+      }),
+      existingReviews: [],
+    });
+
+    await runMain();
+
+    expect(calls.listReviews).toBe(1);
+    expect(calls.createReviewComment).toBe(2);
+  });
+
+  it("replays immediately on a deterministic rejection without an extra lookup", async () => {
+    const calls = installOctokitStub({
+      createReviewError: Object.assign(new Error("unprocessable"), {
+        status: 422,
+      }),
+    });
+
+    await runMain();
+
+    // 422 means nothing was created, so no reconciliation is needed.
+    expect(calls.listReviews).toBe(0);
+    expect(calls.createReviewComment).toBe(2);
+  });
+
+  it("does not replay when the reconciliation lookup itself fails", async () => {
+    const calls = installOctokitStub({
+      createReviewError: new Error("socket hang up"),
+      listReviewsError: new Error("also down"),
+    });
+
+    await runMain();
+
+    // Unknown state: posting nothing can be retried, double-posting cannot.
+    expect(calls.createReviewComment).toBe(0);
+  });
+
+  it("posts exactly one review and no individual comments on success", async () => {
+    const calls = installOctokitStub({});
+
+    await runMain();
+
+    expect(calls.createReview).toBe(1);
+    expect(calls.createReviewComment).toBe(0);
+    expect(calls.listReviews).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Buffered inline comments are posted with one `createReviewComment` call each, and GitHub wraps every such call in its own review. A PR with N inline comments therefore shows N separate `reviewed` entries rather than one review containing N comments — the screenshot in #433.

The comments are already collected in a buffer (`/tmp/inline-comments-buffer.jsonl`) and posted together at the end, so only the final call needs to change.

Fixes #433.

## Cause

`src/entrypoints/post-buffered-inline-comments.ts` loops over the batch:

```ts
for (const c of toPost) {
  if (await postComment(octokit, owner, repo, pull_number, headSha, c)) { ... }
}
```

and `postComment` calls `octokit.rest.pulls.createReviewComment` once per entry. That endpoint has no notion of a containing review, so each call creates a standalone one.

## Change

One `pulls.createReview` with a `comments[]` array. Two details that are easy to get wrong:

- **`event: "COMMENT"` requires a non-empty `body`.** The [API docs](https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#create-a-review-for-a-pull-request) list `body` as *"**Required** when using `REQUEST_CHANGES` or `COMMENT`"*, but the Octokit typings mark it optional, so omitting it type-checks and then fails at runtime with 422. `REVIEW_BODY` supplies the summary line, and a test asserts it stays non-empty.
- **Per-entry fields differ from the single-comment API.** The review payload takes `path` / `body` / `line` / `side` (+ `start_line` / `start_side` for multi-line hunks) and must *not* repeat `commit_id` or `pull_number`, which are set once at the review level.

## Fallback is conditional, not unconditional

`createReview` is atomic — one unmappable line (outside the diff, or stale after a force-push) rejects the whole batch. Dropping all N comments because one is unmappable would be a worse failure than the bug being fixed, so there is a per-comment fallback. But it only runs when the failure proves nothing was created:

| Failure | Created? | Action |
| --- | --- | --- |
| 4xx except 408/429 | definitively not | replay immediately |
| 5xx, 408, 429, transport error, no status | unknown | reconcile, then replay only if absent |

Reconciliation looks for a review on the head SHA carrying `REVIEW_BODY`. If that lookup itself fails, it does not replay: posting nothing is recoverable by re-running, double-posting N comments is not. Thanks to @sylvesterkaczmarek for catching that the original fallback was unconditional.

## Verification

- `bun test` — **983 pass / 0 fail** (2273 assertions, 59 files); 17 new tests.
- `bun run typecheck` — clean.
- `bun run format:check` — clean on all three files touched here.
- Five of the new tests drive `main()` with a stubbed Octokit and assert on whether the per-comment path runs: response lost + review exists → no replay; ambiguous + no review → replay; 422 → replay with no reconciliation call; reconciliation fails → no replay; success → one review, zero individual posts.
- `main()` is behind `import.meta.main` and exported for those tests. `action.yml:446` runs this file directly with `bun run`, where `import.meta.main` is true, so the production path is unchanged; this matches `prepare.ts`, `run.ts` and 3 other entrypoints.

I could not exercise the real API from here, so the batched call is verified against the documented schema and by unit tests rather than end-to-end; the `body`-required behaviour is the part most worth a maintainer's eye.

An earlier revision of this PR claimed `postComment` was broken on `main` via a doubled `.rest`. That was wrong — `@octokit/rest` self-references, so both forms work — and it was an artifact of an unfaithful test stub. Retracted in f6cc6a7; the stub now mirrors the real client and the change to `github-inline-comment-server.ts` was reverted.

🤖 Written with [Claude Code](https://claude.ai/code).

