### PR TITLE
fix: only extract the user request from word-boundary trigger occurrences

### DIFF
--- a/src/utils/extract-user-request.ts
+++ b/src/utils/extract-user-request.ts
@@ -4,6 +4,18 @@
  * Given a comment like "@claude /review-pr please check the auth module",
  * this extracts "/review-pr please check the auth module".
  *
+ * An occurrence of the trigger phrase only counts when it sits at a word
+ * boundary — preceded by whitespace (or the start of the comment) and
+ * followed by whitespace, punctuation, or the end of the comment — matching
+ * the boundary semantics of the trigger matcher in
+ * src/github/validation/trigger.ts. Without this, an earlier mid-token
+ * appearance of the phrase (e.g. "support@claude.dev" before the real
+ * "@claude fix this") wins the substring search and the wrong text becomes
+ * the user's request.
+ *
+ * Uses string operations instead of building a RegExp from the trigger
+ * phrase to avoid potential ReDoS with large comment bodies.
+ *
  * @param commentBody - The full comment body containing the trigger phrase
  * @param triggerPhrase - The trigger phrase (e.g., "@claude")
  * @returns The user's request (text after the trigger phrase), or null if not found
@@ -16,17 +28,22 @@ export function extractUserRequest(
     return null;
   }
 
-  // Use string operations instead of regex for better performance and security
-  // (avoids potential ReDoS with large comment bodies)
-  const triggerIndex = commentBody
-    .toLowerCase()
-    .indexOf(triggerPhrase.toLowerCase());
-  if (triggerIndex === -1) {
-    return null;
+  const lowerBody = commentBody.toLowerCase();
+  const lowerPhrase = triggerPhrase.toLowerCase();
+
+  let idx = lowerBody.indexOf(lowerPhrase);
+  while (idx !== -1) {
+    const prev = idx > 0 ? lowerBody[idx - 1] : undefined;
+    const precededByBoundary = prev === undefined || /\s/.test(prev);
+    const end = idx + lowerPhrase.length;
+    const next = end < lowerBody.length ? lowerBody[end] : undefined;
+    const followedByBoundary = next === undefined || /[\s.,!?;:]/.test(next);
+    if (precededByBoundary && followedByBoundary) {
+      const afterTrigger = commentBody.substring(end).trim();
+      return afterTrigger || null;
+    }
+    idx = lowerBody.indexOf(lowerPhrase, idx + 1);
   }
 
-  const afterTrigger = commentBody
-    .substring(triggerIndex + triggerPhrase.length)
-    .trim();
-  return afterTrigger || null;
+  return null;
 }

--- a/test/extract-user-request.test.ts
+++ b/test/extract-user-request.test.ts
@@ -74,4 +74,31 @@ Focus on security issues.`,
       "/review-pr",
     );
   });
+
+  test("skips mid-token occurrences before the real trigger", () => {
+    expect(
+      extractUserRequest(
+        "Email support@claude.dev and @claude fix the auth module",
+        "@claude",
+      ),
+    ).toBe("fix the auth module");
+  });
+
+  test("skips occurrences followed by a word character", () => {
+    expect(
+      extractUserRequest("cc @claude-bob, @claude fix this", "@claude"),
+    ).toBe("fix this");
+  });
+
+  test("returns null when the phrase only appears mid-token", () => {
+    expect(
+      extractUserRequest("Contact support@claude.dev for help", "@claude"),
+    ).toBeNull();
+  });
+
+  test("accepts a trigger phrase at the start of a later line", () => {
+    expect(
+      extractUserRequest("Some context.\n@claude fix this", "@claude"),
+    ).toBe("fix this");
+  });
 });


### PR DESCRIPTION
Title: fix: only extract the user request from word-boundary trigger occurrences

Body:

Fixes #1798

## Summary

`extractUserRequest` took the first raw `indexOf` occurrence of the trigger
phrase, while `checkContainsTrigger` only accepts the phrase at a word
boundary. A comment like

> Email security@claude.dev ASAP. @claude please review the auth module

triggered correctly but extracted
`.dev ASAP. @claude please review the auth module` as the user's request.

## Changes

- `extractUserRequest` now scans occurrences left to right and honors only
  the first one whose preceding/following characters satisfy the same
  boundary semantics as the trigger matcher (preceded by start/whitespace,
  followed by whitespace, `.,!?;:` or end).
- Keeps the file's string-operations approach — no RegExp built from the
  trigger phrase (ReDoS concern documented in the file).
- Adds tests for: mid-token occurrence before the real trigger, occurrence
  followed by a word character (`@claude-bob`), phrase appearing only
  mid-token (returns null), and a phrase at the start of a later line.

## Testing

- `bun test` — 970 pass, 0 fail
- `bun run typecheck` — clean
- `bun run format:check` — clean
