### PR TITLE
fix: match assignee and allowed-user logins case-insensitively

### DIFF
--- a/src/github/validation/permissions.ts
+++ b/src/github/validation/permissions.ts
@@ -97,9 +97,9 @@ async function checkActorWritePermissions(
       } else if (allowedUsers) {
         const allowedUserList = allowedUsers
           .split(",")
-          .map((u) => u.trim())
+          .map((u) => u.trim().toLowerCase())
           .filter((u) => u.length > 0);
-        if (allowedUserList.includes(actor)) {
+        if (allowedUserList.includes(actor.toLowerCase())) {
           core.warning(
             `⚠️ SECURITY WARNING: Bypassing write permission check for ${actor} due to allowed_non_write_users configuration. This should only be used for workflows with very limited permissions.`,
           );

--- a/src/github/validation/trigger.ts
+++ b/src/github/validation/trigger.ts
@@ -28,7 +28,10 @@ export function checkContainsTrigger(context: ParsedGitHubContext): boolean {
     let triggerUser = assigneeTrigger.replace(/^@/, "");
     const assigneeUsername = context.payload.assignee?.login || "";
 
-    if (triggerUser && assigneeUsername === triggerUser) {
+    if (
+      triggerUser &&
+      assigneeUsername.toLowerCase() === triggerUser.toLowerCase()
+    ) {
       console.log(`Issue assigned to trigger user '${triggerUser}'`);
       return true;
     }

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -184,6 +184,58 @@ describe("checkWritePermissions", () => {
   });
 
   describe("allowed_non_write_users bypass", () => {
+    test.each([
+      { actor: "test-user", allowed: " other-user, TeSt-UsEr " },
+      { actor: "TeSt-UsEr", allowed: "test-user" },
+    ])(
+      "should match allowed usernames regardless of case: %j",
+      async ({ actor, allowed }) => {
+        const mockOctokit = createMockOctokit("read");
+        const context = { ...createContext(), actor };
+
+        expect(
+          await checkWritePermissions(mockOctokit, context, allowed, true),
+        ).toBe(true);
+        expect(coreInfoSpy).toHaveBeenCalledWith(
+          `Checking permissions for actor: ${actor}`,
+        );
+        expect(coreWarningSpy).toHaveBeenCalledWith(
+          expect.stringContaining(`write permission check for ${actor} due to`),
+        );
+      },
+    );
+
+    test("should still require github_token for a case-insensitive username match", async () => {
+      const mockOctokit = createMockOctokit("read");
+
+      expect(
+        await checkWritePermissions(
+          mockOctokit,
+          createContext(),
+          "TeSt-UsEr",
+          false,
+        ),
+      ).toBe(false);
+      expect(coreWarningSpy).toHaveBeenCalledWith(
+        "Actor has insufficient permissions: read",
+      );
+    });
+
+    test.each([
+      { actor: "test-user-other", allowed: "TeSt-UsEr" },
+      { actor: "test-user", allowed: "TeSt-UsEr-Other" },
+    ])(
+      "should not match a different username with the same prefix: %j",
+      async ({ actor, allowed }) => {
+        const mockOctokit = createMockOctokit("read");
+        const context = { ...createContext(), actor };
+
+        expect(
+          await checkWritePermissions(mockOctokit, context, allowed, true),
+        ).toBe(false);
+      },
+    );
+
     test("should bypass permission check for specific user when github_token provided", async () => {
       const mockOctokit = createMockOctokit("read");
       const context = createContext();

--- a/test/trigger-validation.test.ts
+++ b/test/trigger-validation.test.ts
@@ -73,6 +73,32 @@ describe("checkContainsTrigger", () => {
   });
 
   describe("assignee trigger", () => {
+    it.each([
+      { trigger: "@ClAuDe-BoT", login: "claude-bot" },
+      { trigger: "claude-bot", login: "ClAuDe-BoT" },
+    ])(
+      "should match assignee usernames regardless of case: %j",
+      ({ trigger, login }) => {
+        const context = {
+          ...mockIssueAssignedContext,
+          inputs: {
+            ...mockIssueAssignedContext.inputs,
+            assigneeTrigger: trigger,
+          },
+          payload: {
+            ...mockIssueAssignedContext.payload,
+            assignee: {
+              ...(mockIssueAssignedContext.payload as IssuesAssignedEvent)
+                .assignee,
+              login,
+            },
+          },
+        } as ParsedGitHubContext;
+
+        expect(checkContainsTrigger(context)).toBe(true);
+      },
+    );
+
     it("should return true when issue is assigned to the trigger user", () => {
       const context = mockIssueAssignedContext;
       expect(checkContainsTrigger(context)).toBe(true);


### PR DESCRIPTION
## Summary

GitHub logins identify the same account regardless of capitalization, but `assignee_trigger` and `allowed_non_write_users` currently compare them case-sensitively. A difference in capitalization can suppress an assignment trigger or reject a user explicitly named in the allowlist.

Compare logins case-insensitively at these two boundaries, while keeping the original values for API requests and diagnostics. Because mode detection shares the trigger check, mixed-case assignee events also consistently select tag mode.

## Scope

- Keep leading-`@` support for `assignee_trigger` and whitespace handling for comma-separated allowed users.
- Keep wildcard behavior, the user-supplied `github_token` prerequisite, and existing permission and bot checks unchanged.
- Do not change the separate actor include/exclude filters, which remain case-sensitive.

## Regression coverage

- Capitalization differences in both directions for each input.
- Original actor spelling in diagnostics, including the bypass warning.
- No non-write bypass without a user-supplied token.
- Reject different usernames sharing a prefix, in both directions.

The four mixed-case positive cases failed on the unchanged baseline before the comparison fix; the existing suite and the negative controls remain passing.

## Validation

- `bun test`: 973 passed, 0 failed across 57 files on Linux with Bun 1.3.11.
- `bun run typecheck`: passed.
- `bun run format:check`: passed.
- `git diff --check`: passed.

