### PR TITLE
feat: add trackProgress support to agent mode (#1788)

### DIFF
--- a/src/modes/agent/index.ts
+++ b/src/modes/agent/index.ts
@@ -8,7 +8,9 @@ import {
 } from "../../github/operations/git-config";
 import { checkHumanActor } from "../../github/validation/actor";
 import type { GitHubContext } from "../../github/context";
+import { isEntityContext } from "../../github/context";
 import type { Octokits } from "../../github/api/client";
+import { createInitialComment } from "../../github/operations/comments/create-initial";
 
 /**
  * Prepares the agent mode execution context.
@@ -105,6 +107,18 @@ export async function prepareAgentMode({
     process.env.GITHUB_REF_NAME ||
     defaultBranch;
 
+  // Create tracking comment if requested
+  let claudeCommentId: number | undefined = undefined;
+  if (context.inputs.trackProgress && isEntityContext(context)) {
+    try {
+      const commentData = await createInitialComment(octokit.rest, context);
+      claudeCommentId = commentData?.id;
+    } catch (error) {
+      console.error("Failed to create tracking comment:", error);
+      // Continue anyway, it's just a progress tracking comment
+    }
+  }
+
   // Get our GitHub MCP servers config
   const ourMcpConfig = await prepareMcpConfig({
     githubToken,
@@ -112,7 +126,7 @@ export async function prepareAgentMode({
     repo: context.repository.repo,
     branch: currentBranch,
     baseBranch: baseBranch,
-    claudeCommentId: undefined, // No tracking comment in agent mode
+    claudeCommentId, // Pass the tracking comment ID if we created one
     allowedTools,
     mode: "agent",
     context,
@@ -132,7 +146,7 @@ export async function prepareAgentMode({
   claudeArgs = `${claudeArgs} ${userClaudeArgs}`.trim();
 
   return {
-    commentId: undefined,
+    commentId: claudeCommentId,
     branchInfo: {
       baseBranch: baseBranch,
       currentBranch: baseBranch, // Use base branch as current when creating new branch

--- a/src/modes/detector.ts
+++ b/src/modes/detector.ts
@@ -18,7 +18,12 @@ export function detectMode(context: GitHubContext): AutoDetectedMode {
   }
 
   // If track_progress is set for PR/issue events, force tag mode
-  if (context.inputs.trackProgress && isEntityContext(context)) {
+  // UNLESS a prompt is provided, which explicitly requests agent mode
+  if (
+    context.inputs.trackProgress &&
+    isEntityContext(context) &&
+    !context.inputs.prompt
+  ) {
     if (
       isPullRequestEvent(context) ||
       isIssuesEvent(context) ||

--- a/test/modes/detector.test.ts
+++ b/test/modes/detector.test.ts
@@ -48,6 +48,24 @@ describe("detectMode with enhanced routing", () => {
       expect(detectMode(context)).toBe("tag");
     });
 
+    it("should use agent mode when track_progress is true AND prompt is provided for pull_request.opened", () => {
+      const context: GitHubContext = {
+        ...baseContext,
+        eventName: "pull_request",
+        eventAction: "opened",
+        payload: { pull_request: { number: 1 } } as any,
+        entityNumber: 1,
+        isPR: true,
+        inputs: {
+          ...baseContext.inputs,
+          trackProgress: true,
+          prompt: "review",
+        },
+      };
+
+      expect(detectMode(context)).toBe("agent");
+    });
+
     it("should use tag mode when track_progress is true for pull_request.synchronize", () => {
       const context: GitHubContext = {
         ...baseContext,


### PR DESCRIPTION
Fixes #1788. This update allows agent mode runs to get a tracking/progress comment just like tag mode does. Previously, enabling trackProgress would unconditionally force the run into tag mode, ignoring agent-mode settings. Now, if an explicit prompt is provided (which implies agent mode), detectMode will preserve agent mode while still allowing it to create and manage the initial progress comment via createInitialComment.