### PR TITLE
refactor: deduplicate isAllowedBot across actor and permissions validation

### DIFF
--- a/src/github/utils/actor-filter.ts
+++ b/src/github/utils/actor-filter.ts
@@ -88,3 +88,25 @@ export function shouldIncludeCommentByActor(
   // No filters or passed all checks
   return true;
 }
+
+/**
+ * Check if a bot actor is in the allowed bots list.
+ */
+export function isAllowedBot(actor: string, allowedBots: string): boolean {
+  const trimmed = allowedBots.trim();
+  if (trimmed === "*") return true;
+  if (!trimmed) return false;
+
+  const allowedList = trimmed
+    .split(",")
+    .map((bot) =>
+      bot
+        .trim()
+        .toLowerCase()
+        .replace(/\[bot\]$/, ""),
+    )
+    .filter((bot) => bot.length > 0);
+
+  const normalizedActor = actor.toLowerCase().replace(/\[bot\]$/, "");
+  return allowedList.includes(normalizedActor);
+}

--- a/src/github/validation/actor.ts
+++ b/src/github/validation/actor.ts
@@ -7,25 +7,7 @@
 
 import type { Octokit } from "@octokit/rest";
 import type { GitHubContext } from "../context";
-
-function isAllowedBot(actor: string, allowedBots: string): boolean {
-  const trimmed = allowedBots.trim();
-  if (trimmed === "*") return true;
-  if (!trimmed) return false;
-
-  const allowedList = trimmed
-    .split(",")
-    .map((bot) =>
-      bot
-        .trim()
-        .toLowerCase()
-        .replace(/\[bot\]$/, ""),
-    )
-    .filter((bot) => bot.length > 0);
-
-  const normalizedActor = actor.toLowerCase().replace(/\[bot\]$/, "");
-  return allowedList.includes(normalizedActor);
-}
+import { isAllowedBot } from "../utils/actor-filter";
 
 export async function checkHumanActor(
   octokit: Octokit,

--- a/src/github/validation/permissions.ts
+++ b/src/github/validation/permissions.ts
@@ -1,28 +1,7 @@
 import * as core from "@actions/core";
 import { isWorkflowRunEvent, type GitHubContext } from "../context";
 import type { Octokit } from "@octokit/rest";
-
-/**
- * Check if a bot actor is in the allowed bots list.
- */
-function isAllowedBot(actor: string, allowedBots: string): boolean {
-  const trimmed = allowedBots.trim();
-  if (trimmed === "*") return true;
-  if (!trimmed) return false;
-
-  const allowedList = trimmed
-    .split(",")
-    .map((bot) =>
-      bot
-        .trim()
-        .toLowerCase()
-        .replace(/\[bot\]$/, ""),
-    )
-    .filter((bot) => bot.length > 0);
-
-  const normalizedActor = actor.toLowerCase().replace(/\[bot\]$/, "");
-  return allowedList.includes(normalizedActor);
-}
+import { isAllowedBot } from "../utils/actor-filter";
 
 /**
  * Collect the actors whose repository access should be checked. This is


### PR DESCRIPTION
The `isAllowedBot` function was duplicated exactly byte-for-byte across `src/github/validation/actor.ts` and `src/github/validation/permissions.ts`. This PR extracts the function into the shared `src/github/utils/actor-filter.ts` utility file to keep the codebase DRY and maintainable.
**Changes made**
* Moved `isAllowedBot` to `src/github/utils/actor-filter.ts` and exported it.
* Updated `actor.ts` and `permissions.ts` to import the shared utility function instead of maintaining their own copies.