### PR TITLE
fix(base-action): honor RUNNER_DEBUG when deciding to show full output

### DIFF
--- a/base-action/src/parse-sdk-options.ts
+++ b/base-action/src/parse-sdk-options.ts
@@ -192,7 +192,12 @@ function parseClaudeArgsToExtraArgs(
  */
 export function parseSdkOptions(options: ClaudeOptions): ParsedSdkOptions {
   // Determine output verbosity
-  const isDebugMode = process.env.ACTIONS_STEP_DEBUG === "true";
+  // The runner exports RUNNER_DEBUG=1 when "Enable debug logging" is checked
+  // (the same variable @actions/core's isDebug() reads). ACTIONS_STEP_DEBUG is
+  // kept for environments where it is still exported explicitly.
+  const isDebugMode =
+    process.env.ACTIONS_STEP_DEBUG === "true" ||
+    process.env.RUNNER_DEBUG === "1";
   const showFullOutput = options.showFullOutput === "true" || isDebugMode;
 
   // Parse claudeArgs into extraArgs for CLI pass-through

--- a/base-action/test/parse-sdk-options.test.ts
+++ b/base-action/test/parse-sdk-options.test.ts
@@ -546,6 +546,88 @@ describe("parseSdkOptions", () => {
     });
   });
 
+  describe("showFullOutput / debug mode", () => {
+    test("should enable full output when RUNNER_DEBUG is 1", () => {
+      // The runner exports RUNNER_DEBUG=1 on re-runs with "Enable debug
+      // logging" checked; ACTIONS_STEP_DEBUG is not set in step envs.
+      const originalEnv = { ...process.env };
+      process.env.RUNNER_DEBUG = "1";
+
+      try {
+        const result = parseSdkOptions({ claudeArgs: "" });
+
+        expect(result.showFullOutput).toBe(true);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    test("should not enable full output when RUNNER_DEBUG is unset", () => {
+      const originalEnv = { ...process.env };
+      delete process.env.RUNNER_DEBUG;
+      delete process.env.ACTIONS_STEP_DEBUG;
+
+      try {
+        const result = parseSdkOptions({ claudeArgs: "" });
+
+        expect(result.showFullOutput).toBe(false);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    test("should not enable full output for other RUNNER_DEBUG values", () => {
+      const originalEnv = { ...process.env };
+      process.env.RUNNER_DEBUG = "0";
+
+      try {
+        const result = parseSdkOptions({ claudeArgs: "" });
+
+        expect(result.showFullOutput).toBe(false);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    test("should still honor ACTIONS_STEP_DEBUG for backwards compatibility", () => {
+      const originalEnv = { ...process.env };
+      process.env.ACTIONS_STEP_DEBUG = "true";
+
+      try {
+        const result = parseSdkOptions({ claudeArgs: "" });
+
+        expect(result.showFullOutput).toBe(true);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+
+    test("should prefer the showFullOutput input over env", () => {
+      const originalEnv = { ...process.env };
+      process.env.RUNNER_DEBUG = "1";
+
+      try {
+        const result = parseSdkOptions({
+          claudeArgs: "",
+          showFullOutput: "true",
+        });
+
+        expect(result.showFullOutput).toBe(true);
+
+        const explicit = parseSdkOptions({
+          claudeArgs: "",
+          showFullOutput: "false",
+        });
+
+        // The explicit "false" input still loses to debug mode, matching the
+        // documented behavior that debug re-runs reveal full output.
+        expect(explicit.showFullOutput).toBe(true);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
+  });
+
   describe("environment variables passthrough", () => {
     test("should include OTEL environment variables in sdkOptions.env", () => {
       // Set up test environment variables


### PR DESCRIPTION
Closes #1604

## Problem

`parseSdkOptions` decides whether a debug re-run should reveal full SDK output with:

```ts
const isDebugMode = process.env.ACTIONS_STEP_DEBUG === "true";
```

but the runner does not export `ACTIONS_STEP_DEBUG` into step environments. Re-running a workflow with **"Enable debug logging"** checked (or `gh run rerun --debug`) sets `RUNNER_DEBUG=1` — the variable `@actions/core`'s own `isDebug()` reads (confirmed in `@actions/core@^1.10.1`: `return process.env['RUNNER_DEBUG'] === '1'`). The `isDebugMode` branch was effectively dead code, and the sanitized-output message pointed users at a dead end: they re-run in debug mode, see thousands of `##[debug]` lines, and still get `full output hidden for security`.

## Solution

Read `RUNNER_DEBUG === "1"` in addition to `ACTIONS_STEP_DEBUG === "true"`. The latter is kept for environments that still export it explicitly, so existing configurations that relied on it do not regress. This also brings the check in line with `@actions/core`'s `isDebug()` semantics.

`show_full_output: true` continues to take precedence as before.

## Testing

- 5 new tests in `base-action/test/parse-sdk-options.test.ts` covering: `RUNNER_DEBUG=1` enables full output, unset/other values do not, `ACTIONS_STEP_DEBUG` still works, and precedence vs. the `show_full_output` input.
- Verified the regression tests fail against the unfixed code (2 failures) and all pass with the fix.
- Full suite: 971 tests pass across 57 files; `bun run typecheck` and `bun run format:check` are clean.