### PR TITLE
fix: read --mcp-config file paths instead of silently dropping them

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "fs";
 import { parse as parseShellArgs } from "shell-quote";
 import type { ClaudeOptions } from "./run-claude";
 import type { Options as SdkOptions } from "@anthropic-ai/claude-agent-sdk";
@@ -60,13 +61,14 @@ type McpConfig = {
 
 /**
  * Merge multiple MCP config values into a single config.
- * Each config can be a JSON string or a file path.
- * For JSON strings, mcpServers objects are merged.
- * For file paths, they are kept as-is (user's file takes precedence and is used last).
+ * Each config can be a JSON string or a file path; both are read and their
+ * mcpServers objects merged, with later values winning on key collisions.
+ * If nothing can be read, the last unreadable path is returned unchanged so
+ * the CLI can report the error against the real path.
  */
 function mergeMcpConfigs(configValues: string[]): string {
   const merged: McpConfig = { mcpServers: {} };
-  let lastFilePath: string | null = null;
+  const unreadableFilePaths: string[] = [];
 
   for (const config of configValues) {
     const trimmed = config.trim();
@@ -80,31 +82,40 @@ function mergeMcpConfigs(configValues: string[]): string {
           Object.assign(merged.mcpServers!, parsed.mcpServers);
         }
       } catch {
-        // If JSON parsing fails, treat as file path
-        lastFilePath = trimmed;
+        // Not valid JSON despite the leading brace — nothing usable here.
+        unreadableFilePaths.push(trimmed);
       }
     } else {
-      // It's a file path - store it to handle separately
-      lastFilePath = trimmed;
+      // A file path. Read it now and merge its servers, so it survives
+      // alongside the action's built-in inline config. Only one value can be
+      // returned, and the action always prepends its own servers as inline
+      // JSON, so a path that is merely remembered here would always be
+      // discarded and the user's servers would never start.
+      try {
+        const parsed = JSON.parse(readFileSync(trimmed, "utf8")) as McpConfig;
+        if (parsed.mcpServers) {
+          Object.assign(merged.mcpServers!, parsed.mcpServers);
+        }
+      } catch (error) {
+        unreadableFilePaths.push(trimmed);
+        console.warn(
+          `Could not read --mcp-config file ${trimmed}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
     }
   }
 
-  // If we have file paths, we need to keep the merged JSON and let the file
-  // be handled separately. Since we can only return one value, merge what we can.
-  // If there's a file path, we need a different approach - read the file at runtime.
-  // For now, if there's a file path, we'll stringify the merged config.
-  // The action prepends its config as JSON, so we can safely merge inline JSON configs.
-
-  // If no inline configs were found (all file paths), return the last file path
-  if (Object.keys(merged.mcpServers!).length === 0 && lastFilePath) {
-    return lastFilePath;
+  // Nothing could be merged. Hand the path back unchanged rather than an empty
+  // config, so the CLI reports the failure against the real path — and so a
+  // path that exists in the CLI's environment but not this one still works.
+  if (Object.keys(merged.mcpServers!).length === 0) {
+    const lastUnreadable = unreadableFilePaths[unreadableFilePaths.length - 1];
+    if (lastUnreadable) {
+      return lastUnreadable;
+    }
   }
-
-  // Note: If user passes a file path, we cannot merge it at parse time since
-  // we don't have access to the file system here. The action's built-in MCP
-  // servers are always passed as inline JSON, so they will be merged.
-  // If user also passes inline JSON, it will be merged.
-  // If user passes a file path, they should ensure it includes all needed servers.
 
   return JSON.stringify(merged);
 }

--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -63,12 +63,11 @@ type McpConfig = {
  * Merge multiple MCP config values into a single config.
  * Each config can be a JSON string or a file path; both are read and their
  * mcpServers objects merged, with later values winning on key collisions.
- * If nothing can be read, the last unreadable path is returned unchanged so
- * the CLI can report the error against the real path.
+ * Merging is all-or-nothing: an unreadable or malformed value throws instead
+ * of silently running with only the remaining configuration.
  */
 function mergeMcpConfigs(configValues: string[]): string {
   const merged: McpConfig = { mcpServers: {} };
-  const unreadableFilePaths: string[] = [];
 
   for (const config of configValues) {
     const trimmed = config.trim();
@@ -81,9 +80,12 @@ function mergeMcpConfigs(configValues: string[]): string {
         if (parsed.mcpServers) {
           Object.assign(merged.mcpServers!, parsed.mcpServers);
         }
-      } catch {
-        // Not valid JSON despite the leading brace — nothing usable here.
-        unreadableFilePaths.push(trimmed);
+      } catch (error) {
+        throw new Error(
+          `Could not parse inline --mcp-config JSON: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
       }
     } else {
       // A file path. Read it now and merge its servers, so it survives
@@ -97,23 +99,12 @@ function mergeMcpConfigs(configValues: string[]): string {
           Object.assign(merged.mcpServers!, parsed.mcpServers);
         }
       } catch (error) {
-        unreadableFilePaths.push(trimmed);
-        console.warn(
+        throw new Error(
           `Could not read --mcp-config file ${trimmed}: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );
       }
-    }
-  }
-
-  // Nothing could be merged. Hand the path back unchanged rather than an empty
-  // config, so the CLI reports the failure against the real path — and so a
-  // path that exists in the CLI's environment but not this one still works.
-  if (Object.keys(merged.mcpServers!).length === 0) {
-    const lastUnreadable = unreadableFilePaths[unreadableFilePaths.length - 1];
-    if (lastUnreadable) {
-      return lastUnreadable;
     }
   }
 

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -341,21 +341,14 @@ describe("parseSdkOptions", () => {
       );
     });
 
-    test("should merge inline JSON configs when file path is also present", () => {
-      // The file path here does not exist, so only the inline configs can be
-      // merged; the servers from the readable inline JSON must still survive.
+    test("should reject a file path that cannot be merged with inline configs", () => {
       const options: ClaudeOptions = {
         claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config '{"mcpServers":{"github_ci":{"command":"node"}}}' --mcp-config /tmp/user-config.json`,
       };
 
-      const result = parseSdkOptions(options);
-
-      // The inline JSON configs should be merged
-      const mcpConfig = JSON.parse(
-        result.sdkOptions.extraArgs?.["mcp-config"] as string,
+      expect(() => parseSdkOptions(options)).toThrow(
+        "Could not read --mcp-config file /tmp/user-config.json",
       );
-      expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
-      expect(mcpConfig.mcpServers).toHaveProperty("github_ci");
     });
 
     describe("mcp-config file paths are read and merged", () => {
@@ -449,39 +442,34 @@ describe("parseSdkOptions", () => {
         expect(mcpConfig.mcpServers).toHaveProperty("second");
       });
 
-      test("keeps the inline servers when the file cannot be read", () => {
-        const result = parseSdkOptions({
-          claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config ${join(dir, "missing.json")}`,
-        });
+      test("rejects the merge when a file cannot be read", () => {
+        const missing = join(dir, "missing.json");
 
-        const mcpConfig = JSON.parse(
-          result.sdkOptions.extraArgs?.["mcp-config"] as string,
-        );
-        expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
+        expect(() =>
+          parseSdkOptions({
+            claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config ${missing}`,
+          }),
+        ).toThrow(`Could not read --mcp-config file ${missing}`);
       });
 
-      test("keeps the inline servers when the file holds malformed JSON", () => {
+      test("rejects the merge when a file holds malformed JSON", () => {
         writeFileSync(configPath, "{ this is not json");
 
-        const result = parseSdkOptions({
-          claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config ${configPath}`,
-        });
-
-        const mcpConfig = JSON.parse(
-          result.sdkOptions.extraArgs?.["mcp-config"] as string,
-        );
-        expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
+        expect(() =>
+          parseSdkOptions({
+            claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config ${configPath}`,
+          }),
+        ).toThrow(`Could not read --mcp-config file ${configPath}`);
       });
 
-      test("returns the path unchanged when it is the only value and is unreadable", () => {
-        // Preserves the existing single-path behaviour: the CLI resolves the
-        // path itself and reports errors against it.
+      test("rejects repeated unreadable paths that must be merged", () => {
         const missing = join(dir, "missing.json");
-        const result = parseSdkOptions({
-          claudeArgs: `--mcp-config ${missing} --mcp-config ${missing}`,
-        });
 
-        expect(result.sdkOptions.extraArgs?.["mcp-config"]).toBe(missing);
+        expect(() =>
+          parseSdkOptions({
+            claudeArgs: `--mcp-config ${missing} --mcp-config ${missing}`,
+          }),
+        ).toThrow(`Could not read --mcp-config file ${missing}`);
       });
     });
 

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env bun
 
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { parseSdkOptions } from "../src/parse-sdk-options";
 import type { ClaudeOptions } from "../src/run-claude";
 
@@ -339,8 +342,8 @@ describe("parseSdkOptions", () => {
     });
 
     test("should merge inline JSON configs when file path is also present", () => {
-      // When action provides inline JSON and user provides a file path,
-      // the inline JSON configs should be merged (file paths cannot be merged at parse time)
+      // The file path here does not exist, so only the inline configs can be
+      // merged; the servers from the readable inline JSON must still survive.
       const options: ClaudeOptions = {
         claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config '{"mcpServers":{"github_ci":{"command":"node"}}}' --mcp-config /tmp/user-config.json`,
       };
@@ -353,6 +356,133 @@ describe("parseSdkOptions", () => {
       );
       expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
       expect(mcpConfig.mcpServers).toHaveProperty("github_ci");
+    });
+
+    describe("mcp-config file paths are read and merged", () => {
+      // Regression cover for #1004: the action always prepends its own servers
+      // as inline JSON, so a user-supplied --mcp-config file path used to be
+      // dropped entirely and those servers never started.
+      let dir: string;
+      let configPath: string;
+
+      beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), "mcp-config-"));
+        configPath = join(dir, "user-mcp.json");
+      });
+
+      afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+      });
+
+      test("keeps the user's file-path servers alongside the action's inline ones", () => {
+        writeFileSync(
+          configPath,
+          JSON.stringify({
+            mcpServers: { my_server: { command: "uvx", args: ["some-tool"] } },
+          }),
+        );
+
+        const result = parseSdkOptions({
+          claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config ${configPath}`,
+        });
+
+        const mcpConfig = JSON.parse(
+          result.sdkOptions.extraArgs?.["mcp-config"] as string,
+        );
+        expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
+        expect(mcpConfig.mcpServers).toHaveProperty("my_server");
+        expect(mcpConfig.mcpServers.my_server.command).toBe("uvx");
+      });
+
+      test("merges a file path even when it comes first", () => {
+        writeFileSync(
+          configPath,
+          JSON.stringify({ mcpServers: { my_server: { command: "uvx" } } }),
+        );
+
+        const result = parseSdkOptions({
+          claudeArgs: `--mcp-config ${configPath} --mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}'`,
+        });
+
+        const mcpConfig = JSON.parse(
+          result.sdkOptions.extraArgs?.["mcp-config"] as string,
+        );
+        expect(mcpConfig.mcpServers).toHaveProperty("my_server");
+        expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
+      });
+
+      test("lets a later value win on a name collision", () => {
+        writeFileSync(
+          configPath,
+          JSON.stringify({ mcpServers: { shared: { command: "from-file" } } }),
+        );
+
+        const result = parseSdkOptions({
+          claudeArgs: `--mcp-config '{"mcpServers":{"shared":{"command":"from-inline"}}}' --mcp-config ${configPath}`,
+        });
+
+        const mcpConfig = JSON.parse(
+          result.sdkOptions.extraArgs?.["mcp-config"] as string,
+        );
+        expect(mcpConfig.mcpServers.shared.command).toBe("from-file");
+      });
+
+      test("merges two file paths", () => {
+        const second = join(dir, "second.json");
+        writeFileSync(
+          configPath,
+          JSON.stringify({ mcpServers: { first: { command: "a" } } }),
+        );
+        writeFileSync(
+          second,
+          JSON.stringify({ mcpServers: { second: { command: "b" } } }),
+        );
+
+        const result = parseSdkOptions({
+          claudeArgs: `--mcp-config ${configPath} --mcp-config ${second}`,
+        });
+
+        const mcpConfig = JSON.parse(
+          result.sdkOptions.extraArgs?.["mcp-config"] as string,
+        );
+        expect(mcpConfig.mcpServers).toHaveProperty("first");
+        expect(mcpConfig.mcpServers).toHaveProperty("second");
+      });
+
+      test("keeps the inline servers when the file cannot be read", () => {
+        const result = parseSdkOptions({
+          claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config ${join(dir, "missing.json")}`,
+        });
+
+        const mcpConfig = JSON.parse(
+          result.sdkOptions.extraArgs?.["mcp-config"] as string,
+        );
+        expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
+      });
+
+      test("keeps the inline servers when the file holds malformed JSON", () => {
+        writeFileSync(configPath, "{ this is not json");
+
+        const result = parseSdkOptions({
+          claudeArgs: `--mcp-config '{"mcpServers":{"github_comment":{"command":"node"}}}' --mcp-config ${configPath}`,
+        });
+
+        const mcpConfig = JSON.parse(
+          result.sdkOptions.extraArgs?.["mcp-config"] as string,
+        );
+        expect(mcpConfig.mcpServers).toHaveProperty("github_comment");
+      });
+
+      test("returns the path unchanged when it is the only value and is unreadable", () => {
+        // Preserves the existing single-path behaviour: the CLI resolves the
+        // path itself and reports errors against it.
+        const missing = join(dir, "missing.json");
+        const result = parseSdkOptions({
+          claudeArgs: `--mcp-config ${missing} --mcp-config ${missing}`,
+        });
+
+        expect(result.sdkOptions.extraArgs?.["mcp-config"]).toBe(missing);
+      });
     });
 
     test("should handle mcp-config with other flags", () => {


### PR DESCRIPTION
## Summary

`--mcp-config /path/to/file.json` inside `claude_args` is silently dropped, so the user's MCP servers never start. Because `--allowedTools` passes through verbatim, the tools appear allowed but are uncallable — the server is simply absent from `mcp_servers`.

Fixes #1004.

## Cause

`mergeMcpConfigs` kept a file path in `lastFilePath` and returned it only if nothing else had been merged:

```ts
if (Object.keys(merged.mcpServers!).length === 0 && lastFilePath) {
  return lastFilePath;
}
```

The action always prepends its own servers (`github_comment`, …) as **inline JSON** before user `claude_args` are parsed, so `merged.mcpServers` is never empty by then. The condition can't fire, and the function falls through to `JSON.stringify(merged)` — returning only the action's servers.

The existing comment acknowledged the gap but suggested users "ensure the file includes all needed servers", which isn't possible: the action's internal server set isn't knowable at workflow-authoring time and changes between versions. The docstring also already claimed the opposite of the behaviour ("*file paths are kept as-is … user's file takes precedence*").

## Reproduced locally

Driving `parseSdkOptions` with the action's real argument shape (single-quoted inline JSON, as `modes/tag/index.ts` builds it) plus a user file path:

```
before:  {"mcpServers":{"github_comment":{…}}}          ← my_server gone
after:   {"mcpServers":{"github_comment":{…},"my_server":{…}}}
```

## Change

Read and parse the file at merge time and merge its `mcpServers` with the rest; later values win on key collisions, matching how inline configs already merge.

Merging is all-or-nothing. When multiple `--mcp-config` values require action-side merging, every inline JSON value and every file must parse successfully; an unreadable or malformed value throws with its source instead of silently running with a partial server set. A single `--mcp-config /path/to/file.json` is still passed through unchanged, preserving the CLI-owned resolution and error path.

## Verification

- Root suite: **973 pass / 0 fail** (2240 assertions, 57 files).
- `base-action`: **171 pass / 0 fail** (345 assertions, 11 files).
- Confirmed the fail-closed tests are load-bearing: reverting only the implementation produces exactly 4 failures.
- New cases cover file + inline, file listed first, collision precedence, two file paths, missing files, malformed JSON, repeated unreadable paths, and single-path CLI passthrough.
- `bun run typecheck` and `bun run format:check` pass in both the root package and `base-action`.

`base-action` is a separately published package; this changes only the internals of an unexported helper, so its public API is unaffected.

🤖 Written with [Claude Code](https://claude.ai/code).

