### PR TITLE
fix: correctly handle line and startLine of 0 in inline comment creation

### DIFF
--- a/src/mcp/github-inline-comment-server.ts
+++ b/src/mcp/github-inline-comment-server.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { createOctokit } from "../github/api/client";
 import { redactSecrets, sanitizeContent } from "../github/utils/sanitizer";
 import { removeBufferedComment } from "./inline-comment-buffer";
+import { validateCommentLines } from "./inline-comment-validation";
 
 // Get repository and PR information from environment variables
 const REPO_OWNER = process.env.REPO_OWNER;
@@ -102,11 +103,7 @@ server.tool(
       const sanitizedBody = redactSecrets(sanitizeContent(body));
 
       // Validate that either line or both startLine and line are provided
-      if (line === undefined && startLine === undefined) {
-        throw new Error(
-          "Either 'line' for single-line comments or both 'startLine' and 'line' for multi-line comments must be provided",
-        );
-      }
+      validateCommentLines(line, startLine);
 
       if (CLASSIFY_ENABLED && confirmed !== true) {
         appendFileSync(
@@ -147,7 +144,7 @@ server.tool(
 
       // If only line is provided, it's a single-line comment
       // If both startLine and line are provided, it's a multi-line comment
-      const isSingleLine = startLine === undefined;
+      const { isSingleLine } = validateCommentLines(line, startLine);
 
       const octokit = createOctokit(githubToken).rest;
 

--- a/src/mcp/github-inline-comment-server.ts
+++ b/src/mcp/github-inline-comment-server.ts
@@ -102,7 +102,7 @@ server.tool(
       const sanitizedBody = redactSecrets(sanitizeContent(body));
 
       // Validate that either line or both startLine and line are provided
-      if (!line && !startLine) {
+      if (line === undefined && startLine === undefined) {
         throw new Error(
           "Either 'line' for single-line comments or both 'startLine' and 'line' for multi-line comments must be provided",
         );
@@ -147,7 +147,7 @@ server.tool(
 
       // If only line is provided, it's a single-line comment
       // If both startLine and line are provided, it's a multi-line comment
-      const isSingleLine = !startLine;
+      const isSingleLine = startLine === undefined;
 
       const octokit = createOctokit(githubToken).rest;
 

--- a/src/mcp/inline-comment-validation.ts
+++ b/src/mcp/inline-comment-validation.ts
@@ -1,0 +1,18 @@
+export function validateCommentLines(
+  line?: number,
+  startLine?: number,
+): { isSingleLine: boolean } {
+  if (line === undefined && startLine === undefined) {
+    throw new Error(
+      "Either 'line' for single-line comments or both 'startLine' and 'line' for multi-line comments must be provided",
+    );
+  }
+
+  if (startLine !== undefined && line === undefined) {
+    throw new Error(
+      "When 'startLine' is provided, 'line' must also be provided to specify the end of the range",
+    );
+  }
+
+  return { isSingleLine: startLine === undefined };
+}

--- a/test/inline-comment-validation.test.ts
+++ b/test/inline-comment-validation.test.ts
@@ -1,0 +1,42 @@
+import { expect, test, describe } from "bun:test";
+import { validateCommentLines } from "../src/mcp/inline-comment-validation";
+
+describe("github-inline-comment-server parameter validation", () => {
+  test("validates single-line comment (only line provided)", () => {
+    const result = validateCommentLines(10, undefined);
+    expect(result.isSingleLine).toBe(true);
+  });
+
+  test("validates single-line comment (line is 0)", () => {
+    const result = validateCommentLines(0, undefined);
+    expect(result.isSingleLine).toBe(true);
+  });
+
+  test("validates multi-line comment (both startLine and line provided)", () => {
+    const result = validateCommentLines(20, 10);
+    expect(result.isSingleLine).toBe(false);
+  });
+
+  test("validates multi-line comment when startLine is 0", () => {
+    const result = validateCommentLines(10, 0);
+    expect(result.isSingleLine).toBe(false);
+  });
+
+  test("throws when both line and startLine are omitted", () => {
+    expect(() => validateCommentLines(undefined, undefined)).toThrow(
+      "Either 'line' for single-line comments or both 'startLine' and 'line' for multi-line comments must be provided",
+    );
+  });
+
+  test("throws when startLine is provided but line is omitted", () => {
+    expect(() => validateCommentLines(undefined, 10)).toThrow(
+      "When 'startLine' is provided, 'line' must also be provided to specify the end of the range",
+    );
+  });
+
+  test("throws when startLine is 0 and line is omitted", () => {
+    expect(() => validateCommentLines(undefined, 0)).toThrow(
+      "When 'startLine' is provided, 'line' must also be provided to specify the end of the range",
+    );
+  });
+});


### PR DESCRIPTION
The `create_inline_comment` MCP tool previously checked for the presence of `line` and `startLine` using a simple truthiness check (`!line && !startLine`). Because `0` is a valid line number in some contexts but evaluates to falsy in JavaScript, passing `0` for `startLine` caused the tool to misinterpret the multi-line comment as a single-line comment (or fail validation completely).
This PR switches to strict `undefined` checks to correctly handle `0` values.
**Changes made**
* Changed the `!line && !startLine` validation check to `line === undefined && startLine === undefined`.
* Changed the `!startLine` multi-line check to `startLine === undefined`.
