### PR TITLE
fix: remove false-positive post-hoc maxTurns check (#1795)

### DIFF
--- a/base-action/src/run-claude-sdk.ts
+++ b/base-action/src/run-claude-sdk.ts
@@ -238,17 +238,6 @@ export async function runClaudeWithSdk(
     throw new Error("No result message received from Claude");
   }
 
-  if (
-    resultMessage.subtype === "success" &&
-    !resultMessage.is_error &&
-    sdkOptions.maxTurns !== undefined &&
-    resultMessage.num_turns > sdkOptions.maxTurns
-  ) {
-    const message = `Claude reported a successful result after ${resultMessage.num_turns} turns, exceeding the configured maximum of ${sdkOptions.maxTurns}`;
-    core.error(message);
-    throw new Error(message);
-  }
-
   // subtype "success" with is_error:true means the run errored without producing
   // a real result — treat it as failure so CI does not show a misleading green check.
   const isSuccess =

--- a/base-action/test/run-claude-sdk.test.ts
+++ b/base-action/test/run-claude-sdk.test.ts
@@ -218,7 +218,7 @@ describe("runClaudeWithSdk", () => {
     }
   });
 
-  test("fails closed when a successful result exceeds maxTurns", async () => {
+  test("succeeds when a successful result has num_turns > maxTurns (num_turns != rounds)", async () => {
     const consoleErrorSpy = spyOn(console, "error").mockImplementation(
       () => {},
     );
@@ -261,23 +261,19 @@ describe("runClaudeWithSdk", () => {
     try {
       const { runClaudeWithSdk } = await import("../src/run-claude-sdk");
 
-      await expect(
-        runClaudeWithSdk(promptPath, {
-          sdkOptions: { maxTurns: 60 },
-          showFullOutput: false,
-          hasJsonSchema: false,
-        }),
-      ).rejects.toThrow(
-        "Claude reported a successful result after 73 turns, exceeding the configured maximum of 60",
-      );
+      const result = await runClaudeWithSdk(promptPath, {
+        sdkOptions: { maxTurns: 60 },
+        showFullOutput: false,
+        hasJsonSchema: false,
+      });
+
+      expect(result.conclusion).toBe("success");
 
       const executionFile = join(tempDir, "claude-execution-output.json");
       await expect(readFile(executionFile, "utf-8")).resolves.toBe(
         JSON.stringify([initMessage, successResultMessage], null, 2),
       );
-      expect(coreErrorSpy).toHaveBeenCalledWith(
-        "Claude reported a successful result after 73 turns, exceeding the configured maximum of 60",
-      );
+      expect(coreErrorSpy).not.toHaveBeenCalled();
     } finally {
       consoleErrorSpy.mockRestore();
       consoleLogSpy.mockRestore();


### PR DESCRIPTION
Fixes #1795. The post-hoc check for maxTurns incorrectly compared num_turns (which counts one per tool result) against maxTurns (which is API rounds). This caused false-positive failures for runs with many parallel tool calls even though they completed successfully. Since the CLI already enforces max-turns (reporting error_max_turns when hit), this commit drops the misleading post-hoc check.