### PR TITLE
fix: skip malformed buffered inline comment lines instead of failing the post step

### DIFF
--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -15,7 +15,7 @@ import { redactSecrets } from "../github/utils/sanitizer";
 
 const BUFFER_PATH = "/tmp/inline-comments-buffer.jsonl";
 
-type BufferedComment = {
+export type BufferedComment = {
   ts: string;
   path: string;
   line?: number;
@@ -25,6 +25,40 @@ type BufferedComment = {
   body: string;
   confirmed?: boolean;
 };
+
+/**
+ * Parse the buffer file contents into comments, skipping malformed lines.
+ *
+ * The buffer is appended by separate MCP server processes and
+ * removeBufferedComment() deliberately keeps lines it cannot parse, so a
+ * truncated or interleaved line can legitimately be present. One bad line
+ * must not fail the whole post step and cost every valid buffered comment.
+ */
+export function parseBufferedComments(raw: string): BufferedComment[] {
+  const comments: BufferedComment[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      console.log(
+        `::warning::Skipping malformed buffered inline comment: ${line.slice(0, 120)}`,
+      );
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) {
+      console.log(
+        `::warning::Skipping non-object buffered inline comment: ${line.slice(0, 120)}`,
+      );
+      continue;
+    }
+    comments.push(parsed as BufferedComment);
+  }
+  return comments;
+}
 
 const CLASSIFICATION_PROMPT = `You are classifying PR inline comments as either REAL code review feedback or TEST/PROBE calls.
 
@@ -153,10 +187,7 @@ async function main() {
     return;
   }
 
-  const comments: BufferedComment[] = raw
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => JSON.parse(line));
+  const comments: BufferedComment[] = parseBufferedComments(raw);
 
   if (comments.length === 0) {
     console.log("No buffered inline comments");
@@ -228,7 +259,9 @@ async function main() {
   console.log(`Posted ${posted}/${toPost.length}`);
 }
 
-main().catch((e) => {
-  console.error("post-buffered-inline-comments failed:", e);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((e) => {
+    console.error("post-buffered-inline-comments failed:", e);
+    process.exit(1);
+  });
+}

--- a/test/post-buffered-inline-comments.test.ts
+++ b/test/post-buffered-inline-comments.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect } from "bun:test";
+import { parseBufferedComments } from "../src/entrypoints/post-buffered-inline-comments";
+
+describe("parseBufferedComments", () => {
+  test("parses valid JSONL lines", () => {
+    const raw = [
+      JSON.stringify({
+        ts: "2026-01-01T00:00:00Z",
+        path: "src/index.ts",
+        line: 10,
+        body: "Consider handling the empty case.",
+      }),
+      JSON.stringify({
+        ts: "2026-01-01T00:00:01Z",
+        path: "src/util.ts",
+        startLine: 5,
+        line: 8,
+        body: "This loop can skip the last element.",
+      }),
+    ].join("\n");
+
+    const comments = parseBufferedComments(raw);
+    expect(comments.length).toBe(2);
+    expect(comments[0]?.path).toBe("src/index.ts");
+    expect(comments[1]?.startLine).toBe(5);
+  });
+
+  test("skips a malformed line instead of throwing away valid comments", () => {
+    const valid = JSON.stringify({
+      ts: "2026-01-01T00:00:00Z",
+      path: "src/index.ts",
+      line: 10,
+      body: "Real review comment.",
+    });
+    const truncated =
+      '{"ts":"2026-01-01T00:00:01Z","path":"src/util.ts","line"';
+    const raw = `${valid}\n${truncated}\n`;
+
+    const comments = parseBufferedComments(raw);
+    expect(comments.length).toBe(1);
+    expect(comments[0]?.body).toBe("Real review comment.");
+  });
+
+  test("skips lines that parse to non-objects", () => {
+    const valid = JSON.stringify({
+      ts: "2026-01-01T00:00:00Z",
+      path: "src/index.ts",
+      line: 10,
+      body: "Real review comment.",
+    });
+    const raw = `${valid}\n123\n"just a string"\n`;
+
+    const comments = parseBufferedComments(raw);
+    expect(comments.length).toBe(1);
+  });
+
+  test("returns empty array for empty or whitespace-only input", () => {
+    expect(parseBufferedComments("")).toEqual([]);
+    expect(parseBufferedComments("\n\n")).toEqual([]);
+  });
+
+  test("keeps comment bodies containing newlines escaped as JSON", () => {
+    const raw =
+      JSON.stringify({
+        ts: "2026-01-01T00:00:00Z",
+        path: "src/index.ts",
+        line: 10,
+        body: "line one\nline two",
+      }) + "\n";
+
+    const comments = parseBufferedComments(raw);
+    expect(comments.length).toBe(1);
+    expect(comments[0]?.body).toBe("line one\nline two");
+  });
+});


### PR DESCRIPTION
Title: fix: skip malformed buffered inline comment lines instead of failing the post step

Body:

Fixes #1796

## Summary

The post step parsed every buffer line with an unguarded `JSON.parse`, so a
single truncated/interleaved line rejected `main()` and cost **all** buffered
comments — including valid ones. This contradicted `removeBufferedComment()`,
which deliberately keeps unparseable lines in the buffer.

## Changes

- Extract `parseBufferedComments(raw)`, which skips unparseable and
  non-object lines with a `::warning::` annotation (matching this file's
  existing warning style) and returns the valid entries.
- Guard the `main()` invocation with `import.meta.main` so the module is
  importable by tests, following the pattern used by the other entrypoints.
- Add `test/post-buffered-inline-comments.test.ts` covering: valid JSONL,
  malformed-line tolerance, non-object lines, empty input, and escaped
  newlines in bodies.

## Testing

- `bun test` — 971 pass, 0 fail
- `bun run typecheck` — clean
- `bun run format:check` — clean
