### PR TITLE
chore(ci): upgarde checkout-action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -23,7 +23,7 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v1
         with:
@@ -38,7 +38,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       next_version: ${{ steps.next_version.outputs.next_version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -105,7 +105,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -130,7 +130,7 @@ jobs:
   #   environment: production
   #   steps:
   #     - name: Checkout base-action repo
-  #       uses: actions/checkout@v6
+  #       uses: actions/checkout@v7
   #       with:
   #         repository: anthropics/claude-code-base-action
   #         token: ${{ secrets.CLAUDE_CODE_BASE_ACTION_PAT }}

--- a/base-action/README.md
+++ b/base-action/README.md
@@ -344,7 +344,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -124,7 +124,7 @@ For performance, Claude uses shallow clones:
 If you need full history, you can configure this in your workflow before calling Claude in the `actions/checkout` step.
 
 ```
-- uses: actions/checkout@v6
+- uses: actions/checkout@v7
   depth: 0 # will fetch full repo history
 ```
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -30,7 +30,7 @@ For `workflow_run` events, the action checks the repository access of the actor 
 
 ```yaml
 # Preferred — check out the base ref (default).
-- uses: actions/checkout@v6 # no `ref:` → base branch
+- uses: actions/checkout@v7 # no `ref:` → base branch
 - uses: anthropics/claude-code-action@v1
 ```
 
@@ -38,8 +38,8 @@ For `workflow_run` events, the action checks the repository access of the actor 
 # If you need the PR's files locally — check out the base ref at the workspace
 # root (this action expects a git repo there), then check out the head ref into
 # a subdirectory and pass it via --add-dir.
-- uses: actions/checkout@v6 # no `ref:` → base branch at workspace root
-- uses: actions/checkout@v6
+- uses: actions/checkout@v7 # no `ref:` → base branch at workspace root
+- uses: actions/checkout@v7
   with:
     # For workflow_run use: ${{ github.event.workflow_run.head_sha }}
     ref: ${{ github.event.pull_request.head.sha }}

--- a/docs/solutions.md
+++ b/docs/solutions.md
@@ -35,7 +35,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -89,7 +89,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -153,7 +153,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -211,7 +211,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -268,7 +268,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
@@ -344,7 +344,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -464,7 +464,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -521,7 +521,7 @@ jobs:
       security-events: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/examples/ci-failure-auto-fix.yml
+++ b/examples/ci-failure-auto-fix.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0

--- a/examples/claude-wif.yml
+++ b/examples/claude-wif.yml
@@ -32,7 +32,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/examples/claude.yml
+++ b/examples/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/examples/issue-deduplication.yml
+++ b/examples/issue-deduplication.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/examples/issue-triage.yml
+++ b/examples/issue-triage.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/examples/manual-code-analysis.yml
+++ b/examples/manual-code-analysis.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2 # Need at least 2 commits to analyze the latest
 

--- a/examples/pr-review-comprehensive.yml
+++ b/examples/pr-review-comprehensive.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/examples/pr-review-filtered-authors.yml
+++ b/examples/pr-review-filtered-authors.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/examples/pr-review-filtered-paths.yml
+++ b/examples/pr-review-filtered-paths.yml
@@ -19,7 +19,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

Upgrades `actions/checkout` from v6 to v7 across all workflows, examples, and docs to keep this repo aligned with the latest maintained major version.

## What's in v7

actions/checkout v7 introduces one officially documented breaking change: it now refuses, by default, to check out fork PR code in `pull_request_target` and `workflow_run` workflows (the latter only when `workflow_run.event` is a `pull_request*` event), to prevent "pwn request" attacks. 

See: https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/

## Why this doesn't affect this repo

None of this repo's active workflows trigger this restriction:

- `ci.yml`, `claude-review.yml`, `claude.yml`, `issue-triage.yml` use `pull_request`, `issue_comment`, `pull_request_review(_comment)`, or `issues` — none of which are `pull_request_target` or `workflow_run`.

- `release.yml` uses `workflow_run`, but only proceeds when `github.event.workflow_run.event == 'push'` (post-merge release flow), which falls outside the fork-PR-checkout restriction.

- `examples/ci-failure-auto-fix.yml` uses `workflow_run` sourced from a `pull_request`-triggered "CI" workflow, but its job condition already gates on `github.event.workflow_run.pull_requests[0]` (populated only for same-repo PRs), which excludes the same fork-PR case v7 blocks — so behavior is unchanged.

Other changes in v7.0.0/v7.0.1 (internal ESM module migration, dependency bumps, minor bug fixes) are non-breaking implementation details for standard `uses: actions/checkout@v7` usage.

## Verification

- Diffed v6.1.0...v7.0.1: https://github.com/actions/checkout/compare/v6.1.0...v7.0.1

- Reviewed the `on:` trigger of every workflow file touched in this PR.

No functional changes expected; this is a version-string-only update.