### PR TITLE
docs: fix checkout fetch-depth example in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -125,7 +125,8 @@ If you need full history, you can configure this in your workflow before calling
 
 ```
 - uses: actions/checkout@v6
-  depth: 0 # will fetch full repo history
+  with:
+    fetch-depth: 0 # will fetch full repo history
 ```
 
 ## Configuration and Tools


### PR DESCRIPTION
## Summary

Fixes the full-history checkout example in `docs/faq.md`.

`actions/checkout` uses the `fetch-depth` input under `with`, rather than a top-level `depth` field. The existing example would therefore not configure a full-history checkout as intended.

## Test plan

- Ran `git diff --check`
- Verified `actions/checkout` defines `fetch-depth`, where `0` fetches all history
- Documentation-only change