### PR TITLE
fix: skip malformed lines in post-buffered-inline-comments instead of crashing (#1796)

### DIFF
--- a/src/entrypoints/post-buffered-inline-comments.ts
+++ b/src/entrypoints/post-buffered-inline-comments.ts
@@ -156,7 +156,17 @@ async function main() {
   const comments: BufferedComment[] = raw
     .split("\n")
     .filter(Boolean)
-    .map((line) => JSON.parse(line));
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch (e) {
+        console.log(
+          `::warning::Skipping malformed buffered comment line: ${line}`,
+        );
+        return null;
+      }
+    })
+    .filter(Boolean) as BufferedComment[];
 
   if (comments.length === 0) {
     console.log("No buffered inline comments");


### PR DESCRIPTION
Fixes #1796. The post-step previously crashed entirely if any line in the inline-comments buffer was malformed (e.g. from a truncated append), losing all valid buffered comments. This update catches JSON.parse errors per line, skips the malformed lines with a warning annotation, and successfully posts the rest.