### PR TITLE
fix: ignore trigger phrases embedded inside tokens (#1798)

### DIFF
--- a/src/utils/extract-user-request.ts
+++ b/src/utils/extract-user-request.ts
@@ -16,17 +16,35 @@ export function extractUserRequest(
     return null;
   }
 
-  // Use string operations instead of regex for better performance and security
-  // (avoids potential ReDoS with large comment bodies)
-  const triggerIndex = commentBody
-    .toLowerCase()
-    .indexOf(triggerPhrase.toLowerCase());
-  if (triggerIndex === -1) {
-    return null;
-  }
+  const lowerBody = commentBody.toLowerCase();
+  const lowerTrigger = triggerPhrase.toLowerCase();
 
-  const afterTrigger = commentBody
-    .substring(triggerIndex + triggerPhrase.length)
-    .trim();
-  return afterTrigger || null;
+  let searchStartIndex = 0;
+  while (true) {
+    const triggerIndex = lowerBody.indexOf(lowerTrigger, searchStartIndex);
+    if (triggerIndex === -1) {
+      return null;
+    }
+
+    // Check boundary semantics matching checkContainsTrigger:
+    // (^|\s)triggerPhrase([\s.,!?;:]|$)
+    const prevChar = triggerIndex > 0 ? lowerBody[triggerIndex - 1] : "";
+    const nextChar =
+      triggerIndex + lowerTrigger.length < lowerBody.length
+        ? lowerBody[triggerIndex + lowerTrigger.length]
+        : "";
+
+    const isPrevValid = prevChar === "" || /^\s$/.test(prevChar);
+    const isNextValid = nextChar === "" || /^[\s.,!?;:]$/.test(nextChar);
+
+    if (isPrevValid && isNextValid) {
+      const afterTrigger = commentBody
+        .substring(triggerIndex + triggerPhrase.length)
+        .trim();
+      return afterTrigger || null;
+    }
+
+    // If not a valid match, advance search past the current match
+    searchStartIndex = triggerIndex + 1;
+  }
 }

--- a/test/extract-user-request.test.ts
+++ b/test/extract-user-request.test.ts
@@ -60,6 +60,19 @@ Focus on security issues.`,
     expect(extractUserRequest("/claude help me", "/claude")).toBe("help me");
   });
 
+  test("ignores trigger phrase embedded in another word (issue #1798)", () => {
+    const comment =
+      "Email security@claude.dev ASAP. @claude please review the auth module";
+    expect(extractUserRequest(comment, "@claude")).toBe(
+      "please review the auth module",
+    );
+  });
+
+  test("ignores trigger phrase followed by non-punctuation", () => {
+    const comment = "Check out @claudebot first, then @claude do this";
+    expect(extractUserRequest(comment, "@claude")).toBe("do this");
+  });
+
   test("handles trigger phrase with special regex characters", () => {
     expect(
       extractUserRequest("@claude[bot] do something", "@claude[bot]"),


### PR DESCRIPTION
Fixes #1798. When a trigger phrase is embedded inside another token (like security@claude.dev), extractUserRequest previously matched it and extracted the wrong text. This ensures we follow the same strict word boundary semantics as checkContainsTrigger (e.g., (^|\s)triggerPhrase([\s.,!?;:]|$)) while keeping the logic fast and ReDoS-free by using string indexing with targeted boundary checks. Added test cases for the failure scenarios.